### PR TITLE
adds OBO_COOKIE_SECURE env flag

### DIFF
--- a/packages/app/obojobo-express/config/general.json
+++ b/packages/app/obojobo-express/config/general.json
@@ -22,6 +22,7 @@
 		"cookieSecret": "REPLACE_ME_WITH_YOUR_SECRET"
 	},
 	"production": {
+		"secureCookie": {"ENV": "OBO_COOKIE_SECURE"},
 		"cookieSecret": {
 			"ENV": "OBO_COOKIE_SECRET"
 		}


### PR DESCRIPTION
*IF* one needs to run the server on http (for testing), this option will allow the cookies to work without ssl