### PR TITLE
Fixes issues when clicking on Break nodes or text placeholders causing annoying behavior

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.scss
@@ -11,6 +11,8 @@
 		border: 2px dotted $color-shadow;
 		width: 0.1em;
 		user-select: none;
+		background: $color-bg;
+		outline: 2px solid $color-bg; //stylelint-disable unit-blacklist
 
 		.top {
 			top: 0;
@@ -35,9 +37,10 @@
 		position: absolute;
 		right: -2em;
 		top: 0;
-		border: none;
-		background: none;
 		padding: 0;
+		background: $color-bg;
+		border: 2px solid $color-bg;
+		border-radius: 100%;
 		cursor: pointer;
 	}
 }

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.scss
@@ -42,5 +42,9 @@
 		border: 2px solid $color-bg;
 		border-radius: 100%;
 		cursor: pointer;
+
+		> svg {
+			pointer-events: none;
+		}
 	}
 }

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/page-editor.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/page-editor.scss
@@ -27,6 +27,8 @@
 	}
 
 	span[data-placeholder] {
+		pointer-events: none;
+
 		&.required::before {
 			content: attr(data-placeholder);
 			opacity: 0.5;

--- a/packages/obonode/obojobo-chunks-break/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-break/__snapshots__/editor-component.test.js.snap
@@ -4,12 +4,20 @@ exports[`Break Editor Node Node builds the expected component 1`] = `
 <div>
   <div
     className="non-editable-chunk obojobo-draft--chunks--break viewer width-undefined"
+    contentEditable={false}
   >
-    <hr />
+    <div
+      className="ghost"
+      contentEditable={true}
+      suppressContentEditableWarning={true}
+    />
+    <hr
+      contentEditable={false}
+    />
   </div>
 </div>
 `;
 
-exports[`Break Editor Node Node component toggles size to large 1`] = `"<div><div class=\\"non-editable-chunk obojobo-draft--chunks--break viewer width-normal\\"><hr><div class=\\"buttonbox-box\\" contenteditable=\\"false\\"><div class=\\"box-border\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center toggle-size\\"><button class=\\"button\\" contenteditable=\\"false\\">Toggle Size</button></div></div></div></div></div>"`;
+exports[`Break Editor Node Node component toggles size to large 1`] = `"<div><div contenteditable=\\"false\\" class=\\"non-editable-chunk obojobo-draft--chunks--break viewer width-normal\\"><div contenteditable=\\"true\\" class=\\"ghost\\"></div><hr contenteditable=\\"false\\"><div class=\\"buttonbox-box\\"><div class=\\"box-border\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center toggle-size\\"><button class=\\"button\\" contenteditable=\\"false\\">Toggle Size</button></div></div></div></div></div>"`;
 
-exports[`Break Editor Node Node component toggles size to normal 1`] = `"<div><div class=\\"non-editable-chunk obojobo-draft--chunks--break viewer width-large\\"><hr><div class=\\"buttonbox-box\\" contenteditable=\\"false\\"><div class=\\"box-border\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center toggle-size\\"><button class=\\"button\\" contenteditable=\\"false\\">Toggle Size</button></div></div></div></div></div>"`;
+exports[`Break Editor Node Node component toggles size to normal 1`] = `"<div><div contenteditable=\\"false\\" class=\\"non-editable-chunk obojobo-draft--chunks--break viewer width-large\\"><div contenteditable=\\"true\\" class=\\"ghost\\"></div><hr contenteditable=\\"false\\"><div class=\\"buttonbox-box\\"><div class=\\"box-border\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center toggle-size\\"><button class=\\"button\\" contenteditable=\\"false\\">Toggle Size</button></div></div></div></div></div>"`;

--- a/packages/obonode/obojobo-chunks-break/editor-component.js
+++ b/packages/obonode/obojobo-chunks-break/editor-component.js
@@ -8,7 +8,9 @@ import Node from 'obojobo-document-engine/src/scripts/oboeditor/components/node/
 const { Button } = Common.components
 
 class Break extends React.Component {
-	toggleSize() {
+	toggleSize(event) {
+		event.stopPropagation()
+
 		const editor = this.props.editor
 		const content = this.props.node.data.get('content')
 
@@ -22,7 +24,7 @@ class Break extends React.Component {
 
 	renderButton() {
 		return (
-			<div className="buttonbox-box" contentEditable={false}>
+			<div className="buttonbox-box">
 				<div className="box-border">
 					<Button className="toggle-size" onClick={this.toggleSize.bind(this)}>
 						Toggle Size
@@ -36,11 +38,15 @@ class Break extends React.Component {
 		return (
 			<Node {...this.props}>
 				<div
+					contentEditable={false}
 					className={`non-editable-chunk obojobo-draft--chunks--break viewer width-${
 						this.props.node.data.get('content').width
 					}`}
 				>
-					<hr />
+					<div contentEditable={true} suppressContentEditableWarning className="ghost">
+						{this.props.children}
+					</div>
+					<hr contentEditable={false} />
 					{this.props.isSelected ? this.renderButton() : null}
 				</div>
 			</Node>

--- a/packages/obonode/obojobo-chunks-break/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-break/editor-component.scss
@@ -6,7 +6,7 @@ div.non-editable-chunk.obojobo-draft--chunks--break.viewer {
 
 	&.width-large {
 		hr {
-			width: 80%;
+			width: 100%;
 		}
 	}
 
@@ -51,6 +51,23 @@ div.non-editable-chunk.obojobo-draft--chunks--break.viewer {
 			position: relative;
 			z-index: 1;
 			font-size: 1.2em;
+		}
+	}
+
+	.ghost {
+		position: absolute;
+		left: 0;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		opacity: 0;
+		overflow: hidden;
+		color: $color-transparent;
+		text-shadow: 0 0 0 $color-bg;
+
+		* {
+			color: $color-transparent;
+			text-shadow: 0 0 0 $color-bg;
 		}
 	}
 }

--- a/packages/obonode/obojobo-chunks-break/editor-registration.test.js
+++ b/packages/obonode/obojobo-chunks-break/editor-registration.test.js
@@ -33,4 +33,72 @@ describe('Break editor', () => {
 		expect(Break.plugins.renderNode(props, null, next)).toMatchSnapshot()
 		expect(next).toHaveBeenCalled()
 	})
+
+	test('plugins.onBeforeInput calls next for non-break nodes', () => {
+		const next = jest.fn()
+		const event = {
+			preventDefault: jest.fn()
+		}
+		const editor = {
+			value: {
+				blocks: {
+					some: fn => fn({ type: 'not-break-node' })
+				}
+			}
+		}
+
+		Break.plugins.onBeforeInput(event, editor, next)
+		expect(next).toHaveBeenCalled()
+		expect(event.preventDefault).not.toHaveBeenCalled()
+	})
+
+	test('plugins.onBeforeInput calls prevent default for break nodes', () => {
+		const next = jest.fn()
+		const event = {
+			preventDefault: jest.fn()
+		}
+		const editor = {
+			value: {
+				blocks: {
+					some: fn => fn({ type: BREAK_NODE })
+				}
+			}
+		}
+
+		Break.plugins.onBeforeInput(event, editor, next)
+		expect(next).toHaveBeenCalled()
+		expect(event.preventDefault).toHaveBeenCalled()
+	})
+
+	test('plugins.onPaste calls next for non-break nodes', () => {
+		const next = jest.fn()
+		const editor = {
+			value: {
+				blocks: {
+					some: fn => fn({ type: 'not-break-node' })
+				}
+			},
+			undo: jest.fn()
+		}
+
+		Break.plugins.onPaste(null, editor, next)
+		expect(next).toHaveBeenCalled()
+		expect(editor.undo).not.toHaveBeenCalled()
+	})
+
+	test('plugins.onPaste calls next for non-break nodes', () => {
+		const next = jest.fn()
+		const editor = {
+			value: {
+				blocks: {
+					some: fn => fn({ type: BREAK_NODE })
+				}
+			},
+			undo: jest.fn()
+		}
+
+		Break.plugins.onPaste(null, editor, next)
+		expect(next).toHaveBeenCalled()
+		expect(editor.undo).toHaveBeenCalled()
+	})
 })

--- a/packages/obonode/obojobo-chunks-break/empty-node.json
+++ b/packages/obonode/obojobo-chunks-break/empty-node.json
@@ -1,8 +1,14 @@
 {
-	"object":"block",
-	"type":"ObojoboDraft.Chunks.Break",
-	"isVoid":true,
-	"data":{
+	"object": "block",
+	"type": "ObojoboDraft.Chunks.Break",
+	"isVoid": false,
+	"data": {
 		"content": { "width": "normal" }
-	}
+	},
+	"nodes": [
+		{
+			"object": "text",
+			"leaves": [{ "object": "leaf", "text": "", "marks": [] }]
+		}
+	]
 }

--- a/packages/obonode/obojobo-chunks-break/schema.js
+++ b/packages/obonode/obojobo-chunks-break/schema.js
@@ -1,7 +1,13 @@
 const schema = {
 	blocks: {
 		'ObojoboDraft.Chunks.Break': {
-			isVoid: true
+			nodes: [
+				{
+					match: [{ object: 'text' }],
+					min: 1,
+					max: 1
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
* Fixed an issue where placeholders ("Type your text here") were blocking users from being able to click on the document in FF
* Turned Break into a non-void node with a 'ghost' text element, preventing an issue where clicking or focusing in on the break node would cause the scroll to jump to a random area of the page
* Fixed the same issue when clicking on the button to toggle the size of the break
* Updated the styling of the break in the editor when full size to match the way it displays in the editor
* Added white borders around the insert menu dotted line and more info buttons so that elements that intersect it have some visual padding