### PR TITLE
Updates draft manager to not error if draft content is empty

### DIFF
--- a/packages/obojobo-express/views/editor_picker.ejs
+++ b/packages/obojobo-express/views/editor_picker.ejs
@@ -85,10 +85,10 @@
 				</div>
 				<ul id="list">
 					<% drafts.sort(function(a, b) {
-						let aTime = (new Date(a.createdAt)).getTime()
-						let bTime = (new Date(b.createdAt)).getTime()
-						let aTitle = a.content && a.content.content ? '' + a.content.content.title : null
-						let bTitle = b.content && b.content.content ? '' + b.content.content.title : null
+						let aTime = (new Date(a && a.createdAt ? a.createdAt : 0)).getTime()
+						let bTime = (new Date(b && b.createdAt ? b.createdAt : 0)).getTime()
+						let aTitle = a && a.content && a.content.content ? '' + a.content.content.title : ''
+						let bTitle = b && b.content && b.content.content ? '' + b.content.content.title : ''
 						if(aTitle.toLowerCase() < bTitle.toLowerCase()) return -1;
 						if(aTitle.toLowerCase() > bTitle.toLowerCase()) return 1;
 						if(aTitle < bTitle) return 1;


### PR DESCRIPTION
Adds more checks to the drafts sort in the drafts manager to avoid errors being thrown and the page to not display.

The error only happens if the draft content is null, which shouldn't happen, but it is happening to me on production.

Fixes #754 