### PR TITLE
[fix] editor question bank settings radio buttons

### DIFF
--- a/packages/obonode/obojobo-chunks-question-bank/__snapshots__/converter.test.js.snap
+++ b/packages/obonode/obojobo-chunks-question-bank/__snapshots__/converter.test.js.snap
@@ -11,7 +11,7 @@ Object {
     Object {
       "data": Object {
         "content": Object {
-          "choose": 1,
+          "choose": "1",
           "chooseAll": true,
         },
       },
@@ -22,14 +22,14 @@ Object {
     Object {
       "data": Object {
         "content": Object {
-          "choose": 1,
+          "choose": "1",
         },
       },
       "nodes": Array [
         Object {
           "data": Object {
             "content": Object {
-              "choose": 1,
+              "choose": "1",
               "chooseAll": false,
             },
           },
@@ -61,8 +61,7 @@ Object {
     undefined,
   ],
   "content": Object {
-    "choose": Infinity,
-    "chooseAll": true,
+    "choose": "all",
   },
   "id": "mockKey",
   "type": "mockType",
@@ -80,7 +79,9 @@ Object {
     },
     undefined,
   ],
-  "content": Object {},
+  "content": Object {
+    "choose": "1",
+  },
   "id": "mockKey",
   "type": "mockType",
 }

--- a/packages/obonode/obojobo-chunks-question-bank/components/settings/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-question-bank/components/settings/__snapshots__/editor-component.test.js.snap
@@ -33,6 +33,8 @@ exports[`Question Bank Settings Editor Node Settings builds the expected compone
       Pick
     </label>
     <input
+      min="1"
+      onBlur={[Function]}
       onChange={[Function]}
       onClick={[Function]}
       type="number"

--- a/packages/obonode/obojobo-chunks-question-bank/components/settings/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-question-bank/components/settings/__snapshots__/editor-component.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Settings Editor Node Settings builds the expected component 1`] = `
+exports[`Question Bank Settings Editor Node Settings builds the expected component 1`] = `
 <div
   className="qb-settings"
 >
@@ -12,7 +12,7 @@ exports[`Settings Editor Node Settings builds the expected component 1`] = `
     </legend>
     <label>
       <input
-        name="choose"
+        name="mock-id-choose"
         onChange={[Function]}
         type="radio"
         value="all"
@@ -25,7 +25,7 @@ exports[`Settings Editor Node Settings builds the expected component 1`] = `
     <label>
       <input
         checked={true}
-        name="choose"
+        name="mock-id-choose"
         onChange={[Function]}
         type="radio"
         value="pick"

--- a/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.js
@@ -5,12 +5,15 @@ import React from 'react'
 class Settings extends React.Component {
 	changeChooseType(event) {
 		event.stopPropagation()
+
 		const chooseAll = event.target.value === 'all'
+		const nodeContentData = this.props.node.data.get('content')
 
 		return this.props.editor.setNodeByKey(this.props.node.key, {
 			data: {
 				content: {
-					...this.props.node.data.get('content'),
+					...nodeContentData,
+					choose: chooseAll ? '1' : nodeContentData.choose,
 					chooseAll
 				}
 			}
@@ -19,11 +22,31 @@ class Settings extends React.Component {
 
 	changeChooseAmount(event) {
 		event.stopPropagation()
+
 		return this.props.editor.setNodeByKey(this.props.node.key, {
 			data: {
 				content: {
 					...this.props.node.data.get('content'),
-					choose: event.target.value
+					choose: event.target.value,
+					chooseAll: false
+				}
+			}
+		})
+	}
+
+	validateAndUpdateChooseAmount(event) {
+		event.stopPropagation()
+
+		// Ensure that any typed in choose value is a valid number >= 1
+		const choose = this.props.node.data.get('content').choose
+		let updatedChooseNumber = Math.max(1, parseInt(choose, 10))
+		if (!Number.isFinite(updatedChooseNumber)) updatedChooseNumber = 1
+
+		return this.props.editor.setNodeByKey(this.props.node.key, {
+			data: {
+				content: {
+					...this.props.node.data.get('content'),
+					choose: '' + updatedChooseNumber
 				}
 			}
 		})
@@ -31,6 +54,7 @@ class Settings extends React.Component {
 
 	changeSelect(event) {
 		event.stopPropagation()
+
 		return this.props.editor.setNodeByKey(this.props.node.key, {
 			data: {
 				content: {
@@ -72,9 +96,11 @@ class Settings extends React.Component {
 					<input
 						type="number"
 						value={content.choose}
-						disabled={content.chooseAll}
-						onChange={this.changeChooseAmount.bind(this)}
 						onClick={event => event.stopPropagation()}
+						onBlur={this.validateAndUpdateChooseAmount.bind(this)}
+						onChange={this.changeChooseAmount.bind(this)}
+						disabled={content.chooseAll}
+						min="1"
 					/>
 				</fieldset>
 				<label className="select">

--- a/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.js
@@ -43,7 +43,7 @@ class Settings extends React.Component {
 
 	render() {
 		const content = this.props.node.data.get('content')
-
+		const radioGroup = `${this.props.node.key}-choose`
 		return (
 			<div className={'qb-settings'}>
 				<fieldset className="choose">
@@ -51,7 +51,7 @@ class Settings extends React.Component {
 					<label>
 						<input
 							type="radio"
-							name="choose"
+							name={radioGroup}
 							value="all"
 							checked={content.chooseAll}
 							onChange={this.changeChooseType.bind(this)}
@@ -62,7 +62,7 @@ class Settings extends React.Component {
 					<label>
 						<input
 							type="radio"
-							name="choose"
+							name={radioGroup}
 							value="pick"
 							checked={!content.chooseAll}
 							onChange={this.changeChooseType.bind(this)}

--- a/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.scss
@@ -18,6 +18,10 @@
 
 			margin-left: 0.5em;
 			max-width: 5em;
+
+			&:disabled {
+				opacity: 0.5;
+			}
 		}
 
 		span {

--- a/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.test.js
@@ -6,6 +6,8 @@ import renderer from 'react-test-renderer'
 
 import Settings from './editor-component'
 
+jest.useFakeTimers()
+
 describe('Question Bank Settings Editor Node', () => {
 	test('Settings builds the expected component', () => {
 		const component = renderer.create(
@@ -52,6 +54,7 @@ describe('Question Bank Settings Editor Node', () => {
 			.find({ type: 'number' })
 			.simulate('click', { stopPropagation: jest.fn(), target: { value: 11 } })
 
+		jest.runAllTimers()
 		expect(editor.setNodeByKey).toHaveBeenCalledTimes(1)
 	})
 
@@ -82,6 +85,7 @@ describe('Question Bank Settings Editor Node', () => {
 			.find({ type: 'radio', value: 'pick' })
 			.simulate('change', { stopPropagation: jest.fn(), target: { value: 'pick' } })
 
+		jest.runAllTimers()
 		expect(nodeData).toEqual({
 			chooseAll: false,
 			choose: '99'
@@ -91,6 +95,7 @@ describe('Question Bank Settings Editor Node', () => {
 			.find({ type: 'number' })
 			.simulate('change', { stopPropagation: jest.fn(), target: { value: '99' } })
 
+		jest.runAllTimers()
 		expect(nodeData).toEqual({
 			chooseAll: false,
 			choose: '99'
@@ -124,6 +129,7 @@ describe('Question Bank Settings Editor Node', () => {
 			.find({ type: 'radio', value: 'all' })
 			.simulate('change', { stopPropagation: jest.fn(), target: { value: 'all' } })
 
+		jest.runAllTimers()
 		expect(nodeData).toEqual({
 			chooseAll: true,
 			choose: '1'
@@ -157,6 +163,7 @@ describe('Question Bank Settings Editor Node', () => {
 			.find({ type: 'number' })
 			.simulate('focus', { stopPropagation: jest.fn(), target: { value: '-100.5' } })
 
+		jest.runAllTimers()
 		expect(nodeData).toEqual({
 			chooseAll: false,
 			choose: '-100.5'
@@ -167,6 +174,7 @@ describe('Question Bank Settings Editor Node', () => {
 			.at(2)
 			.simulate('blur', { stopPropagation: jest.fn(), target: { value: '-100.5' } })
 
+		jest.runAllTimers()
 		expect(nodeData).toEqual({
 			chooseAll: false,
 			choose: '1'
@@ -189,7 +197,7 @@ describe('Question Bank Settings Editor Node', () => {
 	`(
 		'validateAndUpdateChooseAmount ensures choose value is valid ($choose => $correctedValue)',
 		({ choose, correctedValue }) => {
-			const mockSetNodeByKeyFn = jest.fn()
+			const mockSetState = jest.fn()
 
 			Settings.prototype.validateAndUpdateChooseAmount.bind(
 				{
@@ -199,24 +207,17 @@ describe('Question Bank Settings Editor Node', () => {
 								get: () => ({
 									choose
 								})
-							},
-							key: 'mock-id'
-						},
-						editor: {
-							setNodeByKey: mockSetNodeByKeyFn
+							}
 						}
-					}
+					},
+					setState: mockSetState
 				},
 				{ stopPropagation: jest.fn() }
 			)()
 
-			expect(mockSetNodeByKeyFn).toHaveBeenLastCalledWith('mock-id', {
-				data: {
-					content: {
-						choose: correctedValue
-					}
-				}
-			})
+			jest.runAllTimers()
+			expect(mockSetState).toHaveBeenCalledTimes(1)
+			expect(mockSetState).toHaveBeenCalledWith({ choose: correctedValue })
 		}
 	)
 
@@ -244,6 +245,7 @@ describe('Question Bank Settings Editor Node', () => {
 		select.simulate('click', { stopPropagation: jest.fn(), target: { value: 'random' } })
 		select.simulate('change', { stopPropagation: jest.fn(), target: { value: 'random' } })
 
+		jest.runAllTimers()
 		expect(editor.setNodeByKey).toHaveBeenCalledTimes(1)
 	})
 })

--- a/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.test.js
@@ -45,13 +45,11 @@ describe('Question Bank Settings Editor Node', () => {
 		)
 
 		component
-			.find('input')
-			.at(1)
+			.find({ type: 'radio', value: 'pick' })
 			.simulate('change', { stopPropagation: jest.fn(), target: { value: 'pick' } })
 
 		component
-			.find('input')
-			.at(2)
+			.find({ type: 'number' })
 			.simulate('click', { stopPropagation: jest.fn(), target: { value: 11 } })
 
 		expect(editor.setNodeByKey).toHaveBeenCalledTimes(1)
@@ -81,8 +79,7 @@ describe('Question Bank Settings Editor Node', () => {
 		)
 
 		component
-			.find('input')
-			.at(1)
+			.find({ type: 'radio', value: 'pick' })
 			.simulate('change', { stopPropagation: jest.fn(), target: { value: 'pick' } })
 
 		expect(nodeData).toEqual({
@@ -91,8 +88,7 @@ describe('Question Bank Settings Editor Node', () => {
 		})
 
 		component
-			.find('input')
-			.at(2)
+			.find({ type: 'number' })
 			.simulate('change', { stopPropagation: jest.fn(), target: { value: '99' } })
 
 		expect(nodeData).toEqual({
@@ -125,8 +121,7 @@ describe('Question Bank Settings Editor Node', () => {
 		)
 
 		component
-			.find('input')
-			.at(0)
+			.find({ type: 'radio', value: 'all' })
 			.simulate('change', { stopPropagation: jest.fn(), target: { value: 'all' } })
 
 		expect(nodeData).toEqual({
@@ -159,8 +154,7 @@ describe('Question Bank Settings Editor Node', () => {
 		)
 
 		component
-			.find('input')
-			.at(2)
+			.find({ type: 'number' })
 			.simulate('focus', { stopPropagation: jest.fn(), target: { value: '-100.5' } })
 
 		expect(nodeData).toEqual({
@@ -245,14 +239,10 @@ describe('Question Bank Settings Editor Node', () => {
 			/>
 		)
 
-		component
-			.find('select')
-			.at(0)
-			.simulate('click', { stopPropagation: jest.fn(), target: { value: 'random' } })
-		component
-			.find('select')
-			.at(0)
-			.simulate('change', { stopPropagation: jest.fn(), target: { value: 'random' } })
+		const select = component.find('select').at(0)
+
+		select.simulate('click', { stopPropagation: jest.fn(), target: { value: 'random' } })
+		select.simulate('change', { stopPropagation: jest.fn(), target: { value: 'random' } })
 
 		expect(editor.setNodeByKey).toHaveBeenCalledTimes(1)
 	})

--- a/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-question-bank/components/settings/editor-component.test.js
@@ -4,11 +4,12 @@ import renderer from 'react-test-renderer'
 
 import Settings from './editor-component'
 
-describe('Settings Editor Node', () => {
+describe('Question Bank Settings Editor Node', () => {
 	test('Settings builds the expected component', () => {
 		const component = renderer.create(
 			<Settings
 				node={{
+					key: 'mock-id',
 					data: {
 						get: () => {
 							return {}
@@ -30,6 +31,7 @@ describe('Settings Editor Node', () => {
 		const component = mount(
 			<Settings
 				node={{
+					key: 'mock-id',
 					data: {
 						get: () => {
 							return { chooseAll: false }
@@ -66,6 +68,7 @@ describe('Settings Editor Node', () => {
 			<Settings
 				node={{
 					data: {
+						key: 'mock-id',
 						get: () => {
 							return { chooseAll: false }
 						}

--- a/packages/obonode/obojobo-chunks-question-bank/converter.js
+++ b/packages/obonode/obojobo-chunks-question-bank/converter.js
@@ -19,8 +19,14 @@ const slateToObo = node => {
 				break
 
 			case SETTINGS_NODE:
-				content = child.data.get('content') || {}
-				if (content.chooseAll) content.choose = Infinity
+				content = { ...(child.data.get('content') || {}) }
+
+				if (content.chooseAll) {
+					content.choose = 'all'
+				} else if (!Number.isFinite(parseInt(content.choose, 10))) {
+					content.choose = '1'
+				}
+				delete content.chooseAll
 				break
 		}
 	})
@@ -37,7 +43,7 @@ const oboToSlate = node => {
 	const chooseAll = !Number.isFinite(parseInt(node.content.choose, 10))
 	const data = { content: { ...node.content, chooseAll } }
 
-	if (chooseAll) data.content.choose = 1
+	if (chooseAll) data.content.choose = '1'
 
 	const nodes = [
 		{

--- a/packages/obonode/obojobo-chunks-question-bank/converter.test.js
+++ b/packages/obonode/obojobo-chunks-question-bank/converter.test.js
@@ -38,7 +38,7 @@ describe('QuestionBank converter', () => {
 				{
 					type: SETTINGS_NODE,
 					data: {
-						get: () => ({ chooseAll: true })
+						get: () => ({ chooseAll: true, choose: '100' })
 					}
 				}
 			]
@@ -89,7 +89,7 @@ describe('QuestionBank converter', () => {
 				{
 					type: QUESTION_BANK_NODE,
 					id: 'mockKey',
-					content: { choose: 1 },
+					content: { choose: '1' },
 					children: [
 						{
 							type: 'mockQuestionNode'
@@ -104,5 +104,141 @@ describe('QuestionBank converter', () => {
 		const slateNode = Converter.oboToSlate(oboNode)
 
 		expect(slateNode).toMatchSnapshot()
+	})
+
+	test('slateToObo sets "choose" to "all" if chooseAll is true', () => {
+		const slateNode = {
+			key: 'mockKey',
+			type: 'mockType',
+			data: {
+				get: () => null
+			},
+			nodes: [
+				{
+					type: QUESTION_BANK_NODE,
+					key: 'mockKey',
+					data: {
+						get: () => null
+					},
+					nodes: []
+				},
+				{
+					type: QUESTION_NODE
+				},
+				{
+					type: SETTINGS_NODE,
+					data: {
+						get: () => ({ chooseAll: true, choose: '99' })
+					}
+				}
+			]
+		}
+		const oboNode = Converter.slateToObo(slateNode)
+
+		expect(oboNode.content).toEqual({
+			choose: 'all'
+		})
+	})
+
+	test('slateToObo sets "choose" to "1" if choose is an invalid value', () => {
+		const slateNode = {
+			key: 'mockKey',
+			type: 'mockType',
+			data: {
+				get: () => null
+			},
+			nodes: [
+				{
+					type: QUESTION_BANK_NODE,
+					key: 'mockKey',
+					data: {
+						get: () => null
+					},
+					nodes: []
+				},
+				{
+					type: QUESTION_NODE
+				},
+				{
+					type: SETTINGS_NODE,
+					data: {
+						get: () => ({ choose: 'some-value', chooseAll: false })
+					}
+				}
+			]
+		}
+		const oboNode = Converter.slateToObo(slateNode)
+
+		expect(oboNode.content).toEqual({
+			choose: '1'
+		})
+	})
+
+	test('slateToObo sets "choose" to value if chooseAll is false', () => {
+		const slateNode = {
+			key: 'mockKey',
+			type: 'mockType',
+			data: {
+				get: () => null
+			},
+			nodes: [
+				{
+					type: QUESTION_BANK_NODE,
+					key: 'mockKey',
+					data: {
+						get: () => null
+					},
+					nodes: []
+				},
+				{
+					type: QUESTION_NODE
+				},
+				{
+					type: SETTINGS_NODE,
+					data: {
+						get: () => ({ choose: '99', chooseAll: false })
+					}
+				}
+			]
+		}
+		const oboNode = Converter.slateToObo(slateNode)
+
+		expect(oboNode.content).toEqual({
+			choose: '99'
+		})
+	})
+
+	test('slateToObo sets "choose" to "1" if no content data exists', () => {
+		const slateNode = {
+			key: 'mockKey',
+			type: 'mockType',
+			data: {
+				get: () => null
+			},
+			nodes: [
+				{
+					type: QUESTION_BANK_NODE,
+					key: 'mockKey',
+					data: {
+						get: () => null
+					},
+					nodes: []
+				},
+				{
+					type: QUESTION_NODE
+				},
+				{
+					type: SETTINGS_NODE,
+					data: {
+						get: () => null
+					}
+				}
+			]
+		}
+		const oboNode = Converter.slateToObo(slateNode)
+
+		expect(oboNode.content).toEqual({
+			choose: '1'
+		})
 	})
 })

--- a/packages/obonode/obojobo-chunks-question-bank/empty-node.json
+++ b/packages/obonode/obojobo-chunks-question-bank/empty-node.json
@@ -10,86 +10,84 @@
 	},
 	"nodes": [
 		{
-			"object":"block",
-			"type":"ObojoboDraft.Chunks.QuestionBank.Settings",
-			"isVoid":true,
-			"data":{
+			"object": "block",
+			"type": "ObojoboDraft.Chunks.QuestionBank.Settings",
+			"isVoid": true,
+			"data": {
 				"content": {
-					"chooseAll":true,
-					"choose":"all",
-					"select":"sequential"
+					"chooseAll": true,
+					"choose": "1",
+					"select": "sequential"
 				}
 			}
 		},
 		{
-			"object":"block",
-			"type":"ObojoboDraft.Chunks.Question",
-			"isVoid":false,
+			"object": "block",
+			"type": "ObojoboDraft.Chunks.Question",
+			"isVoid": false,
 			"data": {
 				"content": {
 					"type": "default"
 				}
 			},
-			"nodes":[
+			"nodes": [
 				{
-					"object":"block",
-					"type":"ObojoboDraft.Chunks.Text",
-					"isVoid":false,
-					"data":{"content":{"indent":0}},
-					"nodes":[
+					"object": "block",
+					"type": "ObojoboDraft.Chunks.Text",
+					"isVoid": false,
+					"data": { "content": { "indent": 0 } },
+					"nodes": [
 						{
-							"object":"block",
-							"type":"ObojoboDraft.Chunks.Text.TextLine",
-							"isVoid":false,
-							"data":{"indent":0},
-							"nodes":[
+							"object": "block",
+							"type": "ObojoboDraft.Chunks.Text.TextLine",
+							"isVoid": false,
+							"data": { "indent": 0 },
+							"nodes": [
 								{
-									"object":"text",
-									"leaves":[
-										{"object":"leaf","text":"","marks":[]}
-									]
+									"object": "text",
+									"leaves": [{ "object": "leaf", "text": "", "marks": [] }]
 								}
 							]
 						}
 					]
 				},
 				{
-					"object":"block",
-					"type":"ObojoboDraft.Chunks.MCAssessment",
-					"isVoid":false,
-					"data":{"content":{"responseType":"pick-one","shuffle":true}},
-					"nodes":[
+					"object": "block",
+					"type": "ObojoboDraft.Chunks.MCAssessment",
+					"isVoid": false,
+					"data": { "content": { "responseType": "pick-one", "shuffle": true } },
+					"nodes": [
 						{
-							"object":"block",
-							"type":"ObojoboDraft.Chunks.MCAssessment.MCChoice",
-							"isVoid":false,
-							"data":{"content":{"score":100}},
-							"nodes":[
+							"object": "block",
+							"type": "ObojoboDraft.Chunks.MCAssessment.MCChoice",
+							"isVoid": false,
+							"data": { "content": { "score": 100 } },
+							"nodes": [
 								{
-									"object":"block",
-									"type":"ObojoboDraft.Chunks.MCAssessment.MCAnswer",
-									"isVoid":false,
-									"data":{},
-									"nodes":[
+									"object": "block",
+									"type": "ObojoboDraft.Chunks.MCAssessment.MCAnswer",
+									"isVoid": false,
+									"data": {},
+									"nodes": [
 										{
-											"object":"block",
-											"type":"ObojoboDraft.Chunks.Text",
-											"isVoid":false,
-											"data":{"content":{"indent":0}},
-											"nodes":[
+											"object": "block",
+											"type": "ObojoboDraft.Chunks.Text",
+											"isVoid": false,
+											"data": { "content": { "indent": 0 } },
+											"nodes": [
 												{
-													"object":"block",
-													"type":"ObojoboDraft.Chunks.Text.TextLine",
-													"isVoid":false,
-													"data":{"indent":0},
-													"nodes":[
+													"object": "block",
+													"type": "ObojoboDraft.Chunks.Text.TextLine",
+													"isVoid": false,
+													"data": { "indent": 0 },
+													"nodes": [
 														{
-															"object":"text",
-															"leaves":[
+															"object": "text",
+															"leaves": [
 																{
-																	"object":"leaf",
-																	"text":"",
-																	"marks":[]
+																	"object": "leaf",
+																	"text": "",
+																	"marks": []
 																}
 															]
 														}
@@ -102,36 +100,36 @@
 							]
 						},
 						{
-							"object":"block",
-							"type":"ObojoboDraft.Chunks.MCAssessment.MCChoice",
-							"isVoid":false,
-							"data":{"content":{"score":0}},
-							"nodes":[
+							"object": "block",
+							"type": "ObojoboDraft.Chunks.MCAssessment.MCChoice",
+							"isVoid": false,
+							"data": { "content": { "score": 0 } },
+							"nodes": [
 								{
-									"object":"block",
-									"type":"ObojoboDraft.Chunks.MCAssessment.MCAnswer",
-									"isVoid":false,
-									"data":{},
-									"nodes":[
+									"object": "block",
+									"type": "ObojoboDraft.Chunks.MCAssessment.MCAnswer",
+									"isVoid": false,
+									"data": {},
+									"nodes": [
 										{
-											"object":"block",
-											"type":"ObojoboDraft.Chunks.Text",
-											"isVoid":false,
-											"data":{"content":{"indent":0}},
-											"nodes":[
+											"object": "block",
+											"type": "ObojoboDraft.Chunks.Text",
+											"isVoid": false,
+											"data": { "content": { "indent": 0 } },
+											"nodes": [
 												{
-													"object":"block",
-													"type":"ObojoboDraft.Chunks.Text.TextLine",
-													"isVoid":false,
-													"data":{"indent":0},
-													"nodes":[
+													"object": "block",
+													"type": "ObojoboDraft.Chunks.Text.TextLine",
+													"isVoid": false,
+													"data": { "indent": 0 },
+													"nodes": [
 														{
-															"object":"text",
-															"leaves":[
+															"object": "text",
+															"leaves": [
 																{
-																	"object":"leaf",
-																	"text":"",
-																	"marks":[]
+																	"object": "leaf",
+																	"text": "",
+																	"marks": []
 																}
 															]
 														}

--- a/packages/obonode/obojobo-chunks-question-bank/schema.js
+++ b/packages/obonode/obojobo-chunks-question-bank/schema.js
@@ -24,7 +24,7 @@ const schema = {
 								type: SETTINGS_NODE,
 								data: {
 									content: {
-										choose: 'all',
+										choose: '1',
 										chooseAll: true,
 										select: 'sequential'
 									}
@@ -42,7 +42,7 @@ const schema = {
 								type: SETTINGS_NODE,
 								data: {
 									content: {
-										choose: 'all',
+										choose: '1',
 										chooseAll: true,
 										select: 'sequential'
 									}


### PR DESCRIPTION
* adds question bank id to editor setting radio button input name

The radio buttons for question bank's settings in the editor
all shared the same name. Selecting any of the radio buttons
would cause all other question bank radio input buttons to deselect.
This fix uses the question bank's id to differentiate it from others.