### PR TITLE
Add related event id to viewer:return and viewer:returnFromInactive

### DIFF
--- a/packages/obojobo-document-engine/__tests__/viewer/components/viewer-app.test.js
+++ b/packages/obojobo-document-engine/__tests__/viewer/components/viewer-app.test.js
@@ -537,7 +537,9 @@ describe('ViewerApp', () => {
 		const component = mount(<ViewerApp />)
 
 		setTimeout(() => {
-			component.instance().leaveEvent = { id: 'mockId' }
+			const dateSpy = jest.spyOn(Date, 'now').mockReturnValueOnce(1000)
+			component.instance().leaveEvent = { extensions: { internalEventId: 'mock-id' } }
+			component.instance().leftEpoch = 999
 			APIUtil.postEvent.mockResolvedValueOnce({ value: null })
 			component.update()
 
@@ -546,11 +548,16 @@ describe('ViewerApp', () => {
 			expect(APIUtil.postEvent).toHaveBeenCalledWith({
 				action: 'viewer:return',
 				draftId: undefined,
-				eventVersion: '1.0.0',
-				payload: { relatedEventId: 'mockId' },
+				eventVersion: '2.0.0',
+				payload: {
+					relatedEventId: 'mock-id',
+					leftTime: 999,
+					duration: 1
+				},
 				visitId: undefined
 			})
 
+			dateSpy.mockRestore()
 			component.unmount()
 			done()
 		})
@@ -793,13 +800,27 @@ describe('ViewerApp', () => {
 		const component = mount(<ViewerApp />)
 
 		setTimeout(() => {
+			const dateSpy = jest.spyOn(Date, 'now').mockReturnValueOnce(1000)
+			component.instance().inactiveEvent = { extensions: { internalEventId: 'mock-id' } }
+			component.instance().lastActiveEpoch = 999
+			APIUtil.postEvent.mockResolvedValueOnce({ value: null })
 			component.update()
-			component.instance().inactiveEvent = { id: 'mockEventId' }
 
 			component.instance().onReturnFromIdle()
 
-			expect(APIUtil.postEvent).toHaveBeenCalled()
+			expect(APIUtil.postEvent).toHaveBeenCalledWith({
+				action: 'viewer:returnFromInactive',
+				draftId: undefined,
+				eventVersion: '3.0.0',
+				payload: {
+					relatedEventId: 'mock-id',
+					lastActiveTime: 999,
+					inactiveDuration: 1
+				},
+				visitId: undefined
+			})
 
+			dateSpy.mockRestore()
 			component.unmount()
 			done()
 		})

--- a/packages/obojobo-document-engine/__tests__/viewer/components/viewer-app.test.js
+++ b/packages/obojobo-document-engine/__tests__/viewer/components/viewer-app.test.js
@@ -811,7 +811,7 @@ describe('ViewerApp', () => {
 			expect(APIUtil.postEvent).toHaveBeenCalledWith({
 				action: 'viewer:returnFromInactive',
 				draftId: undefined,
-				eventVersion: '3.0.0',
+				eventVersion: '2.1.0',
 				payload: {
 					relatedEventId: 'mock-id',
 					lastActiveTime: 999,

--- a/packages/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -447,7 +447,7 @@ export default class ViewerApp extends React.Component {
 		APIUtil.postEvent({
 			draftId: this.state.model.get('draftId'),
 			action: 'viewer:returnFromInactive',
-			eventVersion: '3.0.0',
+			eventVersion: '2.1.0',
 			visitId: this.state.navState.visitId,
 			payload: {
 				lastActiveTime: this.lastActiveEpoch,

--- a/packages/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -322,6 +322,8 @@ export default class ViewerApp extends React.Component {
 
 	onVisibilityChange() {
 		if (document.hidden) {
+			this.leftEpoch = new Date()
+
 			APIUtil.postEvent({
 				draftId: this.state.model.get('draftId'),
 				action: 'viewer:leave',
@@ -334,13 +336,17 @@ export default class ViewerApp extends React.Component {
 			APIUtil.postEvent({
 				draftId: this.state.model.get('draftId'),
 				action: 'viewer:return',
-				eventVersion: '1.0.0',
+				eventVersion: '2.0.0',
 				visitId: this.state.navState.visitId,
 				payload: {
-					relatedEventId: this.leaveEvent.id
+					relatedEventId: this.leaveEvent.extensions.internalEventId,
+					leftTime: this.leftEpoch,
+					duration: Date.now() - this.leftEpoch
 				}
 			})
+
 			delete this.leaveEvent
+			delete this.leftEpoch
 		}
 	}
 
@@ -427,6 +433,7 @@ export default class ViewerApp extends React.Component {
 			draftId: this.state.model.get('draftId'),
 			action: 'viewer:inactive',
 			eventVersion: '3.0.0',
+			visitId: this.state.navState.visitId,
 			payload: {
 				lastActiveTime: this.lastActiveEpoch,
 				inactiveDuration: IDLE_TIMEOUT_DURATION_MS
@@ -440,12 +447,12 @@ export default class ViewerApp extends React.Component {
 		APIUtil.postEvent({
 			draftId: this.state.model.get('draftId'),
 			action: 'viewer:returnFromInactive',
-			eventVersion: '2.0.0',
+			eventVersion: '3.0.0',
 			visitId: this.state.navState.visitId,
 			payload: {
 				lastActiveTime: this.lastActiveEpoch,
 				inactiveDuration: Date.now() - this.lastActiveEpoch,
-				relatedEventId: this.inactiveEvent.id
+				relatedEventId: this.inactiveEvent.extensions.internalEventId
 			}
 		})
 

--- a/packages/obojobo-express/__tests__/insert_event.test.js
+++ b/packages/obojobo-express/__tests__/insert_event.test.js
@@ -77,6 +77,41 @@ describe('insert_event', () => {
 			})
 	})
 
+	test('inserts the expected values with a caliper event (with extensions)', () => {
+		expect.assertions(5)
+
+		const db = oboRequire('db')
+		const insertEvent = oboRequire('insert_event')
+		const expectedCreatedAt = new Date().toISOString()
+		const insertObject = {
+			action: 'test::testAction',
+			actorTime: new Date().toISOString(),
+			payload: { value: 'test' },
+			userId: 9,
+			ip: '1.2.3.4',
+			metadata: { value: 'test2' },
+			draftId: '999999',
+			caliperPayload: { id: 'mockCaliperPayload', extensions: {} }
+		}
+		// mock insert
+		db.one.mockResolvedValueOnce({ created_at: expectedCreatedAt })
+
+		return insertEvent(insertObject)
+			.then(result => {
+				expect(result).toHaveProperty('created_at')
+				expect(result.created_at).toBe(expectedCreatedAt)
+				expect(db.one).toHaveBeenCalledTimes(1)
+				expect(db.one).toHaveBeenCalledWith(
+					expect.stringContaining('INSERT INTO events'),
+					insertObject
+				)
+				expect(db.none).toHaveBeenCalledTimes(1)
+			})
+			.catch(err => {
+				throw err
+			})
+	})
+
 	test('Returns promise rejection', () => {
 		expect.assertions(1)
 

--- a/packages/obojobo-express/insert_event.js
+++ b/packages/obojobo-express/insert_event.js
@@ -7,11 +7,17 @@ module.exports = insertObject => {
 		INSERT INTO events
 		(actor_time, action, actor, ip, metadata, payload, draft_id, draft_content_id, version, is_preview)
 		VALUES ($[actorTime], $[action], $[userId], $[ip], $[metadata], $[payload], $[draftId], $[contentId], $[eventVersion], $[isPreview])
-		RETURNING created_at`,
+		RETURNING *`,
 			insertObject
 		)
-		.then(createdAt => {
+		.then(createdEvent => {
 			if (insertObject.caliperPayload) {
+				// Add in internal event id to extensions object:
+				if (!insertObject.caliperPayload.extensions) {
+					insertObject.caliperPayload.extensions = {}
+				}
+				insertObject.caliperPayload.extensions.internalEventId = createdEvent.id
+
 				db.none(
 					`
 					INSERT INTO caliper_store
@@ -21,6 +27,6 @@ module.exports = insertObject => {
 				)
 			}
 
-			return createdAt
+			return createdEvent
 		})
 }


### PR DESCRIPTION
These events were putting the related _caliper_ event ID into these events. This PR changes this to include the related _internal_ event ID. Also adds in some additional helpful date information into viewer:return. Updates version for both viewer:return and viewer:returnFromInactive events.

Related docs PR: https://github.com/ucfopen/Obojobo-Docs/pull/39

Fixes #651 