### PR TITLE
`Make a copy` feature is not working as expected

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
@@ -113,14 +113,14 @@ class CodeEditor extends React.Component {
 		})
 	}
 
-	saveCode() {
+	saveCode(draftId) {
 		// Update the title in the File Toolbar
 		let label = EditorUtil.getTitleFromString(this.state.code, this.props.mode)
 		if (!label || !/[^\s]/.test(label)) label = '(Unnamed Module)'
 		EditorUtil.renamePage(this.props.model.id, label)
 
 		return APIUtil.postDraft(
-			this.props.draftId,
+			draftId || this.props.draftId,
 			this.state.code,
 			this.props.mode === XML_MODE ? 'text/plain' : 'application/json'
 		)

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-menu.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-menu.js
@@ -40,16 +40,17 @@ class FileMenu extends React.PureComponent {
 	}
 
 	copyModule(moduleId, label) {
-		this.renameModule(moduleId, label)
-
+		const oldLabel = this.props.model.title
 		let draftId = null
 
 		APIUtil.createNewDraft()
 			.then(result => {
 				draftId = result.value.id
+				this.renameModule(moduleId, label)
 				return this.props.onSave(draftId)
 			})
 			.then(() => {
+				this.renameModule(moduleId, oldLabel)
 				window.open(window.location.origin + '/editor/visual/' + draftId, '_blank')
 			})
 	}


### PR DESCRIPTION
Resolve: #1129 

I am opening to suggestions

Problem 1:
- Reason: The current document is renamed the then it is copied to the new document.
- Solution: Rename the current document back after copying. This feels a bit hacky but simple. Users can see the title got change for a brief moment.

Problem 2:
- Reason: Code Editor and Visual Editor are using different `onSave` function. The `onSave` of Visual editor takes in `draftId` and saves the document to that `draftId`. The `onSave` of the Code Editor saves to the current draftId.
- Solution: Make `onSave` of the Code Editor acts similarly to the `onSave` of the Visual Editor. 