### PR TITLE
Fixed pages that were stuck as blank

### DIFF
--- a/packages/obojobo-document-engine/__tests__/oboeditor/plugins/__snapshots__/editor-schema.test.js.snap
+++ b/packages/obojobo-document-engine/__tests__/oboeditor/plugins/__snapshots__/editor-schema.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditorSchema matcher builds a list of all possible node types 1`] = `
+Object {
+  "document": Object {
+    "nodes": Array [
+      Object {
+        "match": Array [
+          Object {
+            "type": "ObojoboDraft.Chunks.ActionButton",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.Break",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.Code",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.Figure",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.Heading",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.HTML",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.IFrame",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.List",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.MathEquation",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.MCAssessment",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.Table",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.Text",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.YouTube",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.QuestionBank",
+          },
+          Object {
+            "type": "ObojoboDraft.Chunks.Question",
+          },
+          Object {
+            "type": "ObojoboDraft.Sections.Assessment",
+          },
+          Object {
+            "type": "ObojoboDraft.Pages.Page",
+          },
+        ],
+        "min": 1,
+      },
+    ],
+    "normalize": [Function],
+  },
+}
+`;

--- a/packages/obojobo-document-engine/__tests__/oboeditor/plugins/editor-schema.test.js
+++ b/packages/obojobo-document-engine/__tests__/oboeditor/plugins/editor-schema.test.js
@@ -1,0 +1,38 @@
+import { CHILD_REQUIRED, CHILD_TYPE_INVALID } from 'slate-schema-violations'
+
+import EditorSchema from 'src/scripts/oboeditor/plugins/editor-schema'
+
+describe('EditorSchema', () => {
+	test('matcher builds a list of all possible node types', () => {
+		expect(EditorSchema.schema).toMatchSnapshot()
+	})
+	test('schema.normalize fixes required children in editor', () => {
+		const change = {
+			insertNodeByKey: jest.fn()
+		}
+
+		EditorSchema.schema.document.normalize(change, {
+			code: CHILD_REQUIRED,
+			node: { key: 'mockKey' },
+			child: null,
+			index: 0
+		})
+
+		expect(change.insertNodeByKey).toHaveBeenCalled()
+	})
+
+	test('schema.normalize fixes invalid children in editor', () => {
+		const change = {
+			wrapBlockByKey: jest.fn()
+		}
+
+		EditorSchema.schema.document.normalize(change, {
+			code: CHILD_TYPE_INVALID,
+			node: { key: 'mockKey' },
+			child: { object: 'text', key: 'mockChild' },
+			index: 0
+		})
+
+		expect(change.wrapBlockByKey).toHaveBeenCalled()
+	})
+})

--- a/packages/obojobo-document-engine/src/scripts/oboeditor/components/page-editor.js
+++ b/packages/obojobo-document-engine/src/scripts/oboeditor/components/page-editor.js
@@ -31,6 +31,7 @@ import Rubric from '../../../../ObojoboDraft/Sections/Assessment/components/rubr
 import DefaultNode from './default-node'
 import ParameterNode from './parameter-node'
 import MarkToolbar from './toolbar'
+import EditorSchema from '../plugins/editor-schema'
 
 const CONTENT_NODE = 'ObojoboDraft.Sections.Content'
 const ASSESSMENT_NODE = 'ObojoboDraft.Sections.Assessment'
@@ -90,7 +91,8 @@ const plugins = [
 	Page.plugins,
 	Rubric.plugins,
 	ParameterNode.plugins,
-	Assessment.plugins
+	Assessment.plugins,
+	EditorSchema
 ]
 
 class PageEditor extends React.Component {
@@ -128,7 +130,10 @@ class PageEditor extends React.Component {
 		return (
 			<div className={'editor'}>
 				<div className={'toolbar'}>
-					<MarkToolbar.components.Node value={this.state.value} onChange={change => this.onChange(change)} />
+					<MarkToolbar.components.Node
+						value={this.state.value}
+						onChange={change => this.onChange(change)}
+					/>
 					<div className={'dropdown'}>
 						<button>+ Insert Node</button>
 						<div className={'drop-content'}>
@@ -140,7 +145,6 @@ class PageEditor extends React.Component {
 				</div>
 				<Editor
 					className={'component obojobo-draft--pages--page'}
-					placeholder="Obojobo Visual Editor"
 					value={this.state.value}
 					onChange={change => this.onChange(change)}
 					plugins={plugins}

--- a/packages/obojobo-document-engine/src/scripts/oboeditor/plugins/editor-schema.js
+++ b/packages/obojobo-document-engine/src/scripts/oboeditor/plugins/editor-schema.js
@@ -1,0 +1,57 @@
+import { CHILD_REQUIRED, CHILD_TYPE_INVALID } from 'slate-schema-violations'
+
+// Default node type
+const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
+
+// Placeholder array until EditorStore is implemented
+const nodes = [
+	'ObojoboDraft.Chunks.ActionButton',
+	'ObojoboDraft.Chunks.Break',
+	'ObojoboDraft.Chunks.Code',
+	'ObojoboDraft.Chunks.Figure',
+	'ObojoboDraft.Chunks.Heading',
+	'ObojoboDraft.Chunks.HTML',
+	'ObojoboDraft.Chunks.IFrame',
+	'ObojoboDraft.Chunks.List',
+	'ObojoboDraft.Chunks.MathEquation',
+	'ObojoboDraft.Chunks.MCAssessment',
+	'ObojoboDraft.Chunks.Table',
+	'ObojoboDraft.Chunks.Text',
+	'ObojoboDraft.Chunks.YouTube',
+	'ObojoboDraft.Chunks.QuestionBank',
+	'ObojoboDraft.Chunks.Question',
+	'ObojoboDraft.Sections.Assessment',
+	'ObojoboDraft.Pages.Page'
+]
+
+const matcher = nodes.map(chunk => {
+	return { type: chunk }
+})
+
+const EditorSchema = {
+	schema: {
+		document: {
+			nodes: [{ match: matcher, min: 1 }],
+			normalize: (change, error) => {
+				const { node, child, index } = error
+
+				switch (error.code) {
+					case CHILD_REQUIRED: {
+						return change.insertNodeByKey(node.key, index, {
+							object: 'block',
+							type: TEXT_NODE
+						})
+					}
+					case CHILD_TYPE_INVALID: {
+						return change.wrapBlockByKey(child.key, {
+							object: 'block',
+							type: TEXT_NODE
+						})
+					}
+				}
+			}
+		}
+	}
+}
+
+export default EditorSchema

--- a/packages/obojobo-document-engine/src/scripts/oboeditor/plugins/editor-schema.js
+++ b/packages/obojobo-document-engine/src/scripts/oboeditor/plugins/editor-schema.js
@@ -24,30 +24,24 @@ const nodes = [
 	'ObojoboDraft.Pages.Page'
 ]
 
-const matcher = nodes.map(chunk => {
-	return { type: chunk }
-})
-
 const EditorSchema = {
 	schema: {
 		document: {
-			nodes: [{ match: matcher, min: 1 }],
+			nodes: [{ match: nodes.map(chunk => ({type: chunk})), min: 1 }],
 			normalize: (change, error) => {
 				const { node, child, index } = error
 
 				switch (error.code) {
-					case CHILD_REQUIRED: {
+					case CHILD_REQUIRED: 
 						return change.insertNodeByKey(node.key, index, {
 							object: 'block',
 							type: TEXT_NODE
 						})
-					}
-					case CHILD_TYPE_INVALID: {
+					case CHILD_TYPE_INVALID:
 						return change.wrapBlockByKey(child.key, {
 							object: 'block',
 							type: TEXT_NODE
 						})
-					}
 				}
 			}
 		}


### PR DESCRIPTION
Added a schema to the top-level document that ensures all pages have at least one node in them.  This also sets Text nodes up as the default node; if a user deletes the last node in a page, the page will insert a new, empty text node.

Resolves https://github.com/ucfopen/Obojobo/issues/612