### PR TITLE
Add 0% scoreAction page as a backup for a missing `no-score` page

### DIFF
--- a/packages/obonode/obojobo-sections-assessment/post-assessment/score-actions.js
+++ b/packages/obonode/obojobo-sections-assessment/post-assessment/score-actions.js
@@ -31,10 +31,11 @@ class ScoreActions {
 	getAllMatchingActionsForScore(assessmentScore) {
 		switch (assessmentScore) {
 			case null:
-				// If the assessment score is null try to find a score action matching "no-score"...
-				return this.actions.filter(
-					action => action.range.min === 'no-score' && action.range.max === 'no-score'
-				)
+				// If the assessment score is null try to find a score action matching "no-score".
+				// In case none exists, include any score action pages for a 0% as well.
+				return this.actions
+					.filter(action => action.range.min === 'no-score' && action.range.max === 'no-score')
+					.concat(this.getAllMatchingActionsForScore(0))
 
 			//0-100
 			default:

--- a/packages/obonode/obojobo-sections-assessment/post-assessment/score-actions.test.js
+++ b/packages/obonode/obojobo-sections-assessment/post-assessment/score-actions.test.js
@@ -136,6 +136,24 @@ describe('score-actions', () => {
 					isMinInclusive: true,
 					isMaxInclusive: true
 				}
+			},
+			{
+				page: 'numeric-matching-action-1',
+				range: {
+					min: '0',
+					max: '99',
+					isMinInclusive: true,
+					isMaxInclusive: true
+				}
+			},
+			{
+				page: 'numeric-matching-action-2',
+				range: {
+					min: '0',
+					max: '100',
+					isMinInclusive: true,
+					isMaxInclusive: true
+				}
 			}
 		])
 


### PR DESCRIPTION
Restores some 6.0.1 behavior to score actions - Now if there is no 'no-score' scoreAction for a 'no-score' (null) assesssment score the scoreAction for 0% will be shown as a backup.