### PR TITLE
IFrame hover labels stay stuck on when clicked

### DIFF
--- a/packages/obonode/obojobo-chunks-iframe/controls.scss
+++ b/packages/obonode/obojobo-chunks-iframe/controls.scss
@@ -128,6 +128,10 @@
 		}
 	}
 
+	.control-button-container:hover > .tool-tip {
+		z-index: $z-index-above-all + 1;
+	}
+
 	> .size-controls {
 		position: absolute;
 		right: 0;

--- a/packages/obonode/obojobo-chunks-iframe/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-iframe/viewer-component.scss
@@ -106,6 +106,7 @@
 
 			> .obojobo-draft--components--button {
 				display: block;
+				pointer-events: none;
 			}
 		}
 


### PR DESCRIPTION
Update button point state in IFrame so that it doesn't stay stuck when clicking

Resolve issue #749 