### PR TITLE
Answering a question doesn't change a figure caption

### DIFF
--- a/packages/obonode/obojobo-chunks-question/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-question/viewer-component.scss
@@ -20,7 +20,7 @@
 		border-radius: $dimension-rounded-radius;
 		padding: 0;
 		margin-bottom: 1em;
-		border: 1px solid transparentize($color-shadow, 0.2);
+		border: 1.25px solid transparentize($color-shadow, 0.2);
 		max-width: $dimension-column-width;
 		background: $color-bg;
 


### PR DESCRIPTION
I think the problem was that the incorrect/correct border was 1.25px but the normal border was 1px, so when you answer a question, the border sizes changed.

Fixes #1108.