### PR TITLE
allows process.env.ASSET_ENV to control if minified assets are loaded

### DIFF
--- a/packages/app/obojobo-express/__tests__/asset_resolver.test.js
+++ b/packages/app/obojobo-express/__tests__/asset_resolver.test.js
@@ -1,11 +1,18 @@
-const env_node = process.env.NODE_ENV
-delete process.env.NODE_ENV
-const AssetResolver = require('../asset_resolver')
-
 describe('Asset Resolver', () => {
+	const originalNODE_ENV = process.env.NODE_ENV
+	let AssetResolver
+
 	afterAll(() => {
-		process.env.NODE_ENV = env_node
+		process.env.NODE_ENV = originalNODE_ENV
 	})
+
+	beforeEach(() => {
+		jest.resetModules()
+		delete process.env.NODE_ENV
+		delete process.env.ASSET_ENV
+		AssetResolver = require('../asset_resolver')
+	})
+
 	test('assetForEnv builds pattern for dev server', () => {
 		const path = AssetResolver.assetForEnv('mock/path/item$[.full|.min].js')
 
@@ -34,5 +41,18 @@ describe('Asset Resolver', () => {
 		const path = AssetResolver.assetForEnv('mock/path/item$[.full|.min].js', 'prod')
 
 		expect(path).toEqual('mock/path/item.min.js')
+	})
+
+	test('assertForEnv responds to process.env.ASSET_ENV', () => {
+		const beforeSet = AssetResolver.assetForEnv('mock/path/item$[.full|.min].js')
+		expect(beforeSet).toEqual('mock/path/item.full.js')
+
+		process.env.ASSET_ENV = 'prod'
+
+		const afterSet = AssetResolver.assetForEnv('mock/path/item$[.full|.min].js')
+		expect(afterSet).toEqual('mock/path/item.min.js')
+
+		const afterSetWithForce = AssetResolver.assetForEnv('mock/path/item$[.full|.min].js', 'dev')
+		expect(afterSetWithForce).toEqual('mock/path/item.full.js')
 	})
 })

--- a/packages/app/obojobo-express/asset_resolver.js
+++ b/packages/app/obojobo-express/asset_resolver.js
@@ -41,7 +41,7 @@ const assetForEnv = (assetPath, forceEnvTo = null) => {
 
 const getEnv = forceEnvTo => {
 	const env = forceEnvTo || process.env.ASSET_ENV
-	return (env ? env : NODE_ENV).toLowerCase()
+	return (env || NODE_ENV).toLowerCase()
 }
 
 module.exports = {

--- a/packages/app/obojobo-express/asset_resolver.js
+++ b/packages/app/obojobo-express/asset_resolver.js
@@ -40,7 +40,7 @@ const assetForEnv = (assetPath, forceEnvTo = null) => {
 }
 
 const getEnv = forceEnvTo => {
-	const env = (forceEnvTo ? forceEnvTo : process.env.ASSET_ENV)
+	const env = forceEnvTo || process.env.ASSET_ENV
 	return (env ? env : NODE_ENV).toLowerCase()
 }
 

--- a/packages/app/obojobo-express/asset_resolver.js
+++ b/packages/app/obojobo-express/asset_resolver.js
@@ -40,7 +40,8 @@ const assetForEnv = (assetPath, forceEnvTo = null) => {
 }
 
 const getEnv = forceEnvTo => {
-	return (forceEnvTo ? forceEnvTo : NODE_ENV).toLowerCase()
+	const env = (forceEnvTo ? forceEnvTo : process.env.ASSET_ENV)
+	return (env ? env : NODE_ENV).toLowerCase()
 }
 
 module.exports = {


### PR DESCRIPTION
`process.env.ASSET_ENV` can now be used to control if minified assets are loaded or not.

Before, `NODE_ENV` determined if minified or non-minified assets were loaded. 

The problem is NODE_ENV is also used to determine which config file Obojobo loads.  With those hard linked, one cannot use minified files in development or unmagnified files in production.

Now, if `NODE_ENV=development ASSET_ENV=production` is set, `obojobo-express/config` will use the development configs and `assetForEnv` will create minified asset urls.

fixes #896 