### PR TITLE
Issue#857 Update wrong question type in visual editor tutorial

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/documents/oboeditor-tutorial.json
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/documents/oboeditor-tutorial.json
@@ -5488,7 +5488,7 @@
 									"type": "ObojoboDraft.Chunks.MCAssessment",
 									"content": {
 										"shuffle": true,
-										"responseType": "Pick One"
+										"responseType": "pick-all"
 									},
 									"children": [
 										{


### PR DESCRIPTION
Visual editor tutorial has a 'pick-all' question example but uses 'pick-one'

Resolve issue #857 