### PR TITLE
Fix code wrapping and empty lines

### DIFF
--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/Code/viewer-component.js
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/Code/viewer-component.js
@@ -10,7 +10,7 @@ const { TextChunk } = Common.chunk
 
 const Code = props => (
 	<OboComponent model={props.model} moduleData={props.moduleData}>
-		<TextChunk className="obojobo-draft--chunks--single-text pad">
+		<TextChunk className="obojobo-draft--chunks--code pad">
 			<pre>
 				<code>
 					{props.model.modelState.textGroup.items.map((textItem, index) => (

--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/Code/viewer-component.scss
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/Code/viewer-component.scss
@@ -2,12 +2,19 @@
 
 .obojobo-draft--chunks--code {
 	pre {
-		font-size: 1em;
-		padding-left: 2em;
-		padding-right: 2em;
+		font-size: 0.9em;
+		margin-top: 0;
+		margin-bottom: 0;
+		overflow-x: auto;
+		background: $color-bg2;
+		border-radius: $dimension-rounded-radius;
+		box-sizing: border-box;
+		padding: $dimension-padding / 4 $dimension-padding / 3 / 0.9;
+		tab-size: 2;
 	}
 
 	.text {
 		display: block;
+		min-height: 1em;
 	}
 }

--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/Code/viewer-component.scss
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/Code/viewer-component.scss
@@ -2,14 +2,16 @@
 
 .obojobo-draft--chunks--code {
 	pre {
-		font-size: 0.9em;
+		$font-size: 0.9em;
+
+		font-size: $font-size;
 		margin-top: 0;
 		margin-bottom: 0;
 		overflow-x: auto;
 		background: $color-bg2;
 		border-radius: $dimension-rounded-radius;
 		box-sizing: border-box;
-		padding: $dimension-padding / 4 $dimension-padding / 3 / 0.9;
+		padding: $dimension-padding / 4 $dimension-padding / 3 / ($font-size / 1em);
 		tab-size: 2;
 	}
 

--- a/packages/obojobo-document-engine/__tests__/ObojoboDraft/Chunks/Code/__snapshots__/viewer-component.test.js.snap
+++ b/packages/obojobo-document-engine/__tests__/ObojoboDraft/Chunks/Code/__snapshots__/viewer-component.test.js.snap
@@ -10,7 +10,7 @@ exports[`Code Code component 1`] = `
   id="obo-id"
 >
   <div
-    className="text-chunk obojobo-draft--chunks--single-text pad"
+    className="text-chunk obojobo-draft--chunks--code pad"
   >
     <pre>
       <code>


### PR DESCRIPTION
Resolves #588 and #589 

* Fixes code node having wrong style (Was using single-text)
* Fixes blank lines not showing up
* Styles code in a box which now scrolls horizontally
* Updates tab length to be two spaces instead of four
* Reduces vertical margins (Code elements were pushed too far away from any element above or below - which became obvious when the code was put inside a box)