### PR TITLE
allow json string in env vars

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,9 +9,9 @@
 		"postdeploy": "cd node_modules/obojobo-express && yarn db:migrateup && yarn sampleDraft:seed"
 	},
 	"env": {
-		"OBO_LTI_SECRET": {
-			"description": "LTI Secret used for default key 'obo-next-production-lit-key'",
-			"generator": "secret"
+		"OBO_LTI_KEYS_JSON": {
+			"description": "JSON string of key:secret values used for LTI'",
+			"value": "{\"obo-production-lti-key\":\"CHANGE_THIS_VALUE_NOW\"}"
 		},
 		"OBO_COOKIE_SECRET": {
 			"description": "Secret string used to encrypt cookie data",

--- a/packages/app/obojobo-express/config.js
+++ b/packages/app/obojobo-express/config.js
@@ -25,14 +25,12 @@ if (process.env.DATABASE_URL) {
 }
 
 const isStringJSON = (name, string) => {
+	if(!name.endsWith('_JSON')) return false
 	try{
 		JSON.parse(string)
 		return true
 	} catch (error){
-		if(name.endsWith('_JSON')){
-			throw new Error(`Expected ENV ${name} to be valid JSON, but it did not parse`)
-		}
-		return false
+		throw new Error(`Expected ENV ${name} to be valid JSON, but it did not parse`)
 	}
 }
 

--- a/packages/app/obojobo-express/config.js
+++ b/packages/app/obojobo-express/config.js
@@ -37,7 +37,6 @@ const isStringJSON = (name, string) => {
 }
 
 const replaceENVsInJson = originalJson => {
-	// const originalJson = JSON.stringify(configObject) // convert back to string
 	// replace any "ENV": "CONFIG_VAR" settings with
 	// values from procesess.env
 	const pattern = /\{\s*"ENV"\s*?:\s*?"(.*?)"\s*\}/gi

--- a/packages/app/obojobo-express/config/lti.json
+++ b/packages/app/obojobo-express/config/lti.json
@@ -5,8 +5,6 @@
 		}
 	},
 	"production":{
-		"keys":{
-			"obo-next-production-lti-key": {"ENV": "OBO_LTI_SECRET"}
-		}
+		"keys": {"ENV": "OBO_LTI_KEYS_JSON"}
 	}
 }


### PR DESCRIPTION
env variables can now be valid json strings.  This was needed to allow multiple keys in the lti config without replacing the config.json file

Given the following env:
`ANY_CONFIG_JSON={"host":"mock-host","port":999}`

combined with the following config/sample.json file:

```javascript
{
    development: { ENV: 'ANY_CONFIG_JSON'}
}
```

will expand to:

```javascript
{
    development: {
        host: "mock-host",
        port: 999
    }
}
```

If the env var's name ends with `_JSON`, the code will log an error if the variable is not able to be parsed with `json.parse`. 

This check is only done when the name ends with `_JSON` to:
1. encourage use of a naming convention
2. avoid problems in assuming values that start with `{` or `[` are supposed to be json

## Important

This does change the default LTI configuration for production.

It also changes the Heroku install steps, which will now provide a static default key/secret pair instead of an automatically generated random key with a static key.

Now you'll need to provide a secret otherwise it will be a little dangerous to use with the default password that is provided.  We need to be sure to document the importance of that variable in our Heroku setup documentation.