### PR TITLE
Changes header forwarding from x-host to standard X-Forwarded-Host

### DIFF
--- a/packages/app/obojobo-express/__tests__/express_load_balancer_helper.test.js
+++ b/packages/app/obojobo-express/__tests__/express_load_balancer_helper.test.js
@@ -51,8 +51,8 @@ describe('load balancer helper middleware', () => {
 		expect(req.connection.encrypted).toBe(true)
 	})
 
-	test('host is updated by x-host header', () => {
-		const { req } = mockArgs({ 'x-host': 'crazy_other_host' })
+	test('host is updated by X-Forwarded-Host header', () => {
+		const { req } = mockArgs({ 'x-forwarded-host': 'crazy_other_host' })
 		expect(req.headers.host).toBe('crazy_other_host')
 	})
 })

--- a/packages/app/obojobo-express/express_load_balancer_helper.js
+++ b/packages/app/obojobo-express/express_load_balancer_helper.js
@@ -14,8 +14,8 @@ const resolveSecure = req => {
 
 const resovleHost = req => {
 	// if we're behind a load balancer or something
-	if (req.headers['x-host']) {
-		req.headers.host = req.headers['x-host']
+	if (req.headers['x-forwarded-host']) {
+		req.headers.host = req.headers['x-forwarded-host']
 	}
 }
 


### PR DESCRIPTION
solves #90 by adopting the standard x-forwarded-host.

# This may require admins to update Nginx/Apache config to make sure that the host forwarding works.

I have already added this to ours for future deploys.