### PR TITLE
[fix] editor loading draft request headers corrected

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
@@ -124,7 +124,7 @@ class EditorApp extends React.Component {
 	}
 
 	reloadDraft(draftId, mode) {
-		return APIUtil.getFullDraft(draftId, mode)
+		return APIUtil.getFullDraft(draftId, mode === VISUAL_MODE ? 'json' : mode)
 			.then(response => {
 				let json
 				switch (mode) {

--- a/packages/app/obojobo-express/express_response_decorator.js
+++ b/packages/app/obojobo-express/express_response_decorator.js
@@ -39,10 +39,7 @@ const success = (req, res, next, valueObject) => {
 const badInput = (req, res, next, message) => {
 	res.status(422)
 
-	// give other things a chance to execute
-	oboEvents.emit('HTTP_BAD_INPUT', { req, res, next, message })
-	if (res.headersSent || req.responseHandled) return
-
+	// if json, just return json
 	if (shouldRespondWithJson(req)) {
 		return res.json(
 			camelize({
@@ -55,15 +52,17 @@ const badInput = (req, res, next, message) => {
 		)
 	}
 
+	// give other things a chance to execute
+	oboEvents.emit('HTTP_BAD_INPUT', { req, res, next, message })
+	if (res.headersSent || req.responseHandled) return
+
 	res.send(`Bad Input: ${message}`)
 }
 
 const notAuthorized = (req, res, next, message) => {
 	res.status(401)
-	// give other things a chance to execute
-	oboEvents.emit('HTTP_NOT_AUTHORIZED', { req, res, next, message })
-	if (res.headersSent || req.responseHandled) return
 
+	// if json, just return json
 	if (shouldRespondWithJson(req)) {
 		return res.json(
 			camelize({
@@ -76,15 +75,17 @@ const notAuthorized = (req, res, next, message) => {
 		)
 	}
 
+	// give other things a chance to execute
+	oboEvents.emit('HTTP_NOT_AUTHORIZED', { req, res, next, message })
+	if (res.headersSent || req.responseHandled) return
+
 	res.send(`Not Authorized`)
 }
 
 const reject = (req, res, next, message) => {
 	res.status(403)
-	// give other things a chance to execute
-	oboEvents.emit('HTTP_REJECTED', { req, res, next, message })
-	if (res.headersSent || req.responseHandled) return
 
+	// if json, just return json
 	if (shouldRespondWithJson(req)) {
 		return res.json(
 			camelize({
@@ -97,16 +98,17 @@ const reject = (req, res, next, message) => {
 		)
 	}
 
+	// give other things a chance to execute
+	oboEvents.emit('HTTP_REJECTED', { req, res, next, message })
+	if (res.headersSent || req.responseHandled) return
+
 	res.send(`Rejected Request: ${message}`)
 }
 
 const missing = (req, res, next, message) => {
 	res.status(404)
 
-	// give other things a chance to execute
-	oboEvents.emit('HTTP_NOT_FOUND', { req, res, next, message })
-	if (res.headersSent || req.responseHandled) return
-
+	// if json, just return json
 	if (shouldRespondWithJson(req)) {
 		return res.json(
 			camelize({
@@ -118,6 +120,10 @@ const missing = (req, res, next, message) => {
 			})
 		)
 	}
+
+	// give other things a chance to execute
+	oboEvents.emit('HTTP_NOT_FOUND', { req, res, next, message })
+	if (res.headersSent || req.responseHandled) return
 
 	res.render('404')
 }
@@ -138,10 +144,7 @@ const unexpected = (req, res, next, messageOrError) => {
 		message = 'Unexpected Error'
 	}
 
-	// give other things a chance to execute
-	oboEvents.emit('HTTP_UNEXPECTED', { req, res, next, message })
-	if (res.headersSent || req.responseHandled) return
-
+	// if json, just return json
 	if (shouldRespondWithJson(req)) {
 		return res.json(
 			camelize({
@@ -153,6 +156,10 @@ const unexpected = (req, res, next, messageOrError) => {
 			})
 		)
 	}
+
+	// give other things a chance to execute
+	oboEvents.emit('HTTP_UNEXPECTED', { req, res, next, message })
+	if (res.headersSent || req.responseHandled) return
 
 	res.send(`Server Error: ${message}`)
 }


### PR DESCRIPTION
If res.notAuthroized is called from `/api/drafts/:draftid/full`, the server is responding with an html page.  This is a result of 2 problems: The editor is sending an invalid accepts header to the api when loading the draft contents.  And the new evens emitted from the different error states that allow specialized error pages are preventing the json response from returning.

* editor call to /api/drafts/:draftid/full sends accepts: application/json
* error callbacks now check for json header before firing event