### PR TITLE
incomplete assessment dialog render incorrectly

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal/dialog.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal/dialog.scss
@@ -15,6 +15,7 @@
 
 		> .controls {
 			text-align: center;
+			min-width: 24em;
 
 			.obojobo-draft--components--button {
 				margin-left: 0.5em;

--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal/dialog.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal/dialog.scss
@@ -15,7 +15,7 @@
 
 		> .controls {
 			text-align: center;
-			min-width: 24em;
+			min-width: 26em;
 
 			.obojobo-draft--components--button {
 				margin-left: 0.5em;

--- a/packages/app/obojobo-document-engine/src/scripts/common/components/modal/dialog.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/modal/dialog.scss
@@ -15,7 +15,6 @@
 
 		> .controls {
 			text-align: center;
-			min-width: 26em;
 
 			.obojobo-draft--components--button {
 				margin-left: 0.5em;

--- a/packages/obonode/obojobo-sections-assessment/components/__snapshots__/attempt-incomplete-dialog.test.js.snap
+++ b/packages/obonode/obojobo-sections-assessment/components/__snapshots__/attempt-incomplete-dialog.test.js.snap
@@ -3,7 +3,11 @@
 exports[`AttemptIncompleteDialog AttemptIncompleteDialog component 1`] = `
 <div
   className="obojobo-draft--components--modal--dialog"
-  style={null}
+  style={
+    Object {
+      "width": "35rem",
+    }
+  }
 >
   <div
     aria-labelledby="obojobo-draft--components--modal--modal--content"

--- a/packages/obonode/obojobo-sections-assessment/components/attempt-incomplete-dialog.js
+++ b/packages/obonode/obojobo-sections-assessment/components/attempt-incomplete-dialog.js
@@ -30,6 +30,7 @@ const AttemptIncompleteDialog = props => (
 				default: true
 			}
 		]}
+		width="35rem"
 	>
 		<b>Wait! You left some questions blank.</b>
 		<br />


### PR DESCRIPTION
Add a min-width attribute for incomplete assessment dialog so that buttons do not stack on one another.

Resolve issue #491 