### PR TITLE
adds ability to launch an https server when not using a proxy

### DIFF
--- a/packages/app/obojobo-express/__tests__/http_server.test.js
+++ b/packages/app/obojobo-express/__tests__/http_server.test.js
@@ -1,15 +1,18 @@
 import mockConsole from 'jest-mock-console';
 
-let logger
-let mockExit
-mockVirtual('http')
-let httpServer
-let server
-let app
-let http
-let restoreConsole
-
 describe('http_server', () => {
+	let logger
+	let mockExit
+	mockVirtual('http')
+	mockVirtual('https')
+	let httpServer
+	let insecureServer
+	let secureServer
+	let app
+	let http
+	let https
+	let restoreConsole
+
 	beforeEach(() => {
 		jest.resetModules()
 		restoreConsole = mockConsole('log')
@@ -18,14 +21,22 @@ describe('http_server', () => {
 		global.oboJestMockConfig()
 		mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {})
 		http = require('http')
+		https = require('https')
 		http.createServer = jest.fn()
+		https.createServer = jest.fn()
 		httpServer = require('../http_server')
-		server = {
+		insecureServer = {
 			on: jest.fn(),
 			listen: jest.fn(),
 			address: jest.fn()
 		}
-		http.createServer.mockReturnValue(server)
+		secureServer = {
+			on: jest.fn(),
+			listen: jest.fn(),
+			address: jest.fn()
+		}
+		http.createServer.mockReturnValue(insecureServer)
+		https.createServer.mockReturnValue(secureServer)
 		app = {
 			set: jest.fn()
 		}
@@ -40,13 +51,24 @@ describe('http_server', () => {
 	test('startServer calls expected default methods and values', () => {
 		const returnValue = httpServer(app, logger)
 
+		expect(returnValue).toBe(insecureServer)
 		expect(app.set).toHaveBeenCalledWith('port', 3000)
-		expect(server.listen).toHaveBeenCalledWith(3000)
-		expect(server.on).toHaveBeenCalledWith('error', expect.any(Function))
-		expect(server.on).toHaveBeenCalledWith('listening', expect.any(Function))
-		expect(returnValue).toBe(server)
+		expect(insecureServer.listen).toHaveBeenCalledWith(3000)
+		expect(insecureServer.on).toHaveBeenCalledWith('error', expect.any(Function))
+		expect(insecureServer.on).toHaveBeenCalledWith('listening', expect.any(Function))
+		expect(http.createServer).toHaveBeenCalledWith({}, app)
+		expect(https.createServer).not.toHaveBeenCalled()
 		// eslint-disable-next-line no-console
 		expect(console.log).toHaveBeenCalledWith('Note: Logging and config options can be set using environment variables.')
+	})
+
+	test('startServer starts an https server when it receives a cert', () => {
+		const serverOptions = {cert: 'fake-cert', key: 'fake-key'}
+		const returnValue = httpServer(app, logger, 3000, serverOptions)
+
+		expect(returnValue).toBe(secureServer)
+		expect(https.createServer).toHaveBeenCalledWith(serverOptions, app)
+		expect(http.createServer).not.toHaveBeenCalled()
 	})
 
 	test('startServer converts negative ports to false', () => {
@@ -55,16 +77,16 @@ describe('http_server', () => {
 	})
 
 	test('startServer accepts custom ports', () => {
-		http.createServer.mockReturnValue(server)
+		http.createServer.mockReturnValue(insecureServer)
 		httpServer(app, logger, 2424)
 
 		expect(app.set).toHaveBeenCalledWith('port', 2424)
-		expect(server.listen).toHaveBeenCalledWith(2424)
+		expect(insecureServer.listen).toHaveBeenCalledWith(2424)
 	})
 
 	test('startServer handles EACCES error', () => {
 		httpServer(app, logger)
-		const errorCallback = server.on.mock.calls[0]
+		const errorCallback = insecureServer.on.mock.calls[0]
 		expect(errorCallback[0]).toBe('error')
 
 		// execute the callback
@@ -79,7 +101,7 @@ describe('http_server', () => {
 
 	test('startServer EACCES error logs pipe string', () => {
 		httpServer(app, logger, 'mock-pipe-string')
-		const errorCallback = server.on.mock.calls[0]
+		const errorCallback = insecureServer.on.mock.calls[0]
 		expect(errorCallback[0]).toBe('error')
 
 		// execute the callback
@@ -94,7 +116,7 @@ describe('http_server', () => {
 
 	test('startServer hanldes EADDRINUSE error', () => {
 		httpServer(app, logger)
-		const errorCallback = server.on.mock.calls[0]
+		const errorCallback = insecureServer.on.mock.calls[0]
 		expect(errorCallback[0]).toBe('error')
 
 		// execute the callback
@@ -109,7 +131,7 @@ describe('http_server', () => {
 
 	test('startServer throws on other errors', () => {
 		httpServer(app, logger)
-		const errorCallback = server.on.mock.calls[0]
+		const errorCallback = insecureServer.on.mock.calls[0]
 		expect(errorCallback[0]).toBe('error')
 
 		// execute the callback
@@ -125,7 +147,7 @@ describe('http_server', () => {
 
 	test('startServer throws on non syscall:listen errors', () => {
 		httpServer(app, logger)
-		const errorCallback = server.on.mock.calls[0]
+		const errorCallback = insecureServer.on.mock.calls[0]
 		expect(errorCallback[0]).toBe('error')
 
 		const error = new Error()
@@ -140,18 +162,18 @@ describe('http_server', () => {
 
 	test('startServer on listening logs the server address', () => {
 		httpServer(app, logger)
-		const listeningCallBack = server.on.mock.calls[1]
+		const listeningCallBack = insecureServer.on.mock.calls[1]
 		expect(listeningCallBack[0]).toBe('listening')
-		server.address.mockReturnValue('mock-server-address')
+		insecureServer.address.mockReturnValue('mock-server-address')
 		listeningCallBack[1]()
 		expect(logger.info).toHaveBeenCalledWith('Listening on pipe mock-server-address')
 	})
 
 	test('startServer on listening logs the server port', () => {
 		httpServer(app, logger)
-		const listeningCallBack = server.on.mock.calls[1]
+		const listeningCallBack = insecureServer.on.mock.calls[1]
 		expect(listeningCallBack[0]).toBe('listening')
-		server.address.mockReturnValue({ port: 8888 })
+		insecureServer.address.mockReturnValue({ port: 8888 })
 		listeningCallBack[1]()
 		expect(logger.info).toHaveBeenCalledWith('Listening on port 8888')
 	})

--- a/packages/app/obojobo-express/http_server.js
+++ b/packages/app/obojobo-express/http_server.js
@@ -1,6 +1,4 @@
 /* eslint-disable */
-var http = require('http')
-
 /**
  * This code is derived from bin/www used in Express 4
  * We extracted the code from that file to make it 1: testable
@@ -25,12 +23,14 @@ const normalizePort = val => {
 	return false
 }
 
-const startServer = (app, logger, port = '3000') => {
+const startServer = (app, logger, port = '3000', options = {}) => {
 	console.log('Note: Logging and config options can be set using environment variables.')
+	console.log(`DEBUG is set to: ${process.env.DEBUG}`)
 
 	port = normalizePort(port)
 	app.set('port', port)
-	const server = http.createServer(app)
+	const http_or_https = options.cert ? require('https') : require('http')
+	const server = http_or_https.createServer(options, app)
 
 	server.on('error', error => {
 		if (error.syscall !== 'listen') {


### PR DESCRIPTION
Adds a new optional param to startServer needed to pass the ssl certs to node.  The new option gets passed directly to `http(s).createServer` as is required to pass key and cert info.  

If the option object contains the `cert` key, obojobo will use node's `https` instead of `http` in order to handle those requests.

If you want to run both http and https servers, you'll need to run startServer twice, or start your own (useful for a super simple http -> https redirect)

```javascript
const startServer = require('obojobo-express/http_server')

// before this change
startServer(app, logger, 3000) 

// after this change
startServer(app, logger, 443, {cert: '...', key: '...'}) 
```
Fixes #894