### PR TITLE
changed instances of random to random-all

### DIFF
--- a/packages/obojobo-document-engine/__mocks__/assessment-server.mock.js
+++ b/packages/obojobo-document-engine/__mocks__/assessment-server.mock.js
@@ -524,7 +524,7 @@ const getAttemptStartServerResponse = () => {
 								}
 							],
 							content: {
-								select: 'random'
+								select: 'random-all'
 							},
 							id: 'a02315ea-3f37-4208-86c8-1ddef043278d',
 							type: 'ObojoboDraft.Chunks.QuestionBank'
@@ -1084,7 +1084,7 @@ const getAttemptEndServerResponse = () => {
 									id: 'a02315ea-3f37-4208-86c8-1ddef043278d',
 									type: 'ObojoboDraft.Chunks.QuestionBank',
 									content: {
-										select: 'random'
+										select: 'random-all'
 									},
 									children: [
 										{

--- a/packages/obojobo-document-engine/test-object.json
+++ b/packages/obojobo-document-engine/test-object.json
@@ -3522,7 +3522,7 @@
 							"id": "a02315ea-3f37-4208-86c8-1ddef043278d",
 							"type": "ObojoboDraft.Chunks.QuestionBank",
 							"content": {
-								"select": "random"
+								"select": "random-all"
 							},
 							"children": [
 								{
@@ -4035,7 +4035,7 @@
 							"id": "527a87ef-0e31-4ee0-9c77-9c9fbab297ba",
 							"type": "ObojoboDraft.Chunks.QuestionBank",
 							"content": {
-								"select": "random"
+								"select": "random-all"
 							},
 							"children": [
 								{

--- a/packages/obojobo-document-xml-parser/examples/test-object.xml
+++ b/packages/obojobo-document-xml-parser/examples/test-object.xml
@@ -553,7 +553,7 @@ int Fibonacci(int n)
 			<QuestionBank choose="1" select="sequential">
 
 				<!-- Question bank for attempts 1, 3, 5 and so on: -->
-				<QuestionBank select="random">
+				<QuestionBank select="random-all">
 					<Question>
 						<h1>What is 2+2?</h1>
 						<MCAssessment responseType="pick-one" shuffle="true">
@@ -641,7 +641,7 @@ int Fibonacci(int n)
 
 				</QuestionBank>
 
-				<QuestionBank select="random">
+				<QuestionBank select="random-all">
 					<Question>
 						<h1>Apple is a type of</h1>
 						<MCAssessment responseType="pick-one" shuffle="true">


### PR DESCRIPTION
This was an issue on Obojobo Docs https://github.com/ucfopen/Obojobo-Docs/issues/27 but instances of `random`  were changed to `random-all` in this PR. However due to #642 not going to merge this in at the moment. Will instead remove random-all questions from test-object for the moment