### PR TITLE
Creating a new module in xml/json editor causes 404

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-menu.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-menu.js
@@ -50,7 +50,7 @@ class FileMenu extends React.PureComponent {
 				return this.props.onSave(draftId)
 			})
 			.then(() => {
-				window.open(window.location.origin + '/editor/' + this.props.mode + '/' + draftId, '_blank')
+				window.open(window.location.origin + '/editor/visual/' + draftId, '_blank')
 			})
 	}
 
@@ -91,10 +91,7 @@ class FileMenu extends React.PureComponent {
 				action: () =>
 					APIUtil.createNewDraft().then(result => {
 						if (result.status === 'ok') {
-							window.open(
-								window.location.origin + '/editor/' + this.props.mode + '/' + result.value.id,
-								'_blank'
-							)
+							window.open(window.location.origin + '/editor/visual/' + result.value.id, '_blank')
 						}
 					})
 			},


### PR DESCRIPTION
When creating a new module in XML editor, the new module is launched into `/editor/xml/8a51d...`
Change `xml` to `visual` fixes the problem.

Resolve: #1059 
Fix the same problem for `Make a copy`