### PR TITLE
viewer:close does not fire

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/Viewer/components/viewer-app.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/components/viewer-app.test.js
@@ -814,6 +814,8 @@ describe('ViewerApp', () => {
 		mocksForMount()
 		const component = mount(<ViewerApp />)
 
+		global.navigator.sendBeacon = jest.fn()
+
 		setTimeout(() => {
 			component.update()
 			const spy = jest.spyOn(Dispatcher, 'trigger')
@@ -853,7 +855,9 @@ describe('ViewerApp', () => {
 		})
 	})
 
-	test('onWindowClose calls APIUtil', done => {
+	test('sendCloseEvent calls navigator.sendBeacon', done => {
+		global.navigator.sendBeacon = jest.fn()
+
 		expect.assertions(1)
 		mocksForMount()
 		const component = mount(<ViewerApp />)
@@ -861,9 +865,9 @@ describe('ViewerApp', () => {
 		setTimeout(() => {
 			component.update()
 
-			component.instance().onWindowClose()
+			component.instance().sendCloseEvent()
 
-			expect(APIUtil.postEvent).toHaveBeenCalled()
+			expect(navigator.sendBeacon).toHaveBeenCalled()
 
 			component.unmount()
 			done()

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -148,7 +148,6 @@ export default class ViewerApp extends React.Component {
 				AssessmentStore.init(attemptHistory)
 
 				window.onbeforeunload = this.onBeforeWindowClose
-				window.onunload = this.onWindowClose
 				window.onresize = this.onResize.bind(this)
 
 				this.boundOnDelayResize = this.onDelayResize.bind(this)
@@ -467,6 +466,8 @@ export default class ViewerApp extends React.Component {
 		if (closePrevented) {
 			return true // Returning true will cause browser to ask user to confirm leaving page
 		}
+
+		this.onWindowClose()
 
 		/* eslint-disable-next-line */
 		return undefined // Returning undefined will allow browser to close normally

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -91,7 +91,7 @@ export default class ViewerApp extends React.Component {
 		this.onIdle = this.onIdle.bind(this)
 		this.onReturnFromIdle = this.onReturnFromIdle.bind(this)
 		this.onBeforeWindowClose = this.onBeforeWindowClose.bind(this)
-		this.onWindowClose = this.onWindowClose.bind(this)
+		this.sendCloseEvent = this.sendCloseEvent.bind(this)
 		this.onVisibilityChange = this.onVisibilityChange.bind(this)
 
 		this.state = state
@@ -467,19 +467,26 @@ export default class ViewerApp extends React.Component {
 			return true // Returning true will cause browser to ask user to confirm leaving page
 		}
 
-		this.onWindowClose()
+		this.sendCloseEvent()
 
 		/* eslint-disable-next-line */
 		return undefined // Returning undefined will allow browser to close normally
 	}
 
-	onWindowClose() {
-		APIUtil.postEvent({
+	sendCloseEvent() {
+		const body = {
 			draftId: this.state.model.get('draftId'),
-			action: 'viewer:close',
-			eventVersion: '1.0.0',
-			visitId: this.state.navState.visitId
-		})
+			visitId: this.state.navState.visitId,
+			event: {
+				action: 'viewer:close',
+				draft_id: this.state.model.get('draftId'),
+				actor_time: new Date().toISOString(),
+				event_version: '1.0.0',
+				visitId: this.state.navState.visitId
+			}
+		}
+
+		navigator.sendBeacon('/api/events', JSON.stringify(body))
 	}
 
 	clearPreviewScores() {

--- a/packages/app/obojobo-express/express_current_visit.js
+++ b/packages/app/obojobo-express/express_current_visit.js
@@ -8,6 +8,12 @@ const getCurrentVisitFromRequest = req => {
 		return Promise.resolve()
 	}
 
+	// In certain cases, events are sent via `navigator.sendBeacon`.
+	// Request's headers cannot be set. Therefore, `req.body` is still in JSON fotmat
+	try {
+		req.body = JSON.parse(req.body)
+	} catch (e) {} // eslint-disable-line no-empty
+
 	// Figure out where the visitId is in this request
 	let visitId = null
 	if (req.body && req.body.event && req.body.event.visitId) {


### PR DESCRIPTION
Reason: `unload` event does not wait for async function to complete.

Solution: Use `navigator.sendBeacon` instead of `fetch` to send async POST request (https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon)

Resolve: #946 