### PR TITLE
update dependency caliper-js-public to caliper-js, it moved

### DIFF
--- a/packages/app/obojobo-express/package.json
+++ b/packages/app/obojobo-express/package.json
@@ -43,7 +43,7 @@
 	},
 	"dependencies": {
 		"body-parser": "^1.17.1",
-		"caliper-js-public": "https://github.com/IMSGlobal/caliper-js-public.git#v1.0.0",
+		"caliper-js-public": "https://github.com/IMSGlobal/caliper-js.git#v1.0.0",
 		"compression": "^1.6.2",
 		"connect-pg-simple": "^3.1.2",
 		"css-loader": "^2.0.0",

--- a/packages/app/obojobo-express/package.json
+++ b/packages/app/obojobo-express/package.json
@@ -49,7 +49,7 @@
 		"css-loader": "^2.0.0",
 		"db-migrate": "^0.10.0-beta.20",
 		"db-migrate-pg": "^0.1.11",
-		"debug": "~2.2.0",
+		"debug": "~4.1.1",
 		"debug-logger": "^0.4.1",
 		"ejs": "^2.5.7",
 		"eventemitter": "^0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,9 +2609,9 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-"caliper-js-public@https://github.com/IMSGlobal/caliper-js-public.git#v1.0.0":
+"caliper-js-public@https://github.com/IMSGlobal/caliper-js.git#v1.0.0":
   version "1.0.0"
-  resolved "https://github.com/IMSGlobal/caliper-js-public.git#9654f151deb29b1003e1473d058db67ea5dfef85"
+  resolved "https://github.com/IMSGlobal/caliper-js.git#9654f151deb29b1003e1473d058db67ea5dfef85"
   dependencies:
     caterpillar "^2.0.7"
     caterpillar-browser "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,19 +3635,12 @@ debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@~4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
-  dependencies:
-    ms "0.7.1"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -7778,11 +7771,6 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
-
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
-  integrity sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I diffed the file trees of the two repos, everything looks to be unchanged (they even share the same git commit hash)

Fixes #824 