### PR TITLE
Adds isolation to new nodes in visual editor Level 2

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/common/registry.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/registry.test.js
@@ -7,29 +7,65 @@ describe('Registry', () => {
 
 	test('registerModel registers a model', () => {
 		expect.assertions(2)
-		Registry.registerModel('type')
+		Registry.registerModel('mockType')
 
 		Registry.getItems(items => {
 			expect(items.size).toBe(1)
-			expect(items.get('type')).toEqual({})
+			expect(items.get('mockType')).toMatchInlineSnapshot(`
+									Object {
+									  "cloneBlankNode": [Function],
+									  "default": false,
+									  "init": [Function],
+									  "templateObject": "",
+									  "type": null,
+									  "variables": Object {},
+									}
+						`)
 		})
 	})
 
 	test('registerModel registers a model that already exists', () => {
 		expect.assertions(2)
-		Registry.registerModel('type')
-		Registry.registerModel('type')
+		Registry.registerModel('mockType')
+		Registry.registerModel('mockType')
 
 		Registry.getItems(items => {
 			expect(items.size).toBe(1)
-			expect(items.get('type')).toEqual({})
+			expect(items.get('mockType')).toMatchInlineSnapshot(`
+						Object {
+						  "cloneBlankNode": [Function],
+						  "default": false,
+						  "init": [Function],
+						  "templateObject": "",
+						  "type": null,
+						  "variables": Object {},
+						}
+				`)
+		})
+	})
+
+	test('registerModel cloneBlankNode really does clone the template', () => {
+		expect.hasAssertions()
+
+		const templateObject = { mockProperty: {} }
+		Registry.registerModel('mockType', { templateObject })
+
+		Registry.getItems(items => {
+			const item = items.get('mockType')
+			const clone = item.cloneBlankNode()
+
+			// expect the objects to look the same
+			expect(clone.mockProperty).toEqual(templateObject.mockProperty)
+
+			// but not reference the same object
+			expect(clone.mockProperty).not.toBe(templateObject.mockProperty)
 		})
 	})
 
 	test('registers calls init', () => {
 		expect.assertions(1)
 		const init = jest.fn()
-		Registry.registerModel('type', { init: init })
+		Registry.registerModel('mockType', { init: init })
 
 		Registry.getItems(() => {
 			expect(init).toHaveBeenCalled()

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/node/editor-component.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/node/editor-component.test.js
@@ -7,7 +7,8 @@ jest.mock('Common', () => ({
 						isInsertable: true,
 						icon: null,
 						name: 'mockItem',
-						insertJSON: 'mockNode'
+						templateObject: 'mockNode',
+						cloneBlankNode: () => ({ type: 'mockNode' })
 					}
 				]
 			})

--- a/packages/app/obojobo-document-engine/src/scripts/common/registry.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/registry.js
@@ -4,6 +4,8 @@ let registeredToolbarItems
 let toolbarItems
 let variableHandlers
 
+const noop = () => {}
+
 class _Registry {
 	init() {
 		items = new Map()
@@ -46,34 +48,43 @@ class _Registry {
 
 	registerModel(className, opts = {}) {
 		const item = items.get(className)
+
+		// combine opts with existing item if set
 		if (item) opts = Object.assign(opts, item)
 
+		// combine defaults with opts (and existing item)
 		opts = Object.assign(
 			{
 				type: null,
 				default: false,
 				variables: {},
 				templateObject: '',
-				init() {}
+				init: noop
 			},
 			opts
 		)
 
+		// bind cloneBlankNode to the combined templateObject value
 		opts.cloneBlankNode = this.cloneBlankNode.bind(this, opts.templateObject)
 
+		// save/update the final combined options on items
 		items.set(className, opts)
 
+		// if combined ops has default set to true, store it in the default for this type
 		if (opts.default) {
 			defaults.set(opts.type, className)
 		}
 
+		// run init if it was set
 		opts.init()
 
+		// store variable handlers
 		for (const variable in opts.variables) {
 			const cb = opts.variables[variable]
 			variableHandlers.set(variable, cb)
 		}
 
+		// return this for chaining
 		return this
 	}
 

--- a/packages/app/obojobo-document-engine/src/scripts/common/registry.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/registry.js
@@ -40,33 +40,28 @@ class _Registry {
 		return this
 	}
 
+	cloneBlankNode(templateObject) {
+		return JSON.parse(JSON.stringify(templateObject))
+	}
+
 	registerModel(className, opts = {}) {
 		const item = items.get(className)
 		if (item) opts = Object.assign(opts, item)
-
-		items.set(className, opts)
 
 		opts = Object.assign(
 			{
 				type: null,
 				default: false,
-				insertItem: null,
-				componentClass: null,
-				commandHandler: null,
 				variables: {},
-				init() {},
-				// editor
-				// pull out to editor registry eventually
-				name: '',
-				icon: null,
-				isInsertable: false,
-				slateToObo: null,
-				oboToSlate: null,
-				plugins: null,
-				supportsChildren: false
+				templateObject: '',
+				init() {}
 			},
 			opts
 		)
+
+		opts.cloneBlankNode = this.cloneBlankNode.bind(this, opts.templateObject)
+
+		items.set(className, opts)
 
 		if (opts.default) {
 			defaults.set(opts.type, className)

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
@@ -7,19 +7,23 @@ import DropMenu from './components/insert-menu'
 import './editor-component.scss'
 
 class Node extends React.Component {
-	insertBlockAtStart(item) {
-		const editor = this.props.editor
+	cloneNodeJSON(sourceJSON) {
+		return JSON.parse(JSON.stringify(sourceJSON))
+	}
 
-		return editor.insertNodeByKey(this.props.node.key, 0, Block.create(item.insertJSON))
+	insertBlockAtStart(item) {
+		const json = this.cloneNodeJSON(item.insertJSON)
+
+		return this.props.editor.insertNodeByKey(this.props.node.key, 0, Block.create(json))
 	}
 
 	insertBlockAtEnd(item) {
-		const editor = this.props.editor
+		const json = this.cloneNodeJSON(item.insertJSON)
 
-		return editor.insertNodeByKey(
+		return this.props.editor.insertNodeByKey(
 			this.props.node.key,
 			this.props.node.nodes.size,
-			Block.create(item.insertJSON)
+			Block.create(json)
 		)
 	}
 

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
@@ -7,23 +7,19 @@ import DropMenu from './components/insert-menu'
 import './editor-component.scss'
 
 class Node extends React.Component {
-	cloneNodeJSON(sourceJSON) {
-		return JSON.parse(JSON.stringify(sourceJSON))
-	}
-
 	insertBlockAtStart(item) {
-		const json = this.cloneNodeJSON(item.insertJSON)
-
-		return this.props.editor.insertNodeByKey(this.props.node.key, 0, Block.create(json))
+		return this.props.editor.insertNodeByKey(
+			this.props.node.key,
+			0,
+			Block.create(item.cloneBlankNode())
+		)
 	}
 
 	insertBlockAtEnd(item) {
-		const json = this.cloneNodeJSON(item.insertJSON)
-
 		return this.props.editor.insertNodeByKey(
 			this.props.node.key,
 			this.props.node.nodes.size,
-			Block.create(json)
+			Block.create(item.cloneBlankNode())
 		)
 	}
 

--- a/packages/obonode/obojobo-chunks-action-button/editor.js
+++ b/packages/obonode/obojobo-chunks-action-button/editor.js
@@ -36,7 +36,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.ActionButton', {
 	name: 'Button',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -51,9 +51,6 @@ const ActionButton = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-break/editor.js
+++ b/packages/obonode/obojobo-chunks-break/editor.js
@@ -25,7 +25,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.Break', {
 	name: 'Horizontal Line',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -40,9 +40,6 @@ const Break = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-code/editor.js
+++ b/packages/obonode/obojobo-chunks-code/editor.js
@@ -107,7 +107,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.Code', {
 	name: 'Code',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -123,9 +123,6 @@ const Code = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-figure/editor.js
+++ b/packages/obonode/obojobo-chunks-figure/editor.js
@@ -36,7 +36,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.Figure', {
 	name: 'Figure',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -51,9 +51,6 @@ const Figure = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-heading/editor.js
+++ b/packages/obonode/obojobo-chunks-heading/editor.js
@@ -39,7 +39,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.Heading', {
 	name: 'Heading',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins,
@@ -84,9 +84,6 @@ const Heading = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-html/editor.js
+++ b/packages/obonode/obojobo-chunks-html/editor.js
@@ -43,7 +43,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.HTML', {
 	name: 'HTML',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -58,9 +58,6 @@ const HTML = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-iframe/editor.js
+++ b/packages/obonode/obojobo-chunks-iframe/editor.js
@@ -25,7 +25,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.IFrame', {
 	name: 'IFrame',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -40,9 +40,6 @@ const IFrame = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-list/editor.js
+++ b/packages/obonode/obojobo-chunks-list/editor.js
@@ -146,7 +146,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.List', {
 	name: 'List',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -164,9 +164,6 @@ const List = {
 		isType,
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-math-equation/editor.js
+++ b/packages/obonode/obojobo-chunks-math-equation/editor.js
@@ -25,7 +25,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.MathEquation', {
 	name: 'Math Equation',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -40,9 +40,6 @@ const MathEquation = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-question-bank/editor.js
+++ b/packages/obonode/obojobo-chunks-question-bank/editor.js
@@ -29,7 +29,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.QuestionBank', {
 	name: 'Question Bank',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	supportsChildren: true,
@@ -46,9 +46,6 @@ const QuestionBank = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-question/editor.js
+++ b/packages/obonode/obojobo-chunks-question/editor.js
@@ -29,7 +29,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.Question', {
 	name: 'Question',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	supportsChildren: true,
@@ -58,9 +58,6 @@ const Question = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-table/editor.js
+++ b/packages/obonode/obojobo-chunks-table/editor.js
@@ -110,7 +110,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.Table', {
 	name: 'Table',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -127,9 +127,6 @@ const Table = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-text/editor.js
+++ b/packages/obonode/obojobo-chunks-text/editor.js
@@ -120,7 +120,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.Text', {
 	name: 'Text',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -136,9 +136,6 @@ const Text = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }

--- a/packages/obonode/obojobo-chunks-youtube/editor.js
+++ b/packages/obonode/obojobo-chunks-youtube/editor.js
@@ -25,7 +25,7 @@ Common.Registry.registerModel('ObojoboDraft.Chunks.YouTube', {
 	name: 'YouTube',
 	icon: Icon,
 	isInsertable: true,
-	insertJSON: emptyNode,
+	templateObject: emptyNode,
 	slateToObo: Converter.slateToObo,
 	oboToSlate: Converter.oboToSlate,
 	plugins
@@ -40,9 +40,6 @@ const YouTube = {
 	helpers: {
 		slateToObo: Converter.slateToObo,
 		oboToSlate: Converter.oboToSlate
-	},
-	json: {
-		emptyNode
 	},
 	plugins
 }


### PR DESCRIPTION
This is a more complete/opinionated solution to issue #961 than this PR #962 

@zachberry, I offer this as a second PR so we can either merge this one into master, or merge 962 in for simplicity & speed, then merge this into the next dev branch?

Fixes #961 

* changes `insertJSON` -> `templateObject` in each chunk's call to `registerModel`
* adds a method to the model that will clone a templateObject called `cloneBlankNode`
* adds a test for `cloneBlankNode`
* Registry.registerModel looks like it was creating some option params in a strange order & they weren't being used - so I removed them and re-ordered
* removes .json.emptyNode from each node's exports to reduce unintentional pass by ref ofthe  templateObject (and this is not currently used)