### PR TITLE
adds error handling to setProp

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/common/util/set-prop.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/util/set-prop.test.js
@@ -1,4 +1,4 @@
-import s from '../../../src/scripts/common/util/set-prop.js'
+import setProp from '../../../src/scripts/common/util/set-prop.js'
 
 describe('setProp', () => {
 	let target
@@ -8,56 +8,78 @@ describe('setProp', () => {
 	})
 
 	test('sets default values when no attrs passed', () => {
-		s(target, {}, 'propName', 'default-value')
+		setProp(target, {}, 'propName', 'default-value')
 		expect(target).toEqual({
 			propName: 'default-value'
 		})
 	})
 
 	test('sets default values when attr does not exist', () => {
-		s(target, { myProp: 'mocked-prop' }, 'propName', 'default-value')
+		setProp(target, { myProp: 'new-value' }, 'propName', 'default-value')
 		expect(target).toEqual({
 			propName: 'default-value'
 		})
 	})
 
 	test('sets values if in attrs', () => {
-		s(target, { myProp: 'test-value' }, 'myProp', 'default-value')
+		setProp(target, { myProp: 'new-value' }, 'myProp', 'default-value')
 		expect(target).toEqual({
-			myProp: 'test-value'
+			myProp: 'new-value'
 		})
 	})
 
 	test('calls set function if available', () => {
-		const setFn = jest.fn()
-		setFn.mockImplementation(x => x)
+		const transformFn = jest.fn()
+		transformFn.mockImplementation(x => x)
 
-		s(target, { myProp: 'test-value' }, 'myProp', 'default-value', setFn)
+		setProp(target, { myProp: 'new-value' }, 'myProp', 'default-value', transformFn)
 		expect(target).toEqual({
-			myProp: 'test-value'
+			myProp: 'new-value'
 		})
-		expect(setFn).toHaveBeenCalledTimes(1)
+		expect(transformFn).toHaveBeenCalledTimes(1)
+		expect(transformFn).toHaveBeenCalledWith('new-value')
+	})
+
+	test('set function value is used to alter state', () => {
+		const transformFn = jest.fn()
+		transformFn.mockReturnValue('result-from-transformFn')
+
+		setProp(target, { myProp: 'new-value' }, 'myProp', 'default-value', transformFn)
+		expect(target).toEqual({
+			myProp: 'result-from-transformFn'
+		})
+		expect(transformFn).toHaveBeenCalledTimes(1)
 	})
 
 	test('sets to default value if set function returns null', () => {
-		s(target, { myProp: 'test-value' }, 'myProp', 'default-value', () => null)
+		setProp(target, { myProp: 'new-value' }, 'myProp', 'default-value', () => null)
 		expect(target).toEqual({
 			myProp: 'default-value'
 		})
 	})
 
-	test('allowedValues restricts what is accepted', () => {
-		const setFn = jest.fn()
-		setFn.mockImplementation(x => x)
-
-		s(target, { myProp: 'test-value' }, 'myProp', 'default-value', setFn, ['other-value'])
+	test('allowedValues uses default value when requested value is not allowed', () => {
+		// desired value NOT in allowed values
+		setProp(target, { myProp: 'new-value' }, 'myProp', 'default-value', undefined, ['other-value'])
 		expect(target).toEqual({
 			myProp: 'default-value'
 		})
 
-		s(target, { myProp: 'test-value' }, 'myProp', 'default-value', setFn, ['test-value'])
+		// desired value IS in allowed values
+		setProp(target, { myProp: 'new-value' }, 'myProp', 'default-value', undefined, ['new-value'])
 		expect(target).toEqual({
-			myProp: 'test-value'
+			myProp: 'new-value'
 		})
+	})
+
+	test('when transformFn throws an error, the default value is used', () => {
+		const transformFn = jest.fn()
+		transformFn.mockImplementation(x => {throw Error('mock-error')})
+
+		setProp(target, { myProp: 'new-value' }, 'myProp', 'default-value', transformFn)
+		expect(target).toEqual({
+			myProp: 'default-value'
+		})
+
 	})
 })

--- a/packages/app/obojobo-document-engine/src/scripts/common/util/set-prop.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/util/set-prop.js
@@ -41,13 +41,20 @@ export default (
 
 	// If propName exists on sourceObject...
 	if (typeof sourceObject[propName] !== 'undefined') {
-		// ...filter sourceObject[propName] through transformValueFn
-		const value = transformValueFn(sourceObject[propName])
+		try{
+			// ...filter sourceObject[propName] through transformValueFn
+			const value = transformValueFn(sourceObject[propName])
 
-		// If value ∈ allowedValues (or allowedValues was not specified)...
-		if (allowedValues === null || allowedValues.indexOf(value) > -1) {
-			// ...set the value on targetObject
-			targetObject[propName] = value
+			// If value ∈ allowedValues (or allowedValues was not specified)...
+			if (allowedValues === null || allowedValues.indexOf(value) > -1) {
+				// ...set the value on targetObject
+				targetObject[propName] = value
+			}
+		} catch (error){
+			// absorb the error, the value should remain null
+			// which will end up using the default value
+			console.error(`SetProp transformValueFn for "${propName}" errored.`)
+			console.error(error)
 		}
 	}
 


### PR DESCRIPTION
Updates setProp to handle errors in the transform function.  A missing property was causing a the transform function for Iframe to break the viewer.

This will prevent that sort of issue in future updates.

I added a little polish to the setProp tests while I'm here