### PR TITLE
Fixes filter for capital letters and a few style changes

### DIFF
--- a/packages/app/obojobo-repository/client/css/_defaults.scss
+++ b/packages/app/obojobo-repository/client/css/_defaults.scss
@@ -52,7 +52,7 @@ $font-size: 14.25pt;
 $dimension-module-icon: 90px;
 $dimension-avatar-icon: 90px;
 $dimension-padding: 1.5em;
-$dimension-width: 40em;
+$dimension-width: 42em;
 $dimension-nav-height: 3.75em;
 
 @mixin text-input() {

--- a/packages/app/obojobo-repository/shared/components/repository-banner.scss
+++ b/packages/app/obojobo-repository/shared/components/repository-banner.scss
@@ -32,7 +32,6 @@
 
 .repository--section-wrapper--grey {
 	background-color: $color-banner-bg;
-	border-top: 1px solid $border-color;
 	border-bottom: 1px solid $border-color;
 }
 
@@ -82,7 +81,11 @@
 		-webkit-text-stroke: $stroke-width * 2 $color-banner-bg;
 		// In case we're not in webkit, throw a text-shadow on to at least get
 		// a pixel of glow to keep the background from mixing with the font too much
-		text-shadow: -1px -1px 0 $color-banner-bg, 1px -1px 0 $color-banner-bg,
-			-1px 1px 0 $color-banner-bg, 1px 1px 0 $color-banner-bg;
+		// prettier-ignore
+		text-shadow:
+			-1px -1px 0 $color-banner-bg,
+			1px -1px 0 $color-banner-bg,
+			-1px 1px 0 $color-banner-bg,
+			1px 1px 0 $color-banner-bg;
 	}
 }

--- a/packages/app/obojobo-repository/shared/components/repository-nav.scss
+++ b/packages/app/obojobo-repository/shared/components/repository-nav.scss
@@ -11,6 +11,7 @@
 	background: #ffffff;
 	min-width: 100%;
 	z-index: 100;
+	border-bottom: 1px solid $border-color;
 }
 
 .repository--nav {
@@ -86,13 +87,13 @@
 	}
 }
 
-.repository--nav--current-user {
+.repository--nav .repository--nav--current-user {
 	position: relative;
-	font-size: 1em;
 	height: $dimension-nav-height;
 	text-align: right;
 	padding: 0 $dimension-nav-height 0 0;
 	box-sizing: border-box;
+	margin-right: 0;
 
 	&:hover {
 		.repository--nav--current-user--menu {

--- a/packages/app/obojobo-repository/shared/reducers/dashboard-reducer.js
+++ b/packages/app/obojobo-repository/shared/reducers/dashboard-reducer.js
@@ -26,8 +26,10 @@ const closedDialogState = () => ({
 })
 
 function filterModules(modules, searchString) {
+	searchString = searchString.toLowerCase().replace(/\s+/g, '')
+
 	return modules.filter(m => {
-		return `${(m.title || '').toLowerCase()}${m.draftId}`.includes(searchString)
+		return `${(m.title || '').toLowerCase().replace(/\s+/g, '')}${m.draftId}`.includes(searchString)
 	})
 }
 

--- a/packages/app/obojobo-repository/shared/reducers/dashboard-reducer.js
+++ b/packages/app/obojobo-repository/shared/reducers/dashboard-reducer.js
@@ -28,12 +28,12 @@ const closedDialogState = () => ({
 })
 
 function filterModules(modules, searchString) {
-	searchString = ('' + searchString).toLowerCase().replace(whitespaceRegex, '')
+	searchString = ('' + searchString).replace(whitespaceRegex, '').toLowerCase()
 
 	return modules.filter(m =>
 		((m.title || '') + m.draftId)
-			.toLowerCase()
 			.replace(whitespaceRegex, '')
+			.toLowerCase()
 			.includes(searchString)
 	)
 }


### PR DESCRIPTION
Fixes #1035 

* Repository filter now is completely case-insensitive and also strips out all whitespace
* Increased width of repository main content to restore earlier look of fitting module icons perfectly in the grid
* Sticky header in repository now includes a bottom border