### PR TITLE
Issue/858 unintended `error` attribute in MathEquation

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/documents/oboeditor-tutorial.json
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/documents/oboeditor-tutorial.json
@@ -3165,7 +3165,6 @@
 							"id": "fee457a6-1065-4f8b-9c2b-fab773b082e1",
 							"type": "ObojoboDraft.Chunks.MathEquation",
 							"content": {
-								"error": "",
 								"label": "",
 								"latex": ""
 							},

--- a/packages/obonode/obojobo-chunks-math-equation/math-equation-properties-modal.js
+++ b/packages/obonode/obojobo-chunks-math-equation/math-equation-properties-modal.js
@@ -21,20 +21,34 @@ class MathEquationProperties extends React.Component {
 
 		this.inputRef = React.createRef()
 
-		this.state = this.props.content
-		this.state.error = ''
+		this.state = ({
+			content: this.props.content,
+			error: ''
+		})
 	}
 
 	handleLatexChange(event) {
 		const latex = event.target.value
 
-		return this.setState({ latex })
+		this.setState({
+			...this.state,
+			content: {
+				...this.state.content,
+				latex,
+			}
+		})
 	}
 
 	handleLabelChange(event) {
 		const label = event.target.value
 
-		return this.setState({ label })
+		this.setState({
+			...this.state,
+			content: { 
+				...this.state.content,
+				label
+			}
+		})
 	}
 
 	focusOnFirstElement() {
@@ -42,13 +56,13 @@ class MathEquationProperties extends React.Component {
 	}
 
 	onConfirm() {
-		const katexHtml = getLatexHtml(this.state.latex)
+		const katexHtml = getLatexHtml(this.state.content.latex)
 
 		if (katexHtml.error) {
 			return this.setState({ error: katexHtml.error.message })
 		}
 
-		return this.props.onConfirm(this.state)
+		return this.props.onConfirm(this.state.content)
 	}
 
 	render() {
@@ -66,14 +80,14 @@ class MathEquationProperties extends React.Component {
 							type="text"
 							id="obojobo-draft--chunks--math-equation--latex"
 							ref={this.inputRef}
-							value={this.state.latex || ''}
+							value={this.state.content.latex || ''}
 							onChange={this.handleLatexChange.bind(this)}
 						/>
 						<label>Optional Equation Label:</label>
 						<input
 							type="text"
 							id="obojobo-draft--chunks--math-equation--label"
-							value={this.state.label || ''}
+							value={this.state.content.label || ''}
 							onChange={this.handleLabelChange.bind(this)}
 						/>
 					</div>


### PR DESCRIPTION
In `math-equation-properties-model.js`: let `this.state.content` handles `this.props.content`.
This way `error` in state is separated from `content`.

Resolve issue #858 