### PR TITLE
Fix name of MCChoice

### DIFF
--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/server/mcchoice.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/server/mcchoice.js
@@ -2,7 +2,7 @@ const DraftNode = require('obojobo-express/models/draft_node')
 
 class MCChoice extends DraftNode {
 	static get nodeName() {
-		return 'ObojoboDraft.Chunks.MCChoice'
+		return 'ObojoboDraft.Chunks.MCAssessment.MCChoice'
 	}
 
 	constructor(draftTree, node, initFn) {

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/server/mcchoice.test.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/server/mcchoice.test.js
@@ -13,7 +13,7 @@ describe('MCChoice', () => {
 	})
 
 	test('nodeName is expected value', () => {
-		expect(MCChoice.nodeName).toBe('ObojoboDraft.Chunks.MCChoice')
+		expect(MCChoice.nodeName).toBe('ObojoboDraft.Chunks.MCAssessment.MCChoice')
 	})
 
 	test('registers expected events', () => {


### PR DESCRIPTION
Updates name of MCChoice to the correct name of `ObojoboDraft.Chunks.MCAssessment.MCChoice`

Fixes #914 