### PR TITLE
Wrap PageEditor in a react ErrorBoundry

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/page-editor-error-boundry.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/page-editor-error-boundry.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageEditorErrorBoundry PageEditorErrorBoundry component 1`] = `
+<div>
+  Contents...
+</div>
+`;

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/page-editor-error-boundry.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/page-editor-error-boundry.test.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import mockConsole from 'jest-mock-console'
+import PageEditorErrorBoundry from 'src/scripts/oboeditor/components/page-editor-error-boundry'
+
+describe('PageEditorErrorBoundry', () => {
+	let restoreConsole
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		jest.restoreAllMocks()
+		jest.resetModules()
+		restoreConsole = mockConsole('error')
+	})
+
+	afterEach(() => {
+		restoreConsole()
+	})
+
+	test('PageEditorErrorBoundry component', () => {
+		const component = renderer.create(
+			<PageEditorErrorBoundry editorRef={{}}>
+				<div>Contents...</div>
+			</PageEditorErrorBoundry>
+		)
+		expect(component.toJSON()).toMatchSnapshot()
+	})
+
+	test('PageEditorErrorBoundry calls undo if a child throws an error', () => {
+		const BadComponent = () => {
+			throw new Error('I am a bad component')
+		}
+
+		const editorRef = {
+			current: {
+				undo: jest.fn()
+			}
+		}
+
+		expect(editorRef.current.undo).toHaveBeenCalledTimes(0)
+
+		renderer.create(
+			<PageEditorErrorBoundry editorRef={editorRef}>
+				<BadComponent />
+			</PageEditorErrorBoundry>
+		)
+
+		expect(editorRef.current.undo).toHaveBeenCalledTimes(1)
+	})
+
+	test('PageEditorErrorBoundry still works if editorRef is null', () => {
+		const BadComponent = () => {
+			throw new Error('I am a bad component')
+		}
+
+		const editorRef = {}
+		const mockEditorRefCurrentGetter = jest.fn()
+		Object.defineProperty(editorRef, 'current', {
+			get: () => {
+				mockEditorRefCurrentGetter()
+				return null
+			}
+		})
+
+		expect(mockEditorRefCurrentGetter).toHaveBeenCalledTimes(0)
+
+		renderer.create(
+			<PageEditorErrorBoundry editorRef={editorRef}>
+				<BadComponent />
+			</PageEditorErrorBoundry>
+		)
+
+		expect(mockEditorRefCurrentGetter).toHaveBeenCalledTimes(1)
+	})
+})

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/page-editor-error-boundry.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/page-editor-error-boundry.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+class ErrorBoundary extends React.Component {
+	componentDidCatch() {
+		if (this.props.editorRef.current) {
+			this.props.editorRef.current.undo()
+		}
+	}
+
+	render() {
+		return this.props.children
+	}
+}
+
+export default ErrorBoundary

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/page-editor-error-boundry.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/page-editor-error-boundry.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-class ErrorBoundary extends React.Component {
+class PageEditorErrorBoundry extends React.Component {
 	componentDidCatch() {
 		if (this.props.editorRef.current) {
 			this.props.editorRef.current.undo()
@@ -12,4 +12,4 @@ class ErrorBoundary extends React.Component {
 	}
 }
 
-export default ErrorBoundary
+export default PageEditorErrorBoundry

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/page-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/page-editor.js
@@ -22,6 +22,7 @@ import ToggleParameter from './parameter-node/toggle-parameter'
 import { Value } from 'slate'
 import EditorNav from './navigation/editor-nav'
 import isOrNot from 'obojobo-document-engine/src/scripts/common/util/isornot'
+import PageEditorErrorBoundry from './page-editor-error-boundry'
 
 const { ModalUtil } = Common.util
 
@@ -191,14 +192,16 @@ class PageEditor extends React.Component {
 				/>
 
 				<div className="component obojobo-draft--modules--module" role="main">
-					<Editor
-						className="component obojobo-draft--pages--page"
-						value={this.state.value}
-						ref={this.editorRef}
-						onChange={this.onChange}
-						plugins={this.plugins}
-						readOnly={!this.props.page || !this.state.editable}
-					/>
+					<PageEditorErrorBoundry editorRef={this.editorRef}>
+						<Editor
+							className="component obojobo-draft--pages--page"
+							value={this.state.value}
+							ref={this.editorRef}
+							onChange={this.onChange}
+							plugins={this.plugins}
+							readOnly={!this.props.page || !this.state.editable}
+						/>
+					</PageEditorErrorBoundry>
 				</div>
 			</div>
 		)


### PR DESCRIPTION
Fixes #1032 

Tries to fix really bad errors in the visual editor with an error boundary on page editor. When an error occurs undo is attempted.