### PR TITLE
Pages without an id

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/navigation/header.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/navigation/header.test.js
@@ -99,7 +99,7 @@ describe('Header', () => {
 		expect(EditorUtil.rebuildMenu).toHaveBeenCalled()
 	})
 
-	test('saveId does not allow a missing id', () => {
+	test('saveId does not allow an empty id', () => {
 		const props = {
 			index: 0,
 			list: [

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/navigation/header.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/navigation/header.test.js
@@ -99,6 +99,28 @@ describe('Header', () => {
 		expect(EditorUtil.rebuildMenu).toHaveBeenCalled()
 	})
 
+	test('saveId does not allow a missing id', () => {
+		const props = {
+			index: 0,
+			list: [
+				{
+					id: '5',
+					type: 'header',
+					label: 'label5',
+					contentType: 'page',
+					flags: {
+						assessment: false
+					}
+				}
+			]
+		}
+		const component = mount(<Header {...props} />)
+		component.instance().saveId('5', '')
+
+		expect(Common.models.OboModel.models['5'].setId).not.toHaveBeenCalled()
+		expect(EditorUtil.rebuildMenu).not.toHaveBeenCalled()
+	})
+
 	test('saveId does not update the model', () => {
 		const props = {
 			index: 0,

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/navigation/sub-menu.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/navigation/sub-menu.test.js
@@ -326,6 +326,9 @@ describe('SubMenu', () => {
 
 		component.instance().saveId('7', 'mock-id')
 		expect(EditorUtil.rebuildMenu).not.toHaveBeenCalled()
+
+		component.instance().saveId('7', '')
+		expect(EditorUtil.rebuildMenu).not.toHaveBeenCalled()
 	})
 
 	test('saveId calls rebuildMenu with good id', () => {

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/node/editor-component.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/node/editor-component.test.js
@@ -226,6 +226,31 @@ describe('Component Editor Node', () => {
 		expect(editor.removeNodeByKey).toHaveBeenCalled()
 	})
 
+	test('saveId does not allow an empty id', () => {
+		const editor = {
+			insertNodeByKey: jest.fn(),
+			removeNodeByKey: jest.fn()
+		}
+
+		const component = mount(
+			<Node
+				isSelected={true}
+				node={{
+					data: {
+						get: () => ({ width: 'normal' }),
+						toJSON: () => ({})
+					},
+					nodes: { size: 0 }
+				}}
+				editor={editor}
+			/>
+		)
+		component.instance().saveId('mock-id', '')
+
+		expect(editor.insertNodeByKey).not.toHaveBeenCalled()
+		expect(editor.removeNodeByKey).not.toHaveBeenCalled()
+	})
+
 	test('saveContent calls setNodeByKey', () => {
 		const editor = {
 			setNodeByKey: jest.fn()

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/header.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/header.js
@@ -27,6 +27,11 @@ class Header extends React.Component {
 
 	saveId(oldId, newId) {
 		const model = OboModel.models[oldId]
+
+		if (!newId) {
+			return 'Please enter an id'
+		}
+
 		// prettier-ignore
 		if (!model.setId(newId)) {
 			return 'The id "' + newId + '" already exists. Please choose a unique id'

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/sub-menu.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/sub-menu.js
@@ -84,6 +84,11 @@ class SubMenu extends React.Component {
 
 	saveId(oldId, newId) {
 		const model = OboModel.models[oldId]
+
+		if (!newId) {
+			return 'Please enter an id'
+		}
+
 		if (!model.setId(newId)) {
 			return 'The id "' + newId + '" already exists. Please choose a unique id'
 		}

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
@@ -43,6 +43,11 @@ class Node extends React.Component {
 
 		// check against existing nodes for duplicate keys
 		const model = OboModel.models[prevId]
+
+		if (!newId) {
+			return 'Please enter an id'
+		}
+
 		if (!model.setId(newId)) {
 			return 'The id "' + newId + '" already exists. Please choose a unique id'
 		}


### PR DESCRIPTION
Might want to defer part of this to #1083 or #1085. You can't save an empty id in the Visual or XML editor but the JSON editor still allows it.

Resolves #1114.
