### PR TITLE
Fix the Delete button in the visual editor more info box from crashing the page

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/more-info-box.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/more-info-box.js
@@ -44,9 +44,13 @@ class MoreInfoBox extends React.Component {
 		this.node = React.createRef()
 	}
 
-	componentWillUnmount() {
-		// remove the listener if the component somehow unmounts without closing
+	onClose() {
 		document.removeEventListener('mousedown', this.handleClick, false)
+		if (this.props.onClose) this.props.onClose()
+	}
+
+	componentWillUnmount() {
+		this.onClose()
 	}
 
 	handleClick(event) {
@@ -120,8 +124,7 @@ class MoreInfoBox extends React.Component {
 	}
 
 	close() {
-		document.removeEventListener('mousedown', this.handleClick, false)
-		if (this.props.onClose) this.props.onClose()
+		this.onClose()
 		return this.setState({ isOpen: false })
 	}
 

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/more-info-box.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/more-info-box.js
@@ -44,13 +44,8 @@ class MoreInfoBox extends React.Component {
 		this.node = React.createRef()
 	}
 
-	onClose() {
-		document.removeEventListener('mousedown', this.handleClick, false)
-		if (this.props.onClose) this.props.onClose()
-	}
-
 	componentWillUnmount() {
-		this.onClose()
+		this.close()
 	}
 
 	handleClick(event) {
@@ -124,7 +119,8 @@ class MoreInfoBox extends React.Component {
 	}
 
 	close() {
-		this.onClose()
+		document.removeEventListener('mousedown', this.handleClick, false)
+		if (this.props.onClose) this.props.onClose()
 		return this.setState({ isOpen: false })
 	}
 


### PR DESCRIPTION
When the more info box is unmounted (which will happen when a node is deleted) it now calls it's props.onClose method, which will correctly restore editing powers to the editor.

Fixes #1019 