### PR TITLE
General Model Returning and promise cleanup

### DIFF
--- a/packages/app/obojobo-express/__tests__/express_lti_launch.test.js
+++ b/packages/app/obojobo-express/__tests__/express_lti_launch.test.js
@@ -89,7 +89,7 @@ describe('lti launch middleware', () => {
 			expect(db.one).toBeCalledWith(
 				expect.stringContaining('INSERT INTO launches'),
 				expect.objectContaining({
-					data: {
+					ltiBody: {
 						lis_person_contact_email_primary: 'mann@internet.com',
 						lis_person_name_family: 'Mann',
 						lis_person_name_given: 'Hugh',
@@ -135,7 +135,7 @@ describe('lti launch middleware', () => {
 				expect.stringContaining('INSERT INTO launches'),
 				expect.objectContaining({
 					contentId: '12',
-					data: {
+					ltiBody: {
 						lis_person_contact_email_primary: 'mann@internet.com',
 						lis_person_name_family: 'Mann',
 						lis_person_name_given: 'Hugh',
@@ -143,7 +143,7 @@ describe('lti launch middleware', () => {
 						roles: ['saviour', 'explorer', 'doctor']
 					},
 					draftId: '999',
-					lti_key: undefined, //eslint-disable-line no-undefined
+					ltiConsumerKey: undefined, //eslint-disable-line no-undefined
 					userId: 1
 				})
 			)

--- a/packages/app/obojobo-express/__tests__/models/__snapshots__/user.test.js.snap
+++ b/packages/app/obojobo-express/__tests__/models/__snapshots__/user.test.js.snap
@@ -34,7 +34,7 @@ Array [
 				first_name = $[firstName],
 				last_name = $[lastName],
 				roles = $[roles]
-			RETURNING *
+			RETURNING id
 			",
   User {
     "createdAt": "mockNowDate",

--- a/packages/app/obojobo-express/insert_event.js
+++ b/packages/app/obojobo-express/insert_event.js
@@ -10,14 +10,17 @@ module.exports = insertObject => {
 		RETURNING *`,
 			insertObject
 		)
-		.then(createdEvent => {
+		.then(insertEventResult => {
 			if (insertObject.caliperPayload) {
 				// Add in internal event id to extensions object:
 				if (!insertObject.caliperPayload.extensions) {
 					insertObject.caliperPayload.extensions = {}
 				}
-				insertObject.caliperPayload.extensions.internalEventId = createdEvent.id
+				insertObject.caliperPayload.extensions.internalEventId = insertEventResult.id
 
+				// Don't bother including this in the promise chain
+				// It's considered a non-essential insert and we're
+				// not going to wait for it
 				db.none(
 					`
 					INSERT INTO caliper_store
@@ -27,6 +30,6 @@ module.exports = insertObject => {
 				)
 			}
 
-			return createdEvent
+			return insertEventResult
 		})
 }

--- a/packages/app/obojobo-express/lti.js
+++ b/packages/app/obojobo-express/lti.js
@@ -542,8 +542,8 @@ const insertLTIAssessmentScore = (
 				logId
 			}
 		)
-		.then(result => {
-			return result.id
+		.then(insertScoreResult => {
+			return insertScoreResult.id
 		})
 }
 

--- a/packages/app/obojobo-express/models/draft.js
+++ b/packages/app/obojobo-express/models/draft.js
@@ -121,8 +121,8 @@ class Draft {
 						RETURNING *`,
 						{ userId }
 					)
-					.then(result => {
-						newDraft = result
+					.then(newDraftResult => {
+						newDraft = newDraftResult
 						// Add content referencing the draft
 						return transactionDb.one(
 							`
@@ -131,16 +131,13 @@ class Draft {
 							VALUES
 								($[draftId], $[jsonContent], $[xmlContent])
 							RETURNING *`,
-							{ draftId: result.id, jsonContent, xmlContent }
+							{ draftId: newDraft.id, jsonContent, xmlContent }
 						)
 					})
-					.then(result => {
-						newDraft.content = result
+					.then(newContentResult => {
+						newDraft.content = newContentResult
+						return newDraft
 					})
-			})
-			.then(() => {
-				// transaction committed
-				return newDraft
 			})
 	}
 
@@ -166,7 +163,7 @@ class Draft {
 					xmlContent
 				}
 			)
-			.then(result => result.id)
+			.then(insertContentResult => insertContentResult.id)
 	}
 
 	// returns the first duplicate id found or

--- a/packages/app/obojobo-express/models/user.js
+++ b/packages/app/obojobo-express/models/user.js
@@ -66,13 +66,12 @@ class User {
 				first_name = $[firstName],
 				last_name = $[lastName],
 				roles = $[roles]
-			RETURNING *
+			RETURNING id
 			`,
 				this
 			)
-			.then(result => {
-				// populate my id from the result
-				this.id = result.id
+			.then(insertUserResult => {
+				this.id = insertUserResult.id
 				return this
 			})
 	}


### PR DESCRIPTION
* Multiple places where an insert was requesting * be returned from postgres when only id is used
* Some simplification of query and transaction promise structure
* made a pass to change `.then(result => {...})` to `.then(insertDraftResult => {...})` to clarify some confusing code
* simplified a couple places where variable renaming could simplify the source
* added comment to insert_event to explicitly say why we're not waiting for a result
* updated affected tests and snapshots
* `express_lti_launch.js`'s private `storeLtiLaunch` return changed from `{id: 3}` to `3` (and uses updated)

fixes #863