### PR TITLE
Choose property in QuestionBank expects `int` value but receives a `string`

### DIFF
--- a/packages/obonode/obojobo-chunks-question-bank/server/question-bank.js
+++ b/packages/obonode/obojobo-chunks-question-bank/server/question-bank.js
@@ -58,9 +58,10 @@ class QuestionBank extends DraftNode {
 		// choose should either be an integer > 0 or "all"
 		// ("all" meaning choose all available questions)
 		// Any other value results in the default of "all".
+		const chooseInt = this.node.content.choose ? parseInt(this.node.content.choose) : null
 		const isValidNumericChoose =
-			Number.isFinite(this.node.content.choose) && this.node.content.choose > 0
-		const choose = isValidNumericChoose ? Math.floor(this.node.content.choose) : Infinity
+			Number.isFinite(chooseInt) && chooseInt > 0
+		const choose = isValidNumericChoose ? Math.floor(chooseInt) : Infinity
 
 		const select = this.node.content.select || SELECT_SEQUENTIAL
 


### PR DESCRIPTION
Choose property in QuestionBank expects int value but receives string.

Solution: parse string to int.

Resolve issue #871 