### PR TITLE
Hides scrollbars on questions during the flip animation

### DIFF
--- a/packages/obonode/obojobo-chunks-question/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-question/viewer-component.scss
@@ -132,6 +132,8 @@
 	}
 
 	&.is-flipping {
+		overflow: hidden;
+
 		> .flipper {
 			transition: 0.4s;
 			-ms-transition: none;


### PR DESCRIPTION
Fixes #804 

Added `overflow:hidden` to the `is_flipping` class.