### PR TITLE
[optimize] uses db.taskIf for multi-query functions

### DIFF
--- a/packages/app/obojobo-document-engine/__mocks__/db.js
+++ b/packages/app/obojobo-document-engine/__mocks__/db.js
@@ -21,4 +21,7 @@ db.tx.mockImplementation(cb => cb(db))
 db.batch = jest.fn()
 db.batch.mockImplementation(queries => Promise.all(queries))
 
+db.taskIf = jest.fn()
+db.taskIf.mockImplementation(cb => cb(db))
+
 module.exports = db

--- a/packages/app/obojobo-express/__tests__/insert_event.test.js
+++ b/packages/app/obojobo-express/__tests__/insert_event.test.js
@@ -1,19 +1,17 @@
-jest.mock('../server/db')
+jest.mock('../server/db', () => require('obojobo-document-engine/__mocks__/db'))
+const db = oboRequire('server/db')
+const insertEvent = oboRequire('server/insert_event')
+const expectedCreatedAt = new Date().toISOString()
 
 describe('insert_event', () => {
-	beforeAll(() => {})
-	afterAll(() => {})
 	beforeEach(() => {
-		jest.resetAllMocks()
+		jest.clearAllMocks()
+		jest.restoreAllMocks()
 	})
-	afterEach(() => {})
 
 	test('inserts the expected values', () => {
-		expect.assertions(4)
+		expect.hasAssertions()
 
-		const db = oboRequire('server/db')
-		const insertEvent = oboRequire('server/insert_event')
-		const expectedCreatedAt = new Date().toISOString()
 		const insertObject = {
 			action: 'test::testAction',
 			actorTime: new Date().toISOString(),
@@ -43,11 +41,8 @@ describe('insert_event', () => {
 	})
 
 	test('inserts the expected values with a caliper event', () => {
-		expect.assertions(5)
+		expect.hasAssertions()
 
-		const db = oboRequire('server/db')
-		const insertEvent = oboRequire('server/insert_event')
-		const expectedCreatedAt = new Date().toISOString()
 		const insertObject = {
 			action: 'test::testAction',
 			actorTime: new Date().toISOString(),
@@ -78,11 +73,8 @@ describe('insert_event', () => {
 	})
 
 	test('inserts the expected values with a caliper event (with extensions)', () => {
-		expect.assertions(5)
+		expect.hasAssertions()
 
-		const db = oboRequire('server/db')
-		const insertEvent = oboRequire('server/insert_event')
-		const expectedCreatedAt = new Date().toISOString()
 		const insertObject = {
 			action: 'test::testAction',
 			actorTime: new Date().toISOString(),
@@ -113,10 +105,8 @@ describe('insert_event', () => {
 	})
 
 	test('insert event handles visitId correctly', () => {
-		expect.assertions(2)
+		expect.hasAssertions()
 
-		const db = oboRequire('server/db')
-		const insertEvent = oboRequire('server/insert_event')
 		const insertObject = {}
 		db.one.mockResolvedValue({})
 
@@ -130,10 +120,8 @@ describe('insert_event', () => {
 	})
 
 	test('Returns promise rejection', () => {
-		expect.assertions(1)
+		expect.hasAssertions()
 
-		const db = oboRequire('server/db')
-		const insertEvent = oboRequire('server/insert_event')
 		const err = new Error('const error')
 		// mock insert
 		db.one.mockRejectedValueOnce(err)

--- a/packages/app/obojobo-express/__tests__/models/visit.test.js
+++ b/packages/app/obojobo-express/__tests__/models/visit.test.js
@@ -9,6 +9,8 @@ const db = oboRequire('server/db')
 describe('Visit Model', () => {
 	beforeEach(() => {
 		jest.resetAllMocks()
+		db.taskIf = jest.fn()
+		db.taskIf.mockImplementation(cb => cb(db))
 	})
 
 	test('constructor builds expected values', () => {

--- a/packages/app/obojobo-express/__tests__/routes/api/events.test.js
+++ b/packages/app/obojobo-express/__tests__/routes/api/events.test.js
@@ -1,5 +1,5 @@
 jest.mock('../../../server/models/draft')
-jest.mock('../../../server/db')
+jest.mock('../../../server/db', () => require('obojobo-document-engine/__mocks__/db'))
 
 jest.unmock('express') // we'll use supertest + express for this
 

--- a/packages/app/obojobo-express/server/insert_event.js
+++ b/packages/app/obojobo-express/server/insert_event.js
@@ -1,36 +1,35 @@
 const db = oboRequire('server/db')
 
-module.exports = insertObject => {
+module.exports = async insertObject => {
 	insertObject.visitId = insertObject.visitId || null
-	return db
-		.one(
-			`
-		INSERT INTO events
-		(actor_time, action, actor, ip, metadata, payload, draft_id, draft_content_id, version, is_preview, visit_id)
-		VALUES ($[actorTime], $[action], $[userId], $[ip], $[metadata], $[payload], $[draftId], $[contentId], $[eventVersion], $[isPreview], $[visitId])
-		RETURNING *`,
+	return db.taskIf(async t => {
+		const insertEventResult = await t.one(
+			`INSERT INTO events
+			(actor_time, action, actor, ip, metadata, payload, draft_id, draft_content_id, version, is_preview, visit_id)
+			VALUES ($[actorTime], $[action], $[userId], $[ip], $[metadata], $[payload], $[draftId], $[contentId], $[eventVersion], $[isPreview], $[visitId])
+			RETURNING *`,
 			insertObject
 		)
-		.then(insertEventResult => {
-			if (insertObject.caliperPayload) {
-				// Add in internal event id to extensions object:
-				if (!insertObject.caliperPayload.extensions) {
-					insertObject.caliperPayload.extensions = {}
-				}
-				insertObject.caliperPayload.extensions.internalEventId = insertEventResult.id
 
-				// Don't bother including this in the promise chain
-				// It's considered a non-essential insert and we're
-				// not going to wait for it
-				db.none(
-					`
-					INSERT INTO caliper_store
-					(payload, is_preview)
-					VALUES ($[caliperPayload], $[isPreview])`,
-					insertObject
-				)
+		if (insertObject.caliperPayload) {
+			// Add in internal event id to extensions object:
+			if (!insertObject.caliperPayload.extensions) {
+				insertObject.caliperPayload.extensions = {}
 			}
+			insertObject.caliperPayload.extensions.internalEventId = insertEventResult.id
 
-			return insertEventResult
-		})
+			// Don't bother including this in the promise chain
+			// It's considered a non-essential insert and we're
+			// not going to wait for it
+			await t.none(
+				`
+				INSERT INTO caliper_store
+				(payload, is_preview)
+				VALUES ($[caliperPayload], $[isPreview])`,
+				insertObject
+			)
+		}
+
+		return insertEventResult
+	})
 }

--- a/packages/app/obojobo-repository/server/services/search.js
+++ b/packages/app/obojobo-repository/server/services/search.js
@@ -2,35 +2,37 @@ const db = require('obojobo-express/server/db')
 const UserModel = require('obojobo-express/server/models/user')
 
 const searchForUserByString = async searchString => {
-	// creates a function to make searching firstname and lastname together faster
-	await db.none(
-		`CREATE OR REPLACE FUNCTION obo_immutable_concat_ws(s text, t1 text, t2 text)
-			RETURNS text AS
-			$func$
-			SELECT concat_ws(s, t1, t2)
-			$func$ LANGUAGE sql IMMUTABLE;
-			`
-	)
+	return db.taskIf(async t => {
+		// creates a function to make searching firstname and lastname together faster
+		await t.none(
+			`CREATE OR REPLACE FUNCTION obo_immutable_concat_ws(s text, t1 text, t2 text)
+				RETURNS text AS
+				$func$
+				SELECT concat_ws(s, t1, t2)
+				$func$ LANGUAGE sql IMMUTABLE;
+				`
+		)
 
-	const users = await db.manyOrNone(
-		`SELECT
-				id,
-				first_name AS "firstName",
-				last_name AS "lastName",
-				email,
-				username,
-				created_at AS "createdAt",
-				roles
-			FROM users
-			WHERE obo_immutable_concat_ws(' ', first_name, last_name) ILIKE $[search]
-			OR email ILIKE $[search]
-			OR username ILIKE $[search]
-			ORDER BY first_name, last_name
-			LIMIT 25`,
-		{ search: `%${searchString}%` }
-	)
+		const users = await t.manyOrNone(
+			`SELECT
+					id,
+					first_name AS "firstName",
+					last_name AS "lastName",
+					email,
+					username,
+					created_at AS "createdAt",
+					roles
+				FROM users
+				WHERE obo_immutable_concat_ws(' ', first_name, last_name) ILIKE $[search]
+				OR email ILIKE $[search]
+				OR username ILIKE $[search]
+				ORDER BY first_name, last_name
+				LIMIT 25`,
+			{ search: `%${searchString}%` }
+		)
 
-	return users.map(u => new UserModel(u))
+		return users.map(u => new UserModel(u))
+	})
 }
 
 module.exports = {


### PR DESCRIPTION
I discovered in pg-promise's docs that pg-promise connects and disconnects from the database a lot. 

See https://github.com/vitaly-t/pg-promise#methods

 In an effort to optimize this I did some research and found that using tasks and taskIf everywhere in OboNext didn't prevent the connect/disconnect due to those queries not actually being 'nested'.

So I located any spot in the code that does do multiple nested queries and implemented taskIf on those.

I cleaned up the tests for insert_event while I was here.