### PR TITLE
moves building on prepublish into obojobo-express

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 		"lint:css": "lerna run lint:css",
 		"lint:js": "lerna run  lint:js",
 		"precommit": "lerna run precommit && yarn test:ci",
-		"prepublish": "yarn build",
 		"release:publish": "lerna publish from-package",
 		"release:tag": "lerna version --no-push --sign-git-commit --sign-git-tag --no-commit-hooks --force-publish",
 		"start": "start_obojobo_server",

--- a/packages/app/obojobo-express/package.json
+++ b/packages/app/obojobo-express/package.json
@@ -23,6 +23,7 @@
 		"lint": "yarn lint:js && yarn lint:css",
 		"lint:js": "eslint .",
 		"lint:css": "stylelint **/*.scss",
+		"prepublish": "yarn build",
 		"prettier:run": "prettier --write '**/*.{js,scss}'",
 		"precommit": "lint-staged"
 	},


### PR DESCRIPTION
This should avoid an unnecessary yarn build call when running yarn install at the top level.  The aim is to only have it automatically run when obojobo-express is actually published.