### PR TITLE
Updates XML parser to parse h3-h6 tags

### DIFF
--- a/packages/obojobo-document-xml-parser/__tests__/__snapshots__/nodes.test.js.snap
+++ b/packages/obojobo-document-xml-parser/__tests__/__snapshots__/nodes.test.js.snap
@@ -318,6 +318,63 @@ Object {
         "headingLevel": 2,
         "textGroup": Array [
           Object {
+            "data": Object {
+              "align": "center",
+            },
+            "text": Object {
+              "styleList": Array [],
+              "value": "This is a test",
+            },
+          },
+        ],
+      },
+      "id": null,
+      "type": "ObojoboDraft.Chunks.Heading",
+    },
+    Object {
+      "children": Array [],
+      "content": Object {
+        "headingLevel": 3,
+        "textGroup": Array [
+          Object {
+            "data": Object {
+              "align": "left",
+            },
+            "text": Object {
+              "styleList": Array [],
+              "value": "This is a test",
+            },
+          },
+        ],
+      },
+      "id": null,
+      "type": "ObojoboDraft.Chunks.Heading",
+    },
+    Object {
+      "children": Array [],
+      "content": Object {
+        "headingLevel": 4,
+        "textGroup": Array [
+          Object {
+            "data": Object {
+              "align": "right",
+            },
+            "text": Object {
+              "styleList": Array [],
+              "value": "This is a test",
+            },
+          },
+        ],
+      },
+      "id": null,
+      "type": "ObojoboDraft.Chunks.Heading",
+    },
+    Object {
+      "children": Array [],
+      "content": Object {
+        "headingLevel": 5,
+        "textGroup": Array [
+          Object {
             "data": null,
             "text": Object {
               "styleList": Array [],
@@ -332,12 +389,10 @@ Object {
     Object {
       "children": Array [],
       "content": Object {
-        "headingLevel": 2,
+        "headingLevel": 6,
         "textGroup": Array [
           Object {
-            "data": Object {
-              "align": "center",
-            },
+            "data": null,
             "text": Object {
               "styleList": Array [],
               "value": "This is a test",

--- a/packages/obojobo-document-xml-parser/__tests__/obo_node_shorthand/heading.xml
+++ b/packages/obojobo-document-xml-parser/__tests__/obo_node_shorthand/heading.xml
@@ -2,7 +2,10 @@
 <ObojoboDraftDoc>
     <Module>
         <h1>This is a test</h1>
-        <h2>This is a test</h2>
         <h2 align="center">This is a test</h2>
+        <h3 align="left">This is a test</h3>
+        <h4 align="right">This is a test</h4>
+        <h5>This is a test</h5>
+        <h6>This is a test</h6>
     </Module>
 </ObojoboDraftDoc>

--- a/packages/obojobo-document-xml-parser/__tests__/obo_node_xml/heading.xml
+++ b/packages/obojobo-document-xml-parser/__tests__/obo_node_xml/heading.xml
@@ -8,12 +8,27 @@
         </Heading>
         <Heading headingLevel="2">
             <textGroup>
+                <t align="center">This is a test</t>
+            </textGroup>
+        </Heading>
+        <Heading headingLevel="3">
+            <textGroup>
+                <t align="left">This is a test</t>
+            </textGroup>
+        </Heading>
+        <Heading headingLevel="4">
+            <textGroup>
+                <t align="right">This is a test</t>
+            </textGroup>
+        </Heading>
+        <Heading headingLevel="5">
+            <textGroup>
                 <t>This is a test</t>
             </textGroup>
         </Heading>
-        <Heading headingLevel="2">
+        <Heading headingLevel="6">
             <textGroup>
-                <t align="center">This is a test</t>
+                <t>This is a test</t>
             </textGroup>
         </Heading>
     </Module>

--- a/packages/obojobo-document-xml-parser/src/html-transform.js
+++ b/packages/obojobo-document-xml-parser/src/html-transform.js
@@ -22,16 +22,14 @@ let htmlTransform = (node) => {
 		{
 			case 'h1':
 			case 'h2':
+			case 'h3':
+			case 'h4':
+			case 'h5':
+			case 'h6':
 				if(!node.attributes) node.attributes = {};
 				node.attributes.headingLevel = parseInt(node.name.charAt(1), 10);
 				node.name = 'ObojoboDraft.Chunks.Heading'
 				node.elements = createTextGroup(node.elements)
-				// if(node.attributes.align)
-				// {
-				// 	let align = node.attributes.align;
-				// 	delete node.attributes.align;
-				// 	node.elements[0].elements[0].attributes = { align:align }
-				// }
 				applyAlign(node)
 
 


### PR DESCRIPTION
Fixes #742 

Allows XML parser to understand 'h3' to 'h6'.