### PR TITLE
[clean] removes /api/drafts/:draft/raw route

### DIFF
--- a/packages/app/obojobo-express/__tests__/routes/api/drafts.test.js
+++ b/packages/app/obojobo-express/__tests__/routes/api/drafts.test.js
@@ -717,18 +717,4 @@ describe('api draft route', () => {
 				expect(response.body.value).toHaveProperty('type', 'unexpected')
 			})
 	})
-
-	test('raw draft queries the db', () => {
-		expect.hasAssertions()
-		db.one.mockResolvedValueOnce('mock-db-result')
-		mockCurrentUser = { id: 99, canViewEditor: true } // mock current logged in user
-		return request(app)
-			.get('/api/drafts/00000000-0000-0000-0000-000000000000/raw')
-			.then(response => {
-				expect(response.header['content-type']).toContain('application/json')
-				expect(response.statusCode).toBe(200)
-				expect(response.body).toHaveProperty('status', 'ok')
-				expect(response.body).toHaveProperty('value', 'mock-db-result')
-			})
-	})
 })

--- a/packages/app/obojobo-express/routes/api/drafts.js
+++ b/packages/app/obojobo-express/routes/api/drafts.js
@@ -3,7 +3,6 @@ const fs = require('fs')
 const router = express.Router()
 const DraftModel = oboRequire('models/draft')
 const logger = oboRequire('logger')
-const db = oboRequire('db')
 const pgp = require('pg-promise')
 const xmlToDraftObject = require('obojobo-document-xml-parser/xml-to-draft-object')
 const emptyXmlPath = require.resolve('obojobo-document-engine/documents/empty.xml')
@@ -63,36 +62,6 @@ router
 
 			res.unexpected(e)
 		}
-	})
-
-// Get a raw draft record from the database
-// mounted as /api/drafts/:draftId/raw
-router
-	.route('/:draftId/raw')
-	.get([requireDraftId, requireCanViewEditor, checkValidationRules])
-	.get((req, res) => {
-		return db
-			.one(
-				`
-			SELECT
-				drafts.id AS id,
-				drafts.user_id as author,
-				drafts_content.id AS version,
-				drafts.created_at AS draft_created_at,
-				drafts_content.created_at AS content_created_at,
-				drafts_content.content AS content,
-				drafts_content.xml AS xml
-			FROM drafts
-			JOIN drafts_content
-				ON drafts.id = drafts_content.draft_id
-			WHERE drafts.id = $[id]
-				AND deleted = FALSE
-			ORDER BY content_created_at DESC
-			LIMIT 1
-			`,
-				{ id: req.params.draftId }
-			)
-			.then(res.success)
 	})
 
 // Get a Draft Document Tree (for viewing by a student)


### PR DESCRIPTION
I believe this route was used by the old editor. It needed some
permission restrictions added if we kept it, but nothing in the app
uses it now - so I suggest we just remove it now.

I'm not sure if this should be dev 8 or dev 9? @zachberry?

Fixes #1033 