### PR TITLE
Add promise rejection for save function

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
@@ -123,13 +123,17 @@ class CodeEditor extends React.Component {
 			this.props.draftId,
 			this.state.code,
 			this.props.mode === XML_MODE ? 'text/plain' : 'application/json'
-		).then(result => {
-			if (result.status !== 'ok') {
-				ModalUtil.show(<SimpleDialog ok title={'Error: ' + result.value.message} />)
-			} else {
-				this.setState({ saved: true })
-			}
-		})
+		)
+			.then(result => {
+				if (result.status !== 'ok') {
+					ModalUtil.show(<SimpleDialog ok title={'Error: ' + result.value.message} />)
+				} else {
+					this.setState({ saved: true })
+				}
+			})
+			.catch(e => {
+				ModalUtil.show(<SimpleDialog ok title={'Error: ' + e} />)
+			})
 	}
 
 	// Makes CodeMirror commands match Slate commands


### PR DESCRIPTION
XML/JSON editor save feature does not handle Promise rejection.
The user does not know when rejection occurs.

Fix: #1082 
Relate: #1070