### PR TITLE
Allow events and caliper_store is_preview to be null

### DIFF
--- a/packages/obojobo-express/migrations/20180522180212-modify-events-add-content-id.js
+++ b/packages/obojobo-express/migrations/20180522180212-modify-events-add-content-id.js
@@ -15,7 +15,6 @@ exports.setup = function(options, seedLink) {
 }
 
 exports.up = function(db) {
-	// The UUID will temporarily allow null
 	return (
 		db
 			.addColumn('events', 'draft_content_id', {
@@ -24,45 +23,42 @@ exports.up = function(db) {
 			// Grab all the current records, which will not have draft_content_ids
 			.then(() => {
 				return db.runSql(`
-					SELECT
-						id,
-						draft_id,
-						created_at
-					FROM events
-				`)
-			})
-			// Find the correct UUID for each record
-			.then(result => {
-				let updates = []
-				result.rows.forEach(row => {
-					const draftId = row.draft_id
-					const created = row.created_at
-					const rowId = row.id
+					-- make a table with content id's and start/end dates that apply to it
+					CREATE TEMP TABLE content_dates AS
+					SELECT * FROM (
+						SELECT
+							id,
+							draft_id,
+							created_at,
+							CASE
+								WHEN lead(draft_id) over (order by draft_id, created_at asc) = draft_id
+								THEN lead(created_at) over (order by draft_id, created_at asc)
+								ELSE now()
+							END AS end_date
+						FROM drafts_content
+					) AS S;
 
-					updates.push(`
-						UPDATE
-							events
-						SET
-							draft_content_id=content.id
-						FROM
-						(
-							SELECT
-								id
-							FROM
-								drafts_content
-							WHERE
-								draft_id='${draftId}'
-								AND created_at<='${created.toISOString()}'
-							ORDER BY
-								created_at DESC
-							LIMIT 1
-						) content
-						WHERE
-							events.id=${rowId}
-					`)
-				})
-				updates = updates.join(';')
-				return db.runSql(updates)
+					-- use the temp table copy the draft_content_id into events table
+					UPDATE
+						events
+					SET
+						draft_content_id=DC.draft_content_id
+					FROM
+					(
+						SELECT
+							e.id AS event_id,
+							d.id AS draft_content_id
+						FROM events AS e
+						LEFT JOIN content_dates AS d
+							ON d.draft_id = e.draft_id
+							AND  d.created_at < e.created_at
+							AND  d.end_date > e.created_at
+						WHERE e.draft_id IS NOT null
+					) AS DC
+					WHERE
+						events.id=event_id
+						AND events.draft_id IS NOT null;
+				`)
 			})
 	)
 }

--- a/packages/obojobo-express/migrations/20180627193918-modify-events-add-is-preview.js
+++ b/packages/obojobo-express/migrations/20180627193918-modify-events-add-is-preview.js
@@ -1,20 +1,5 @@
 'use strict'
 
-const canViewEditorRoles = require('../config').permissions.canViewEditor
-
-const doRolesIncludeCanViewEditorRole = rolesStr => {
-	const roles = rolesStr
-		.substr(1, rolesStr.length - 2)
-		.split(',')
-		.map(r => r.replace(/"/g, '').replace(/ /g, ''))
-
-	for (let i = 0, len = roles.length; i < len; i++) {
-		if (canViewEditorRoles.indexOf(roles[i]) > -1) return true
-	}
-
-	return false
-}
-
 let dbm
 let type
 let seed
@@ -30,105 +15,13 @@ exports.setup = function(options, seedLink) {
 }
 
 exports.up = function(db) {
-	const launches = {}
-
-	return (
-		db
-			// Add is_preview but don't enforce notNull since there may be data in there already!
-			.addColumn('events', 'is_preview', {
-				type: 'boolean'
-			})
-			// Grab all the launches. In pre-amethyst releases preview mode was
-			// determined based on if the user had canViewEditor permissions and that
-			// was based on their LTI roles. Will attempt to grab the time of the event,
-			// reference it with the time of the launch (and user and draft)
-			.then(() => {
-				return db.runSql(`
-					SELECT
-						id, created_at, user_id, draft_id, data->>'roles' AS roles
-					FROM
-						launches
-					ORDER BY
-						created_at
-				`)
-			})
-			// Build a map of launches
-			.then(result => {
-				result.rows.forEach(row => {
-					const key = row.user_id + ':' + row.draft_id
-					if (!launches[key]) launches[key] = []
-
-					launches[key].push(row)
-				})
-			})
-			// Grab all the events
-			.then(() => {
-				return db.runSql(`
-					SELECT
-						id, created_at, actor as user_id, draft_id
-					FROM
-						events
-					ORDER BY
-						created_at
-				`)
-			})
-			// Go through all events and figure out the associated launch
-			.then(result => {
-				const updates = []
-
-				result.rows.forEach(event => {
-					const key = event.user_id + ':' + event.draft_id
-					const launchesForUserAndDraft = launches[key]
-					let isPreview
-
-					if (!launchesForUserAndDraft) {
-						// Unable to find a launch, most likely this is because this is a preview
-						isPreview = true
-					} else {
-						let i = 0
-						for (let len = launchesForUserAndDraft.length; i < len; i++) {
-							const launch = launchesForUserAndDraft[i]
-
-							if (launch.created_at > event.created_at) break
-						}
-
-						if (i === 0) {
-							console.error(launchesForUserAndDraft, event.id, event.created_at)
-							throw 'Unable to find launch for event - event is before any launch! ' + event.id
-						}
-
-						const matchingLaunch = launchesForUserAndDraft[i - 1]
-
-						isPreview = doRolesIncludeCanViewEditorRole(matchingLaunch.roles)
-					}
-
-					updates.push(`
-							UPDATE
-								events
-							SET
-								is_preview=${isPreview}
-							WHERE
-								id=${event.id}
-					`)
-				})
-
-				return updates.join(';')
-			})
-			.then(updates => {
-				return db.runSql(updates)
-			})
-			// Require notNull after content has been filled out
-			.then(() => {
-				return db.changeColumn('events', 'is_preview', {
-					type: 'boolean',
-					notNull: true
-				})
-			})
-			// Finally, add the index
-			.then(() => {
-				return db.addIndex('events', 'events_is_preview', ['is_preview'])
-			})
-	)
+	return db
+		.addColumn('events', 'is_preview', {
+			type: 'boolean'
+		})
+		.then(() => {
+			return db.addIndex('events', 'events_is_preview', ['is_preview'])
+		})
 }
 
 exports.down = function(db) {

--- a/packages/obojobo-express/migrations/20180627200648-modify-caliper-store-add-is-preview.js
+++ b/packages/obojobo-express/migrations/20180627200648-modify-caliper-store-add-is-preview.js
@@ -15,57 +15,13 @@ exports.setup = function(options, seedLink) {
 }
 
 exports.up = function(db) {
-	return (
-		db
-			// Add is_preview but don't enforce notNull since there may be data in there already!
-			.addColumn('caliper_store', 'is_preview', {
-				type: 'boolean'
-			})
-			// Grab all the current records, which should have a 'previewMode' property
-			// in extensions
-			.then(() => {
-				return db.runSql(`
-					SELECT
-						*
-					FROM caliper_store
-				`)
-			})
-			.then(result => {
-				const updates = result.rows
-					.map(row => {
-						const id = row.id
-						const payload = row.payload
-						let isPreview = true
-
-						if (payload.extensions && typeof payload.extensions.previewMode !== 'undefined') {
-							isPreview = Boolean(payload.extensions.previewMode)
-						}
-
-						return `
-						UPDATE
-							caliper_store
-						SET
-							is_preview=${isPreview}
-						WHERE
-							id='${id}'
-					`
-					})
-					.join(';')
-
-				return db.runSql(updates)
-			})
-			// Require notNull after content has been filled out
-			.then(() => {
-				return db.changeColumn('caliper_store', 'is_preview', {
-					type: 'boolean',
-					notNull: true
-				})
-			})
-			// Finally, add the index
-			.then(() => {
-				return db.addIndex('caliper_store', 'caliper_store_is_preview', ['is_preview'])
-			})
-	)
+	return db
+		.addColumn('caliper_store', 'is_preview', {
+			type: 'boolean'
+		})
+		.then(() => {
+			return db.addIndex('caliper_store', 'caliper_store_is_preview', ['is_preview'])
+		})
 }
 
 exports.down = function(db) {


### PR DESCRIPTION
These events work on massive tables and backfilling the data is problematic. Relaxing this requirement.