### PR TITLE
Adds isolation to new nodes in visual editor

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
@@ -7,19 +7,23 @@ import DropMenu from './components/insert-menu'
 import './editor-component.scss'
 
 class Node extends React.Component {
-	insertBlockAtStart(item) {
-		const editor = this.props.editor
+	cloneNodeJSON(sourceJSON) {
+		return JSON.parse(JSON.stringify(sourceJSON))
+	}
 
-		return editor.insertNodeByKey(this.props.node.key, 0, Block.create(item.insertJSON))
+	insertBlockAtStart(item) {
+		const json = this.cloneNodeJSON(item.insertJSON)
+
+		return this.props.editor.insertNodeByKey(this.props.node.key, 0, Block.create(json))
 	}
 
 	insertBlockAtEnd(item) {
-		const editor = this.props.editor
+		const json = this.cloneNodeJSON(item.insertJSON)
 
-		return editor.insertNodeByKey(
+		return this.props.editor.insertNodeByKey(
 			this.props.node.key,
 			this.props.node.nodes.size,
-			Block.create(item.insertJSON)
+			Block.create(json)
 		)
 	}
 


### PR DESCRIPTION
Creating a new node in the Visual Editor now clones the
original node's json instead of returning a reference to it.

fixes #961 

NOTE: #963 is a more extensive version of this and has some notes to consider