### PR TITLE
Fixed Old Repository URLs

### DIFF
--- a/packages/obojobo-document-engine/README.md
+++ b/packages/obojobo-document-engine/README.md
@@ -1,1 +1,1 @@
-This is the Obojobo Next Document Engine. Documentation for this project can be found at https://github.com/ucfcdl/Obojobo-Next.
+This is the Obojobo Next Document Engine. Documentation for this project can be found at https://ucfopen.github.io/Obojobo-Docs/.

--- a/packages/obojobo-document-engine/documents/empty.xml
+++ b/packages/obojobo-document-engine/documents/empty.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ObojoboDraftDoc>
 	<!-- Sample Obojobo Draft Document -->
-	<!-- https://github.com/ucfcdl/Obojobo-Next/wiki/Obojobo-Document-XML-Format -->
+	<!-- https://ucfopen.github.io/Obojobo-Docs/releases/v3.3.2/authors/ -->
 	<Module title="My Obojobo Module Title">
 
 		<Content>

--- a/packages/obojobo-express/README.MD
+++ b/packages/obojobo-express/README.MD
@@ -1,1 +1,1 @@
-This is the Obojobo Next Express Server. Documentation for this project can be found at https://github.com/ucfcdl/Obojobo-Next.
+This is the Obojobo Next Express Server. Documentation for this project can be found at https://ucfopen.github.io/Obojobo-Docs/.


### PR DESCRIPTION
Changed documentation URLs from ucfcdl/Obojobo-Next and ucf/Obojobo-Document-Engine to point to the new Obojobo-Docs.