### PR TITLE
[reporting] Adds a custom type definition for cloc

### DIFF
--- a/cloc-type-definitions.txt
+++ b/cloc-type-definitions.txt
@@ -1,0 +1,14 @@
+Jest Tests
+    filter rm_comments_in_strings " /* */
+    filter rm_comments_in_strings " //
+    filter call_regexp_common C++
+    extension test.js
+    3rd_gen_scale 1.48
+    end_of_line_continuation \\$
+Jest Test Snapshots
+    filter rm_comments_in_strings " /* */
+    filter rm_comments_in_strings " //
+    filter call_regexp_common C++
+    extension js.snap
+    3rd_gen_scale 1.48
+    end_of_line_continuation \\$


### PR DESCRIPTION
cloc reports don't have a type definition for Jest tests or Jest snapshots.  This file adds them so you can separate those stats from normal javascript

usage:
```
cloc ./ --hide-rate --by-percent cmb --read-lang-def=cloc-type-definitions.txt
```