### PR TITLE
[clean] removes fetch shim needed to support ie11

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/viewer/dist.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/dist.js
@@ -1,4 +1,3 @@
-import 'whatwg-fetch'
 require('../common/dist.js')
 window.Viewer = require('./index')
 require('./app.js')

--- a/packages/app/obojobo-express/package.json
+++ b/packages/app/obojobo-express/package.json
@@ -93,8 +93,7 @@
 		"webpack": "^4.41.0",
 		"webpack-cli": "^3.3.9",
 		"webpack-dev-server": "^3.8.2",
-		"webpack-manifest-plugin": "^2.2.0",
-		"whatwg-fetch": "^3.0.0"
+		"webpack-manifest-plugin": "^2.2.0"
 	},
 	"bin": {
 		"start_obojobo_server": "./bin/start_obojobo_server",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14189,11 +14189,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
-
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"


### PR DESCRIPTION
We no longer support ie11, so the fetch shim to do so can be removed.