### PR TITLE
moves session clearing to user model

### DIFF
--- a/packages/app/obojobo-express/__tests__/express_lti_launch.test.js
+++ b/packages/app/obojobo-express/__tests__/express_lti_launch.test.js
@@ -61,6 +61,7 @@ describe('lti launch middleware', () => {
 			cb()
 		}) // session.save is successful
 		User.saveOrCreateCallback.mockReset()
+		User.clearSessionsForUserById.mockReset()
 		logger.error.mockReset()
 		DraftDocument.fetchById = jest.fn().mockResolvedValueOnce(
 			new DraftDocument({
@@ -242,12 +243,11 @@ describe('lti launch middleware', () => {
 	})
 
 	test('assignment deletes previous sessions for current user', () => {
-		expect.hasAssertions()
+		expect.assertions(2)
 		const [req, res, mockNext] = mockExpressArgs(true)
+		expect(User.clearSessionsForUserById).not.toHaveBeenCalled()
 		return ltiLaunch.assignment(req, res, mockNext).then(() => {
-			expect(db.none).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM sessions'), {
-				currentUserId: 1
-			})
+			expect(User.clearSessionsForUserById).toHaveBeenCalledWith(1)
 		})
 	})
 

--- a/packages/app/obojobo-express/__tests__/models/user.test.js
+++ b/packages/app/obojobo-express/__tests__/models/user.test.js
@@ -172,6 +172,16 @@ describe('user model', () => {
 		})
 	})
 
+	test('clearSessionsForUserById deletes sessions from the db', () => {
+		db.none.mockResolvedValueOnce('')
+
+		return User.clearSessionsForUserById(66).then(() => {
+			expect(db.none).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM sessions'), {
+				id: 66
+			})
+		})
+	})
+
 	test('throws error when not given enough arguments', () => {
 		expect(() => {
 			new User()

--- a/packages/app/obojobo-express/express_lti_launch.js
+++ b/packages/app/obojobo-express/express_lti_launch.js
@@ -100,12 +100,7 @@ const userFromLaunch = (req, ltiBody) => {
 			// prevents clearing the current session
 			// eslint-disable-next-line eqeqeq
 			if (!req.currentUser || req.currentUser.id != newUser.id) {
-				return db.none(
-					`
-					DELETE FROM sessions
-					WHERE sess ->> 'currentUserId' = $[currentUserId]`,
-					{ currentUserId: newUser.id }
-				)
+				return User.clearSessionsForUserById(newUser.id)
 			}
 		})
 		.then(() => {
@@ -151,7 +146,6 @@ exports.assignment = (req, res, next) => {
 				launchId,
 				body: req.lti.body
 			}
-
 			return next()
 		})
 		.catch(error => {

--- a/packages/app/obojobo-express/models/__mocks__/user.js
+++ b/packages/app/obojobo-express/models/__mocks__/user.js
@@ -53,4 +53,6 @@ class MockUser {
 	}
 }
 
+MockUser.clearSessionsForUserById = jest.fn()
+
 module.exports = MockUser

--- a/packages/app/obojobo-express/models/user.js
+++ b/packages/app/obojobo-express/models/user.js
@@ -54,6 +54,10 @@ class User {
 			})
 	}
 
+	static clearSessionsForUserById(id) {
+		return db.none(`DELETE FROM sessions WHERE sess ->> 'currentUserId' = $[id]`, { id })
+	}
+
 	saveOrCreate() {
 		return db
 			.one(


### PR DESCRIPTION
Suggest moving the session clearing db call into the model (part of general desire to move as many db queries into model code as possible)