### PR TITLE
Add API Route for 'full draft'

### DIFF
--- a/packages/obojobo-document-engine/__tests__/oboeditor/components/editor-app.test.js
+++ b/packages/obojobo-document-engine/__tests__/oboeditor/components/editor-app.test.js
@@ -27,7 +27,7 @@ describe('EditorApp', () => {
 			modelState: { start: 'mockStart' }
 		})
 
-		APIUtil.getDraft.mockResolvedValueOnce({ value: testObject })
+		APIUtil.getFullDraft.mockResolvedValueOnce({ value: testObject })
 		EditorStore.getState.mockReturnValueOnce({})
 
 		const component = mount(<EditorApp />)
@@ -52,7 +52,7 @@ describe('EditorApp', () => {
 			modelState: { start: 'mockStart' }
 		})
 
-		APIUtil.getDraft.mockResolvedValueOnce({ value: testObject })
+		APIUtil.getFullDraft.mockResolvedValueOnce({ value: testObject })
 		EditorStore.getState.mockReturnValueOnce({})
 
 		const component = mount(<EditorApp />)
@@ -74,7 +74,7 @@ describe('EditorApp', () => {
 			modelState: { start: 'mockStart' }
 		})
 
-		APIUtil.getDraft.mockResolvedValueOnce({ value: testObject })
+		APIUtil.getFullDraft.mockResolvedValueOnce({ value: testObject })
 		EditorStore.getState.mockReturnValueOnce({}).mockReturnValueOnce({})
 
 		const component = mount(<EditorApp />)
@@ -97,7 +97,7 @@ describe('EditorApp', () => {
 			modelState: { start: 'mockStart' }
 		})
 
-		APIUtil.getDraft.mockResolvedValueOnce({
+		APIUtil.getFullDraft.mockResolvedValueOnce({
 			status: 'error',
 			value: { type: 'someType', message: 'someMessage' }
 		})

--- a/packages/obojobo-document-engine/__tests__/viewer/util/api-util.test.js
+++ b/packages/obojobo-document-engine/__tests__/viewer/util/api-util.test.js
@@ -176,6 +176,25 @@ describe('apiutil', () => {
 		})
 	})
 
+	test('getFullDraft calls fetch', () => {
+		expect.assertions(3)
+
+		fetch.mockResolvedValueOnce({
+			json: () => ({
+				status: 'ok',
+				value: 'mockValue'
+			})
+		})
+
+		return APIUtil.getFullDraft('mockId').then(() => {
+			expect(fetch).toHaveBeenCalled()
+			const calledEndpoint = fetch.mock.calls[0][0]
+			const calledOptions = fetch.mock.calls[0][1]
+			expect(calledEndpoint).toBe('/api/drafts/mockId/full')
+			expect(calledOptions).toBe()
+		})
+	})
+
 	test('requestStart calls fetch', () => {
 		expect.assertions(4)
 

--- a/packages/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
+++ b/packages/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
@@ -37,7 +37,7 @@ class EditorApp extends React.Component {
 		const urlTokens = document.location.pathname.split('/')
 		const draftId = urlTokens[2] ? urlTokens[2] : null
 
-		return APIUtil.getDraft(draftId)
+		return APIUtil.getFullDraft(draftId)
 			.then(response => {
 				if (response.status === 'error') throw response.value
 				return response

--- a/packages/obojobo-document-engine/src/scripts/viewer/util/api-util.js
+++ b/packages/obojobo-document-engine/src/scripts/viewer/util/api-util.js
@@ -62,6 +62,10 @@ const APIUtil = {
 		return fetch(`/api/drafts/${id}`).then(processJsonResults)
 	},
 
+	getFullDraft(id) {
+		return fetch(`/api/drafts/${id}/full`).then(processJsonResults)
+	},
+
 	requestStart(visitId, draftId) {
 		return APIUtil.post('/api/visits/start', {
 			visitId,

--- a/packages/obojobo-express/__tests__/models/draft.test.js
+++ b/packages/obojobo-express/__tests__/models/draft.test.js
@@ -40,10 +40,11 @@ describe('Draft Model', () => {
 	afterEach(() => {})
 
 	test('constructor initializes expected properties', () => {
-		const d = new DraftModel({})
+		const d = new DraftModel('mock-author-id', {})
 		expect(d.nodesById).toBeInstanceOf(Map)
 		expect(d.nodesByType).toBeInstanceOf(Map)
 		expect(d.root).toBeInstanceOf(DraftNode)
+		expect(d.authorId).toBe('mock-author-id')
 	})
 
 	test('yell calls to child nodes', () => {

--- a/packages/obojobo-express/__tests__/models/draft_node.test.js
+++ b/packages/obojobo-express/__tests__/models/draft_node.test.js
@@ -114,7 +114,7 @@ describe('models draft', () => {
 	})
 
 	test('contains finds child nodes', () => {
-		const d = new Draft(mockRawDraft.content)
+		const d = new Draft(null, mockRawDraft.content)
 		expect(d.root.contains({ id: 999 })).toBe(true)
 		expect(d.root.contains({ id: 888 })).toBe(true)
 		expect(d.root.contains({ id: 777 })).toBe(true)
@@ -130,7 +130,7 @@ describe('models draft', () => {
 
 	test('yells to children', () => {
 		expect.assertions(3)
-		const d = new Draft(mockRawDraft.content)
+		const d = new Draft(null, mockRawDraft.content)
 
 		const node = d.getChildNodeById(666)
 

--- a/packages/obojobo-express/models/draft.js
+++ b/packages/obojobo-express/models/draft.js
@@ -32,7 +32,8 @@ const findDuplicateIdsRecursive = (jsonTreeNode, idSet = new Set()) => {
 }
 
 class Draft {
-	constructor(rawDraft) {
+	constructor(authorId, rawDraft) {
+		this.authorId = authorId
 		this.nodesById = new Map()
 		this.nodesByType = new Map()
 		this.draftId = rawDraft.draftId
@@ -76,6 +77,7 @@ class Draft {
 				`
 			SELECT
 				drafts.id AS id,
+				drafts.user_id as author,
 				drafts_content.id AS version,
 				drafts.created_at AS draft_created_at,
 				drafts_content.created_at AS content_created_at,
@@ -95,7 +97,7 @@ class Draft {
 				result.content.contentId = result.version
 				result.content._rev = result.version
 
-				return new Draft(result.content)
+				return new Draft(result.author, result.content)
 			})
 			.catch(error => {
 				logger.error('fetchById Error', error.message)

--- a/packages/obojobo-express/routes/api/drafts.js
+++ b/packages/obojobo-express/routes/api/drafts.js
@@ -4,43 +4,74 @@ const router = express.Router()
 const DraftModel = oboRequire('models/draft')
 const logger = oboRequire('logger')
 const db = oboRequire('db')
+const pgp = require('pg-promise')
 const xmlToDraftObject = require('obojobo-document-xml-parser/xml-to-draft-object')
+const emptyXmlPath = require.resolve('obojobo-document-engine/documents/empty.xml')
+const draftTemplateXML = fs.readFileSync(emptyXmlPath).toString()
+const tutorialDraft = require('obojobo-document-engine/src/scripts/oboeditor/documents/oboeditor-tutorial.json')
+const draftTemplate = xmlToDraftObject(draftTemplateXML, true)
 const {
 	checkValidationRules,
 	requireDraftId,
+	requireCanViewEditor,
 	requireCanCreateDrafts,
 	requireCanDeleteDrafts,
 	requireCanViewDrafts
 } = oboRequire('express_validators')
 
-const emptyXmlPath = require.resolve('obojobo-document-engine/documents/empty.xml')
-const draftTemplateXML = fs.readFileSync(emptyXmlPath).toString()
+const isNoDataFromQueryError = e => {
+	return (
+		e instanceof pgp.errors.QueryResultError && e.code === pgp.errors.queryResultErrorCode.noData
+	)
+}
 
-const tutorialDraft = require('../../../obojobo-document-engine/src/scripts/oboeditor/documents/oboeditor-tutorial.json')
+// Get a complete Draft Document Tree (for editing)
+// mounted as /api/drafts/:draftId/full
+router
+	.route('/:draftId/full')
+	.get([requireDraftId, requireCanViewEditor, checkValidationRules])
+	.get(async (req, res) => {
+		try {
+			const draftModel = await DraftModel.fetchById(req.params.draftId)
 
-const draftTemplate = xmlToDraftObject(draftTemplateXML, true)
+			if (draftModel.authorId !== req.currentUser.id) {
+				return res.notAuthorized(
+					'You must be the author of this draft to retrieve this information'
+				)
+			}
 
-// Get a Draft Document Tree
+			return res.success(draftModel.document)
+		} catch (e) {
+			if (isNoDataFromQueryError(e)) {
+				return res.missing('Draft not found')
+			}
+
+			res.unexpected(e)
+		}
+	})
+
+// Get a Draft Document Tree (for viewing by a student)
 // mounted as /api/drafts/:draftId
 router
 	.route('/:draftId')
 	.get([requireDraftId, checkValidationRules])
-	.get((req, res) => {
-		const draftId = req.params.draftId
+	.get(async (req, res) => {
+		try {
+			const draftModel = await DraftModel.fetchById(req.params.draftId)
 
-		return DraftModel.fetchById(draftId)
-			.then(draftTree => {
-				draftTree.root.yell('internal:sendToClient', req, res)
-				res.success(draftTree.document)
-			})
-			.catch(error => {
-				const QueryResultError = db.errors.QueryResultError
-				const qrec = db.errors.queryResultErrorCode
-				if (error instanceof QueryResultError && error.code === qrec.noData) {
-					return res.missing('Draft not found')
-				}
-				res.unexpected(error)
-			})
+			// Dispatch the "internal:sendToClient" event - this allows any installed OboNode to
+			// alter the data before the document is returned (for example, to remove assessment
+			// questions)
+			draftModel.root.yell('internal:sendToClient', req, res)
+
+			return res.success(draftModel.document)
+		} catch (e) {
+			if (isNoDataFromQueryError(e)) {
+				return res.missing('Draft not found')
+			}
+
+			res.unexpected(e)
+		}
 	})
 
 // Create a Draft


### PR DESCRIPTION
Fixes #737 

Aka the non-scrubbed draft for the editor. I called it 'full' draft but I'm open to other ideas.

* Adds new /draft/:draftId/full route to get the un-scrubbed draft for the editor
* Adds APIUtil.getFullDraft
* Adds authorId to draft model
* Fixes /draft/:draftId routes to return errors (previously the catch cases were halting and never returning)