### PR TITLE
Fix save problems on visual/xml/json editor

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/code-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/code-editor.test.js
@@ -6,6 +6,7 @@ import APIUtil from 'src/scripts/viewer/util/api-util'
 import EditorUtil from 'src/scripts/oboeditor/util/editor-util'
 
 const mockClickFn = jest.fn().mockImplementation((a, b, c) => c())
+
 jest.mock('src/scripts/viewer/util/api-util')
 jest.mock('src/scripts/oboeditor/util/editor-util')
 jest.mock('react-codemirror2', () => ({
@@ -194,6 +195,10 @@ describe('CodeEditor', () => {
 	})
 
 	test('saveCode calls APIUtil', () => {
+		APIUtil.postDraft.mockResolvedValue({
+			status: 'ok'
+		})
+
 		const props = {
 			initialCode: '',
 			mode: XML_MODE,
@@ -207,6 +212,25 @@ describe('CodeEditor', () => {
 		component.instance().saveCode()
 
 		expect(APIUtil.postDraft).toHaveBeenCalledTimes(2)
+	})
+
+	test('saveCode() with invalid document', () => {
+		APIUtil.postDraft.mockResolvedValue({
+			status: 'error',
+			value: {
+				message: 'mock_message'
+			}
+		})
+
+		const props = {
+			initialCode: '',
+			mode: XML_MODE,
+			model: { title: 'Mock Title' }
+		}
+		const component = mount(<CodeEditor {...props} />)
+		component.instance().saveCode()
+
+		expect(APIUtil.postDraft).toHaveBeenCalledTimes(1)
 	})
 
 	test('setEditor changes state', () => {

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/file-menu.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/file-menu.test.js
@@ -274,6 +274,20 @@ describe('File Menu', () => {
 		expect(EditorUtil.renamePage).toHaveBeenCalled()
 	})
 
+	test('renameAndSaveModule renames and saves draft', () => {
+		APIUtil.getAllDrafts.mockResolvedValueOnce({
+			value: [{ draftId: 'mockDraft' }, { draftId: 'otherDraft' }]
+		})
+		const onSave = jest.fn()
+
+		const component = mount(<FileMenu draftId="mockDraft" onSave={onSave} />)
+
+		component.instance().renameAndSaveModule('mockId', 'mock title')
+
+		expect(EditorUtil.renamePage).toHaveBeenCalled()
+		expect(onSave).toHaveBeenCalled()
+	})
+
 	test('copyModule creates a copy of the current draft', () => {
 		APIUtil.getAllDrafts.mockResolvedValueOnce({
 			value: [{ draftId: 'mockDraft' }, { draftId: 'otherDraft' }]

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/view-menu.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/view-menu.test.js
@@ -14,7 +14,9 @@ describe('ViewMenu', () => {
 	})
 
 	test('ViewMenu node in XML_MODE', () => {
-		const save = jest.fn()
+		const save = () => ({
+			then: func => func()
+		})
 		const switchMode = jest.fn()
 
 		const component = mount(
@@ -29,7 +31,9 @@ describe('ViewMenu', () => {
 	})
 
 	test('ViewMenu performs actions', () => {
-		const save = jest.fn()
+		const save = () => ({
+			then: func => func()
+		})
 		const switchMode = jest.fn()
 
 		const component = mount(

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
@@ -12,10 +12,12 @@ import 'codemirror/addon/fold/foldgutter.css'
 import 'codemirror/addon/fold/xml-fold.js'
 import { Controlled as CodeMirror } from 'react-codemirror2'
 
-import APIUtil from 'obojobo-document-engine/src/scripts/viewer/util/api-util'
-import EditorUtil from 'obojobo-document-engine/src/scripts/oboeditor/util/editor-util'
+import APIUtil from '../../../scripts/viewer/util/api-util'
+import EditorUtil from '../../../scripts/oboeditor/util/editor-util'
 import FileToolbar from './toolbars/file-toolbar'
 import hotKeyPlugin from '../plugins/hot-key-plugin'
+import ModalUtil from '../../common/util/modal-util'
+import SimpleDialog from '../../common/components/modal/simple-dialog'
 
 const XML_MODE = 'xml'
 const JSON_MODE = 'json'
@@ -117,13 +119,17 @@ class CodeEditor extends React.Component {
 		if (!label || !/[^\s]/.test(label)) label = '(Unnamed Module)'
 		EditorUtil.renamePage(this.props.model.id, label)
 
-		this.setState({ saved: true })
-
 		return APIUtil.postDraft(
 			this.props.draftId,
 			this.state.code,
 			this.props.mode === XML_MODE ? 'text/plain' : 'application/json'
-		)
+		).then(result => {
+			if (result.status !== 'ok') {
+				ModalUtil.show(<SimpleDialog ok title={'Error: ' + result.value.message} />)
+			} else {
+				this.setState({ saved: true })
+			}
+		})
 	}
 
 	// Makes CodeMirror commands match Slate commands

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-menu.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-menu.js
@@ -26,6 +26,11 @@ class FileMenu extends React.PureComponent {
 		}
 	}
 
+	renameAndSaveModule(moduleId, label) {
+		this.renameModule(moduleId, label)
+		this.props.onSave(this.props.draftId)
+	}
+
 	deleteModule() {
 		return APIUtil.deleteDraft(this.props.draftId).then(result => {
 			if (result.status === 'ok') {
@@ -78,12 +83,7 @@ class FileMenu extends React.PureComponent {
 			{
 				name: 'Save',
 				type: 'action',
-				action: () =>
-					this.props.onSave(this.props.draftId).then(result => {
-						if (result.status !== 'ok') {
-							ModalUtil.show(<SimpleDialog ok title={'Error: ' + result.value.message} />)
-						}
-					})
+				action: () => this.props.onSave(this.props.draftId)
 			},
 			{
 				name: 'New',
@@ -136,7 +136,7 @@ class FileMenu extends React.PureComponent {
 							title="Rename Module"
 							message="Enter the new title for the module:"
 							value={this.props.model.title}
-							onConfirm={this.renameModule.bind(this, this.props.model.id)}
+							onConfirm={this.renameAndSaveModule.bind(this, this.props.model.id)}
 						/>
 					)
 			},

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/view-menu.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/view-menu.js
@@ -22,8 +22,9 @@ class ViewMenu extends React.PureComponent {
 						name: 'JSON Editor',
 						type: 'action',
 						action: () => {
-							this.props.onSave(this.props.draftId)
-							this.props.switchMode(JSON_MODE)
+							this.props.onSave(this.props.draftId).then(() => {
+								this.props.switchMode(JSON_MODE)
+							})
 						},
 						disabled: this.props.mode === JSON_MODE
 					},
@@ -31,8 +32,9 @@ class ViewMenu extends React.PureComponent {
 						name: 'XML Editor',
 						type: 'action',
 						action: () => {
-							this.props.onSave(this.props.draftId)
-							this.props.switchMode(XML_MODE)
+							this.props.onSave(this.props.draftId).then(() => {
+								this.props.switchMode(XML_MODE)
+							})
 						},
 						disabled: this.props.mode === XML_MODE
 					},
@@ -40,8 +42,9 @@ class ViewMenu extends React.PureComponent {
 						name: 'Visual Editor',
 						type: 'action',
 						action: () => {
-							this.props.onSave(this.props.draftId)
-							this.props.switchMode(VISUAL_MODE)
+							this.props.onSave(this.props.draftId).then(() => {
+								this.props.switchMode(VISUAL_MODE)
+							})
 						},
 						disabled: this.props.mode === VISUAL_MODE
 					}


### PR DESCRIPTION
Overview:
1. `File` -> `Rename` -> `OK`: This will rename and save the draft
2. Fixed problem draft does not save when switching between XML, JSON, and Visual editor.
3. Fixed problem on when `cmd/ctrl+s` does not prompt error to the user.

Resolve: #1070 