### PR TITLE
Issue/613 html rendering

### DIFF
--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/HTML/editor.js
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/HTML/editor.js
@@ -5,7 +5,9 @@ const HTML_NODE = 'ObojoboDraft.Chunks.HTML'
 const Node = props => {
 	return (
 		<div className={'component'}>
-			<div className={'obojobo-draft--chunks--html viewer pad html-editor'}>{props.children}</div>
+			<div className={'obojobo-draft--chunks--html viewer pad html-editor'}>
+				<pre>{props.children}</pre>
+			</div>
 		</div>
 	)
 }
@@ -55,6 +57,16 @@ const plugins = {
 		switch (props.node.type) {
 			case HTML_NODE:
 				return <Node {...props} {...props.attributes} />
+		}
+	},
+	onKeyDown(event, change) {
+		const isHTML = change.value.blocks.some(block => block.type === HTML_NODE)
+		if (!isHTML) return
+
+		// Insert a softbreak on enter
+		if (event.key === 'Enter') {
+			event.preventDefault()
+			return change.insertText('\n')
 		}
 	},
 	schema: {

--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/HTML/editor.js
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/HTML/editor.js
@@ -5,7 +5,7 @@ const HTML_NODE = 'ObojoboDraft.Chunks.HTML'
 const Node = props => {
 	return (
 		<div className={'component'}>
-			<div className={'obojobo-draft--chunks--html viewer pad'}>{props.children}</div>
+			<div className={'obojobo-draft--chunks--html viewer pad html-editor'}>{props.children}</div>
 		</div>
 	)
 }

--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/HTML/viewer-component.scss
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/HTML/viewer-component.scss
@@ -12,4 +12,9 @@
 	&.align-right {
 		text-align: right;
 	}
+
+	&.html-editor {
+		background: $color-bg2;
+		border: 1px solid black;
+	}
 }

--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/HTML/viewer-component.scss
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/HTML/viewer-component.scss
@@ -14,7 +14,28 @@
 	}
 
 	&.html-editor {
-		background: $color-bg2;
-		border: 1px solid black;
+		pre {
+			::before {
+				color: $color-text-minor;
+				content: 'HTML';
+				display: block;
+				font-family: $font-default;
+				position: absolute;
+				left: 3.5em;
+				top: 0;
+				transform: scale(0.7);
+				transform-origin: top left;
+			}
+
+			font-size: 0.9em;
+			margin-top: 0;
+			margin-bottom: 0;
+			overflow-x: auto;
+			background: $color-bg2;
+			border-radius: $dimension-rounded-radius;
+			box-sizing: border-box;
+			padding: $dimension-padding / 4 $dimension-padding / 3 / 0.9;
+			tab-size: 2;
+		}
 	}
 }

--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/MCAssessment/MCAnswer/editor.js
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/MCAssessment/MCAnswer/editor.js
@@ -33,13 +33,13 @@ const nodes = {
 	'ObojoboDraft.Chunks.Code': Code,
 	'ObojoboDraft.Chunks.Figure': Figure,
 	'ObojoboDraft.Chunks.Heading': Heading,
+	'ObojoboDraft.Chunks.HTML': HTML,
 	'ObojoboDraft.Chunks.IFrame': IFrame,
 	'ObojoboDraft.Chunks.List': List,
 	'ObojoboDraft.Chunks.MathEquation': MathEquation,
 	'ObojoboDraft.Chunks.Table': Table,
 	'ObojoboDraft.Chunks.Text': Text,
-	'ObojoboDraft.Chunks.YouTube': YouTube,
-	'ObojoboDraft.Chunks.HTML': HTML
+	'ObojoboDraft.Chunks.YouTube': YouTube
 }
 
 const Node = props => {
@@ -106,6 +106,7 @@ const plugins = {
 							{ type: CODE_NODE },
 							{ type: FIGURE_NODE },
 							{ type: HEADING_NODE },
+							{ type: HTML_NODE },
 							{ type: IFRAME_NODE },
 							{ type: LIST_NODE },
 							{ type: MATH_NODE },

--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/MCAssessment/MCFeedback/editor.js
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/MCAssessment/MCFeedback/editor.js
@@ -33,13 +33,13 @@ const nodes = {
 	'ObojoboDraft.Chunks.Code': Code,
 	'ObojoboDraft.Chunks.Figure': Figure,
 	'ObojoboDraft.Chunks.Heading': Heading,
+	'ObojoboDraft.Chunks.HTML': HTML,
 	'ObojoboDraft.Chunks.IFrame': IFrame,
 	'ObojoboDraft.Chunks.List': List,
 	'ObojoboDraft.Chunks.MathEquation': MathEquation,
 	'ObojoboDraft.Chunks.Table': Table,
 	'ObojoboDraft.Chunks.Text': Text,
-	'ObojoboDraft.Chunks.YouTube': YouTube,
-	'ObojoboDraft.Chunks.HTML': HTML
+	'ObojoboDraft.Chunks.YouTube': YouTube
 }
 
 class Node extends React.Component {
@@ -123,6 +123,7 @@ const plugins = {
 							{ type: CODE_NODE },
 							{ type: FIGURE_NODE },
 							{ type: HEADING_NODE },
+							{ type: HTML_NODE },
 							{ type: IFRAME_NODE },
 							{ type: LIST_NODE },
 							{ type: MATH_NODE },

--- a/packages/obojobo-document-engine/ObojoboDraft/Chunks/Question/editor.js
+++ b/packages/obojobo-document-engine/ObojoboDraft/Chunks/Question/editor.js
@@ -41,14 +41,14 @@ const nodes = {
 	'ObojoboDraft.Chunks.Code': Code,
 	'ObojoboDraft.Chunks.Figure': Figure,
 	'ObojoboDraft.Chunks.Heading': Heading,
+	'ObojoboDraft.Chunks.HTML': HTML,
 	'ObojoboDraft.Chunks.IFrame': IFrame,
 	'ObojoboDraft.Chunks.List': List,
 	'ObojoboDraft.Chunks.MathEquation': MathEquation,
 	'ObojoboDraft.Chunks.Table': Table,
 	'ObojoboDraft.Chunks.Text': Text,
 	'ObojoboDraft.Chunks.YouTube': YouTube,
-	'ObojoboDraft.Chunks.MCAssessment': MCAssessment,
-	'ObojoboDraft.Chunks.HTML': HTML
+	'ObojoboDraft.Chunks.MCAssessment': MCAssessment
 }
 
 const Solution = props => {
@@ -190,6 +190,7 @@ const plugins = {
 							{ type: CODE_NODE },
 							{ type: FIGURE_NODE },
 							{ type: HEADING_NODE },
+							{ type: HTML_NODE },
 							{ type: IFRAME_NODE },
 							{ type: LIST_NODE },
 							{ type: MATH_NODE },

--- a/packages/obojobo-document-engine/ObojoboDraft/Pages/Page/editor.js
+++ b/packages/obojobo-document-engine/ObojoboDraft/Pages/Page/editor.js
@@ -7,6 +7,7 @@ import Break from '../../Chunks/Break/editor'
 import Code from '../../Chunks/Code/editor'
 import Figure from '../../Chunks/Figure/editor'
 import Heading from '../../Chunks/Heading/editor'
+import HTML from '../../Chunks/HTML/editor'
 import IFrame from '../../Chunks/IFrame/editor'
 import List from '../../Chunks/List/editor'
 import MathEquation from '../../Chunks/MathEquation/editor'
@@ -30,6 +31,7 @@ const nodes = {
 	'ObojoboDraft.Chunks.Code': Code,
 	'ObojoboDraft.Chunks.Figure': Figure,
 	'ObojoboDraft.Chunks.Heading': Heading,
+	'ObojoboDraft.Chunks.HTML': HTML,
 	'ObojoboDraft.Chunks.IFrame': IFrame,
 	'ObojoboDraft.Chunks.List': List,
 	'ObojoboDraft.Chunks.MathEquation': MathEquation,
@@ -104,6 +106,7 @@ const plugins = {
 							{ type: 'ObojoboDraft.Chunks.Code' },
 							{ type: 'ObojoboDraft.Chunks.Figure' },
 							{ type: 'ObojoboDraft.Chunks.Heading' },
+							{ type: 'ObojoboDraft.Chunks.HTML' },
 							{ type: 'ObojoboDraft.Chunks.IFrame' },
 							{ type: 'ObojoboDraft.Chunks.List' },
 							{ type: 'ObojoboDraft.Chunks.MathEquation' },

--- a/packages/obojobo-document-engine/__tests__/ObojoboDraft/Chunks/HTML/__snapshots__/editor.test.js.snap
+++ b/packages/obojobo-document-engine/__tests__/ObojoboDraft/Chunks/HTML/__snapshots__/editor.test.js.snap
@@ -5,8 +5,10 @@ exports[`HTML editor Node builds the expected component 1`] = `
   className="component"
 >
   <div
-    className="obojobo-draft--chunks--html viewer pad"
-  />
+    className="obojobo-draft--chunks--html viewer pad html-editor"
+  >
+    <pre />
+  </div>
 </div>
 `;
 

--- a/packages/obojobo-document-engine/__tests__/ObojoboDraft/Chunks/HTML/editor.test.js
+++ b/packages/obojobo-document-engine/__tests__/ObojoboDraft/Chunks/HTML/editor.test.js
@@ -89,4 +89,70 @@ describe('HTML editor', () => {
 
 		expect(HTML.plugins.renderNode(props)).toMatchSnapshot()
 	})
+
+	test('plugins.onKeyDown deals with no html', () => {
+		const change = {
+			value: {
+				blocks: [
+					{
+						type: 'mockType'
+					}
+				]
+			}
+		}
+		change.insertBlock = jest.fn().mockReturnValueOnce(change)
+
+		const event = {
+			key: 'Enter',
+			preventDefault: jest.fn()
+		}
+
+		HTML.plugins.onKeyDown(event, change)
+
+		expect(event.preventDefault).not.toHaveBeenCalled()
+	})
+
+	test('plugins.onKeyDown deals with random keypress', () => {
+		const change = {
+			value: {
+				blocks: [
+					{
+						type: HTML_NODE
+					}
+				]
+			}
+		}
+		change.insertBlock = jest.fn().mockReturnValueOnce(change)
+
+		const event = {
+			key: 'e',
+			preventDefault: jest.fn()
+		}
+
+		HTML.plugins.onKeyDown(event, change)
+
+		expect(event.preventDefault).not.toHaveBeenCalled()
+	})
+
+	test('plugins.onKeyDown deals with [Enter]', () => {
+		const change = {
+			value: {
+				blocks: [
+					{
+						type: HTML_NODE
+					}
+				]
+			},
+			insertText: jest.fn()
+		}
+
+		const event = {
+			key: 'Enter',
+			preventDefault: jest.fn()
+		}
+
+		HTML.plugins.onKeyDown(event, change)
+		expect(event.preventDefault).toHaveBeenCalled()
+		expect(change.insertText).toHaveBeenCalled()
+	})
 })

--- a/packages/obojobo-document-engine/src/scripts/oboeditor/components/page-editor.js
+++ b/packages/obojobo-document-engine/src/scripts/oboeditor/components/page-editor.js
@@ -128,7 +128,10 @@ class PageEditor extends React.Component {
 		return (
 			<div className={'editor'}>
 				<div className={'toolbar'}>
-					<MarkToolbar.components.Node value={this.state.value} onChange={change => this.onChange(change)} />
+					<MarkToolbar.components.Node
+						value={this.state.value}
+						onChange={change => this.onChange(change)}
+					/>
 					<div className={'dropdown'}>
 						<button>+ Insert Node</button>
 						<div className={'drop-content'}>


### PR DESCRIPTION
Adds more clear rendering for HTML nodes, and allows HTML nodes to be rendered in assessments and questions.
HTML nodes now render similarly to code nodes in the editor, and are label as being HTML (so they are not mistaken for code nodes).  Although they don't have all the same capabilities of a Code node, they do allow enters and indents to enable users to format their HTML in a more readable way.

Resolves https://github.com/ucfopen/Obojobo/issues/613