### PR TITLE
Fix problem when `question:scoreSet` is being fired twice

### DIFF
--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/viewer-component.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/viewer-component.js
@@ -10,7 +10,6 @@ import Viewer from 'obojobo-document-engine/src/scripts/viewer'
 import _ from 'underscore'
 import isOrNot from 'obojobo-document-engine/src/scripts/common/util/isornot'
 
-const { Dispatcher } = Common.flux
 const { OboModel } = Common.models
 const { DOMUtil } = Common.page
 const { OboComponent } = Viewer.components
@@ -44,7 +43,6 @@ export default class MCAssessment extends React.Component {
 		this.onClickReset = this.onClickReset.bind(this)
 		this.onFormChange = this.onFormChange.bind(this)
 		this.onFormSubmit = this.onFormSubmit.bind(this)
-		this.onCheckAnswer = this.onCheckAnswer.bind(this)
 		this.isShowingExplanation = this.isShowingExplanation.bind(this)
 
 		this.sortIds()
@@ -301,10 +299,6 @@ export default class MCAssessment extends React.Component {
 		)
 	}
 
-	componentDidMount() {
-		Dispatcher.on('question:checkAnswer', this.onCheckAnswer)
-	}
-
 	componentDidUpdate() {
 		this.sortIds()
 
@@ -325,22 +319,6 @@ export default class MCAssessment extends React.Component {
 				delete this.nextFocus
 				FocusUtil.focusComponent(this.getQuestionModel().get('id'))
 				break
-		}
-	}
-
-	componentWillUnmount() {
-		Dispatcher.off('question:checkAnswer', this.onCheckAnswer)
-	}
-
-	onCheckAnswer(payload) {
-		const questionId = this.getQuestionModel().get('id')
-
-		if (payload.value.id === questionId) {
-			QuestionUtil.setScore(
-				questionId,
-				this.calculateScore(),
-				this.props.moduleData.navState.context
-			)
 		}
 	}
 
@@ -494,9 +472,7 @@ export default class MCAssessment extends React.Component {
 			>
 				<fieldset>
 					<legend className="instructions">
-						<span className="for-screen-reader-only">{`Multiple choice form with ${
-							sortedChoiceModels.length
-						} choices. `}</span>
+						<span className="for-screen-reader-only">{`Multiple choice form with ${sortedChoiceModels.length} choices. `}</span>
 						{this.getInstructions(responseType, this.props.type)}
 					</legend>
 					<MCAssessmentAnswerChoices

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/viewer-component.test.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/viewer-component.test.js
@@ -2,7 +2,6 @@ import { mount, shallow } from 'enzyme'
 
 import Common from 'obojobo-document-engine/src/scripts/common'
 import DOMUtil from 'obojobo-document-engine/src/scripts/common/page/dom-util'
-import Dispatcher from 'obojobo-document-engine/src/scripts/common/flux/dispatcher'
 import FocusUtil from 'obojobo-document-engine/src/scripts/viewer/util/focus-util'
 import MCAssessment from './viewer-component'
 import OboModel from 'obojobo-document-engine/src/scripts/common/models/obo-model'
@@ -33,7 +32,6 @@ const MCCHOICE_NODE_TYPE = 'ObojoboDraft.Chunks.MCAssessment.MCChoice'
 const TYPE_PICK_ONE = 'pick-one'
 const TYPE_MULTI_CORRECT = 'pick-one-multiple-correct'
 const TYPE_PICK_ALL = 'pick-all'
-const ACTION_CHECK_ANSWER = 'question:checkAnswer'
 
 require('./viewer') // used to register this oboModel
 require('./MCChoice/viewer') // // dependency on Obojobo.Chunks.MCAssessment
@@ -1630,94 +1628,6 @@ describe('MCAssessment', () => {
 			parent,
 			'mockContext'
 		)
-	})
-
-	test('componentDidMount sets up the Dispatcher', () => {
-		const moduleData = {
-			questionState: 'mockQuestionState',
-			navState: {}
-		}
-		const parent = OboModel.create(questionJSON)
-		const model = parent.children.models[0]
-
-		// short circuits sortIds
-		QuestionUtil.getData.mockReturnValueOnce(false)
-
-		mount(<MCAssessment model={model} moduleData={moduleData} mode="assessment" type="default" />)
-
-		expect(QuestionUtil.getData).toHaveBeenCalled()
-		expect(Dispatcher.on).toHaveBeenCalledWith(ACTION_CHECK_ANSWER, expect.any(Function))
-	})
-
-	test('componentWillUnmount removes the Dispatcher', () => {
-		const moduleData = {
-			questionState: 'mockQuestionState',
-			navState: {}
-		}
-		const parent = OboModel.create(questionJSON)
-		const model = parent.children.models[0]
-
-		// short circuits sortIds
-		QuestionUtil.getData.mockReturnValueOnce(false)
-
-		const component = mount(
-			<MCAssessment model={model} moduleData={moduleData} mode="assessment" type="default" />
-		)
-
-		component.unmount()
-
-		expect(Dispatcher.off).toHaveBeenCalledWith(ACTION_CHECK_ANSWER, expect.any(Function))
-	})
-
-	test('onCheckAnswer does nothing if this is not the correct question', () => {
-		const moduleData = {
-			navState: {
-				context: 'mockContext'
-			},
-			focusState: {}
-		}
-		const parent = OboModel.create(questionJSON)
-		const model = parent.children.models[0]
-
-		QuestionUtil.getData.mockReturnValueOnce(false)
-
-		const component = shallow(
-			<MCAssessment model={model} moduleData={moduleData} mode="assessment" type="default" />
-		)
-		component.instance().onCheckAnswer({
-			value: {
-				id: 'mockDifferentId'
-			}
-		})
-
-		expect(QuestionUtil.setScore).not.toHaveBeenCalled()
-	})
-
-	test('onCheckAnswer calls QuestionUtil for the correct question', () => {
-		const moduleData = {
-			navState: {
-				context: 'mockContext'
-			},
-			focusState: {}
-		}
-		const parent = OboModel.create(questionJSON)
-		const model = parent.children.models[0]
-
-		QuestionUtil.getData.mockReturnValueOnce(false)
-
-		// mock for calculateScore - score is 0
-		QuestionUtil.getResponse.mockReturnValue({ ids: ['choice2'] })
-
-		const component = shallow(
-			<MCAssessment model={model} moduleData={moduleData} mode="assessment" type="default" />
-		)
-		component.instance().onCheckAnswer({
-			value: {
-				id: 'parent'
-			}
-		})
-
-		expect(QuestionUtil.setScore).toHaveBeenCalledWith('parent', 0, 'mockContext')
 	})
 
 	test('componentDidUpdate calls sortIds', () => {


### PR DESCRIPTION
Reason: when a user submits a non-survey MCAssessment, `question:scoreSet` and `question:checkAnswer` are being fired. The MCAssessment also has an event listener for `question:checkAnswer` that fires `question:scoreSet` again.

Solution: delete the event listener to stop the second event from being fired.

Resolve: #985 