### PR TITLE
Strips empty `mods` in json-to-xml-parser but still allows it to be saved

### DIFF
--- a/packages/app/obojobo-document-json-parser/src/parsers/assessment-node-parser.js
+++ b/packages/app/obojobo-document-json-parser/src/parsers/assessment-node-parser.js
@@ -43,7 +43,7 @@ const rubricParser = rubric => {
 			modsBodyXML += `<mod${attrs} />`
 		})
 
-		modsXML = `<mods>` + modsBodyXML + `</mods>`
+		modsXML = !modsBodyXML ? '' : `<mods>` + modsBodyXML + `</mods>`
 	}
 
 	const attrs = processAttrs(rubric, ['mods'])

--- a/packages/app/obojobo-document-xml-parser/src/assessment-rubric-parser.js
+++ b/packages/app/obojobo-document-xml-parser/src/assessment-rubric-parser.js
@@ -1,6 +1,11 @@
 let parseRubric = el => {
 	let mods = []
-	if (el.elements && el.elements[0] && el.elements[0].name === 'mods') {
+	if (
+		el.elements &&
+		el.elements[0] &&
+		el.elements[0].name === 'mods' &&
+		Array.isArray(el.elements[0].value)
+	) {
 		mods = el.elements[0].value.map(child => parseMod(child))
 	}
 


### PR DESCRIPTION

Overview: 
1. Prevent an empty mods array from being put into XML so the XML is consistent
2. Allow the empty mods array to be valid

Resolve: #1072 