### PR TITLE
adds canvas_masquerading_user_id to lti config

### DIFF
--- a/packages/app/obojobo-express/views/lti_config_xml.ejs
+++ b/packages/app/obojobo-express/views/lti_config_xml.ejs
@@ -31,6 +31,7 @@
 			<lticm:property name="canvas_assignment_due_at_iso8601">$Canvas.assignment.dueAt.iso8601</lticm:property>
 			<lticm:property name="canvas_term_name">$Canvas.term.name</lticm:property>
 			<lticm:property name="canvas_course_previous_course_ids">$Canvas.course.previousCourseIds</lticm:property>
+			<lticm:property name="canvas_masquerading_user_id">$Canvas.masqueradingUser.id</lticm:property>
 		</lticm:options>
 
 		<%# Course Nav %>


### PR DESCRIPTION
This will ask canvas for the id of the user that is masquerading as someone.  We may be able to use this in conjunction with checking data to detect the test student