### PR TITLE
Fixes an error that occurs when uploading an image

### DIFF
--- a/packages/obonode/obojobo-chunks-figure/image-properties-modal.js
+++ b/packages/obonode/obojobo-chunks-figure/image-properties-modal.js
@@ -2,7 +2,7 @@ import './image-properties-modal.scss'
 
 import { isUrlUUID } from './utils'
 
-import APIUtil from 'obojobo-document-engine/src/scripts/viewer/util/api-util'
+import API from 'obojobo-document-engine/src/scripts/viewer/util/api'
 import Common from 'obojobo-document-engine/src/scripts/common'
 import Image from './image'
 import React from 'react'
@@ -33,7 +33,7 @@ class ImageProperties extends React.Component {
 		const file = event.target.files[0]
 		const formData = new window.FormData()
 		formData.append('userImage', file, file.name)
-		APIUtil.postMultiPart('/api/media/upload', formData).then(mediaData => {
+		API.postMultiPart('/api/media/upload', formData).then(mediaData => {
 			this.setState({ url: mediaData.media_id, urlInputText: '', filename: mediaData.filename })
 		})
 	}

--- a/packages/obonode/obojobo-chunks-figure/image-properties-modal.test.js
+++ b/packages/obonode/obojobo-chunks-figure/image-properties-modal.test.js
@@ -14,7 +14,7 @@ jest.mock('./utils', () => {
 	}
 })
 
-jest.mock('obojobo-document-engine/src/scripts/viewer/util/api-util', () => ({
+jest.mock('obojobo-document-engine/src/scripts/viewer/util/api', () => ({
 	postMultiPart: jest.fn().mockResolvedValue({ mediaId: 'mockMediaId' }),
 	get: jest
 		.fn()


### PR DESCRIPTION
Might need some more eyes on this, but It seems like `image-properties-modal.js` was trying to call `APIUtil.postMultiPart`. That function is defined in `obojobo-document-engine/src/scripts/viewer/util/api` but `obojobo-document-engine/src/scripts/viewer/util/api-util` was imported instead.

See below:
https://github.com/ucfopen/Obojobo/blob/166e89cba8093b3c134db4ea49a307bc0f38ad8e/packages/obonode/obojobo-chunks-figure/image-properties-modal.js#L5

https://github.com/ucfopen/Obojobo/blob/166e89cba8093b3c134db4ea49a307bc0f38ad8e/packages/obonode/obojobo-chunks-figure/image-properties-modal.js#L36-L38

And in `api.js`:
https://github.com/ucfopen/Obojobo/blob/166e89cba8093b3c134db4ea49a307bc0f38ad8e/packages/app/obojobo-document-engine/src/scripts/viewer/util/api.js#L62-L67

Fixes #1140.