### PR TITLE
Fixed module renaming issue

### DIFF
--- a/packages/obojobo-document-engine/__tests__/oboeditor/components/editor-nav.test.js
+++ b/packages/obojobo-document-engine/__tests__/oboeditor/components/editor-nav.test.js
@@ -2,12 +2,12 @@ import { mount } from 'enzyme'
 import React from 'react'
 import renderer from 'react-test-renderer'
 
-import EditorNav from '../../../src/scripts/oboeditor/components/editor-nav'
+import EditorNav from 'src/scripts/oboeditor/components/editor-nav'
 
-import EditorUtil from '../../../src/scripts/oboeditor/util/editor-util'
-import Common from '../../../src/scripts/common'
+import EditorUtil from 'src/scripts/oboeditor/util/editor-util'
+import Common from 'src/scripts/common'
 
-jest.mock('../../../src/scripts/oboeditor/util/editor-util')
+jest.mock('src/scripts/oboeditor/util/editor-util')
 
 describe('EditorNav', () => {
 	beforeAll(() => {
@@ -118,7 +118,7 @@ describe('EditorNav', () => {
 		expect(EditorUtil.addAssessment).toHaveBeenCalled()
 	})
 
-	test('EditorNav component clicks Rename Module button', () => {
+	test('EditorNav component clicks Rename Module button and cancels change', () => {
 		EditorUtil.getOrderedList.mockReturnValueOnce([
 			{
 				id: 6,
@@ -140,7 +140,57 @@ describe('EditorNav', () => {
 			.at(2)
 			.simulate('click')
 
-		expect(EditorUtil.renamePage).toHaveBeenCalled()
+		expect(EditorUtil.renamePage).not.toHaveBeenCalled()
+	})
+
+	test('EditorNav component clicks Rename Module button with empty name', () => {
+		EditorUtil.getOrderedList.mockReturnValueOnce([
+			{
+				id: 6,
+				type: 'heading',
+				label: 'label6',
+				flags: {
+					assessment: true
+				}
+			}
+		])
+		jest.spyOn(window, 'prompt')
+		window.prompt.mockReturnValueOnce('')
+
+		const props = { navState: {} }
+		const component = mount(<EditorNav {...props} />)
+
+		component
+			.find('button')
+			.at(2)
+			.simulate('click')
+
+		expect(EditorUtil.renamePage).toHaveBeenCalledWith(6, '(Unnamed Module)')
+	})
+
+	test('EditorNav component clicks Rename Module button', () => {
+		EditorUtil.getOrderedList.mockReturnValueOnce([
+			{
+				id: 6,
+				type: 'heading',
+				label: 'label6',
+				flags: {
+					assessment: true
+				}
+			}
+		])
+		jest.spyOn(window, 'prompt')
+		window.prompt.mockReturnValueOnce('mockNewName')
+
+		const props = { navState: {} }
+		const component = mount(<EditorNav {...props} />)
+
+		component
+			.find('button')
+			.at(2)
+			.simulate('click')
+
+		expect(EditorUtil.renamePage).toHaveBeenCalledWith(6, 'mockNewName')
 	})
 
 	test('EditorNav component clicks Copy URL button', () => {
@@ -149,8 +199,6 @@ describe('EditorNav', () => {
 		window.alert.mockReturnValueOnce(null)
 
 		EditorUtil.getOrderedList.mockReturnValueOnce([])
-		jest.spyOn(window, 'prompt')
-		window.prompt.mockReturnValueOnce(null)
 
 		const props = { navState: {} }
 		const component = mount(<EditorNav {...props} />)
@@ -215,7 +263,7 @@ describe('EditorNav', () => {
 		expect(EditorUtil.movePage).toHaveBeenCalled()
 	})
 
-	test('EditorNav component clicks Edit Name button in item', () => {
+	test('EditorNav component clicks Edit Name button in item and cancels change', () => {
 		EditorUtil.getOrderedList
 			.mockReturnValueOnce([
 				{
@@ -230,6 +278,34 @@ describe('EditorNav', () => {
 			.mockReturnValueOnce([])
 		jest.spyOn(window, 'prompt')
 		window.prompt.mockReturnValueOnce(null)
+
+		const props = { navState: {} }
+		const component = mount(<EditorNav {...props} />)
+
+		component
+			.find('li')
+			.find('button')
+			.at(1) // [Move Down, Edit Name, Delete]
+			.simulate('click')
+
+		expect(EditorUtil.renamePage).not.toHaveBeenCalled()
+	})
+
+	test('EditorNav component clicks Edit Name button in item', () => {
+		EditorUtil.getOrderedList
+			.mockReturnValueOnce([
+				{
+					id: 5,
+					type: 'link',
+					label: 'label5',
+					flags: {
+						assessment: true
+					}
+				}
+			])
+			.mockReturnValueOnce([])
+		jest.spyOn(window, 'prompt')
+		window.prompt.mockReturnValueOnce('mockNewName')
 
 		const props = { navState: {} }
 		const component = mount(<EditorNav {...props} />)
@@ -256,8 +332,6 @@ describe('EditorNav', () => {
 				}
 			])
 			.mockReturnValueOnce([])
-		jest.spyOn(window, 'prompt')
-		window.prompt.mockReturnValueOnce(null)
 
 		const props = { navState: {} }
 		const component = mount(<EditorNav {...props} />)

--- a/packages/obojobo-document-engine/__tests__/oboeditor/components/editor-nav.test.js
+++ b/packages/obojobo-document-engine/__tests__/oboeditor/components/editor-nav.test.js
@@ -155,7 +155,7 @@ describe('EditorNav', () => {
 			}
 		])
 		jest.spyOn(window, 'prompt')
-		window.prompt.mockReturnValueOnce('')
+		window.prompt.mockReturnValueOnce('   ')
 
 		const props = { navState: {} }
 		const component = mount(<EditorNav {...props} />)
@@ -289,6 +289,34 @@ describe('EditorNav', () => {
 			.simulate('click')
 
 		expect(EditorUtil.renamePage).not.toHaveBeenCalled()
+	})
+
+	test('EditorNav component clicks Edit Name button in item and submits only whitespace', () => {
+		EditorUtil.getOrderedList
+			.mockReturnValueOnce([
+				{
+					id: 5,
+					type: 'link',
+					label: 'label5',
+					flags: {
+						assessment: true
+					}
+				}
+			])
+			.mockReturnValueOnce([])
+		jest.spyOn(window, 'prompt')
+		window.prompt.mockReturnValueOnce('     ')
+
+		const props = { navState: {} }
+		const component = mount(<EditorNav {...props} />)
+
+		component
+			.find('li')
+			.find('button')
+			.at(1) // [Move Down, Edit Name, Delete]
+			.simulate('click')
+
+		expect(EditorUtil.renamePage).toHaveBeenCalled()
 	})
 
 	test('EditorNav component clicks Edit Name button in item', () => {

--- a/packages/obojobo-document-engine/src/scripts/oboeditor/components/editor-nav.js
+++ b/packages/obojobo-document-engine/src/scripts/oboeditor/components/editor-nav.js
@@ -51,10 +51,13 @@ class EditorNav extends React.Component {
 	}
 
 	renamePage(pageId) {
-		const label = window.prompt('Enter the new title:')
+		let label = window.prompt('Enter the new title:')
 
 		// null means the user canceled without changing the value
 		if (label === null) return
+
+		// If the user sent an empty value or only whitespace, set it to null to fix later
+		if (!label || /\s/.test(label)) label = null
 
 		// If presented with an empty "ok", the page validation code will
 		// provide "Page n" as the name
@@ -67,8 +70,8 @@ class EditorNav extends React.Component {
 		// null means the user canceled without changing the value
 		if (label === null) return
 
-		// If the module name is empty, provide a default value
-		if (!label) label = '(Unnamed Module)'
+		// If the module name is empty or just whitespace, provide a default value
+		if (!label || /\s/.test(label)) label = '(Unnamed Module)'
 
 		EditorUtil.renamePage(moduleId, label)
 	}

--- a/packages/obojobo-document-engine/src/scripts/oboeditor/components/editor-nav.js
+++ b/packages/obojobo-document-engine/src/scripts/oboeditor/components/editor-nav.js
@@ -51,8 +51,26 @@ class EditorNav extends React.Component {
 	}
 
 	renamePage(pageId) {
-		const label = window.prompt('Enter the new title:') || pageId
+		const label = window.prompt('Enter the new title:')
+
+		// null means the user canceled without changing the value
+		if (label === null) return
+
+		// If presented with an empty "ok", the page validation code will
+		// provide "Page n" as the name
 		EditorUtil.renamePage(pageId, label)
+	}
+
+	renameModule(moduleId) {
+		let label = window.prompt('Enter the new title:')
+
+		// null means the user canceled without changing the value
+		if (label === null) return
+
+		// If the module name is empty, provide a default value
+		if (!label) label = '(Unnamed Module)'
+
+		EditorUtil.renamePage(moduleId, label)
 	}
 
 	movePage(pageId, index) {
@@ -158,7 +176,7 @@ class EditorNav extends React.Component {
 						+ Add Assessment
 					</button>
 					<br />
-					<button className={'content-add-button'} onClick={() => this.renamePage(moduleItem.id)}>
+					<button className={'content-add-button'} onClick={() => this.renameModule(moduleItem.id)}>
 						Rename Module
 					</button>
 					<button className={'content-add-button'} onClick={() => this.copyToClipboard(url)}>


### PR DESCRIPTION
Set up renaming so that canceling the rename keeps the old name and pressing "OK" with a blank name field renames it to a placeholder name.

Resolves https://github.com/ucfopen/Obojobo/issues/608