### PR TITLE
XML editor now preserves unexpected tags and their attributes instead of breaking.

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/common/text/chunk-style-list.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/text/chunk-style-list.test.js
@@ -302,6 +302,46 @@ describe('ChunkStyleList', function() {
 		])
 	})
 
+	test('normalizes unexpected styles', () => {
+		styleList = new ChunkStyleList()
+
+		styleList.add(new StyleRange(0, 5, 'b', {}))
+		styleList.add(new StyleRange(0, 5, 'extra', {}))
+		styleList.add(new StyleRange(0, 5, 'u', { prop: 'val1' }))
+		styleList.add(new StyleRange(5, 10, 'u', {}))
+		styleList.add(new StyleRange(5, 10, 'extra', {}))
+		styleList.normalize()
+
+		expect(styleList.getExportedObject()).toEqual([
+			{
+				start: 0,
+				end: 5,
+				type: 'b',
+				data: {}
+			},
+			{
+				start: 0,
+				end: 10,
+				type: 'extra',
+				data: {}
+			},
+			{
+				start: 5,
+				end: 10,
+				type: 'u',
+				data: {}
+			},
+			{
+				start: 0,
+				end: 5,
+				type: 'u',
+				data: {
+					prop: 'val1'
+				}
+			}
+		])
+	})
+
 	test('getStylesInRange returns styles completely within a given range', () => {
 		const styles = styleList.getStylesInRange(5, 15)
 

--- a/packages/app/obojobo-document-engine/__tests__/common/text/style-range.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/text/style-range.test.js
@@ -132,6 +132,12 @@ describe('StyleRange', () => {
 		expect(item.isMergeable('mockType', { a: 1 })).toEqual(false)
 	})
 
+	test('isMergeable returns false when data objects have a different number of keys', () => {
+		const item = new StyleRange(5, 10, 'mockType', {})
+
+		expect(item.isMergeable('mockType', { a: 1 })).toEqual(false)
+	})
+
 	test('isMergeable returns true when type and data is the same', () => {
 		const item = new StyleRange(5, 10, 'mockType', 17)
 

--- a/packages/app/obojobo-document-engine/__tests__/common/text/styleable-text-renderer.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/text/styleable-text-renderer.test.js
@@ -232,4 +232,36 @@ describe('styleableTextRenderer', () => {
 		`.replace(/[\t\n]/g, '')
 		)
 	})
+
+	test('Unexpected tags with and without data', () => {
+		const st = new StyleableText('dog fox cat')
+		st.styleText('extra', 0, 3, { prop: 'val1' })
+		st.styleText('extra', 3, 7)
+		const mockEl = styleableTextRenderer(st)
+
+		expect(mockElToHTMLString(mockEl)).toEqual(
+			`
+			<span>
+				<extra prop="val1">dog</extra>
+				<extra> fox</extra> cat
+			</span>
+		`.replace(/[\t\n]/g, '')
+		)
+	})
+
+	test('Unexpected tags mixed with expected tags', () => {
+		const st = new StyleableText('dog fox cat')
+		st.styleText('b', 0, 3)
+		st.styleText('extra', 3, 7)
+		const mockEl = styleableTextRenderer(st)
+
+		expect(mockElToHTMLString(mockEl)).toEqual(
+			`
+			<span>
+				<b>dog</b>
+				<extra> fox</extra> cat
+			</span>
+		`.replace(/[\t\n]/g, '')
+		)
+	})
 })

--- a/packages/app/obojobo-document-engine/src/scripts/common/text/style-range.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/text/style-range.js
@@ -57,6 +57,9 @@ class StyleRange {
 		if (this.type !== otherType) return false
 
 		if (this.data instanceof Object) {
+			if (Object.keys(this.data).length !== Object.keys(otherData).length) {
+				return false
+			}
 			for (const k in this.data) {
 				const v = this.data[k]
 				if (otherData[k] === null || typeof otherData[k] === 'undefined' || otherData[k] !== v) {

--- a/packages/app/obojobo-document-engine/src/scripts/common/text/styleable-text-renderer.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/text/styleable-text-renderer.js
@@ -6,7 +6,7 @@ const StyleType = require('./style-type')
 const MockElement = require('../mockdom/mock-element')
 const MockTextNode = require('../mockdom/mock-text-node')
 
-const ORDER = [
+const STYLE_ORDER = [
 	StyleType.COMMENT,
 	StyleType.LATEX,
 	StyleType.LINK,
@@ -98,7 +98,9 @@ const getTextNodeFragmentDescriptorsAt = function(rootNode, startIndex, endIndex
 
 const wrapElement = function(styleRange, nodeToWrap, text) {
 	let newChild, node, root
-	switch (styleRange.type) {
+	// The style type actually rendered may not always match the style range's type text
+	let styleType = styleRange.type
+	switch (styleType) {
 		case 'sup': {
 			let level = styleRange.data
 			if (level > 0) {
@@ -166,11 +168,11 @@ const wrapElement = function(styleRange, nodeToWrap, text) {
 		}
 
 		case StyleType.MONOSPACE:
-			styleRange.type = 'code'
+			styleType = 'code'
 		// Intentional fallthrough
 
 		default:
-			newChild = new MockElement(styleRange.type, Object.assign({}, styleRange.data))
+			newChild = new MockElement(styleType, Object.assign({}, styleRange.data))
 			nodeToWrap.parent.replaceChild(nodeToWrap, newChild)
 			newChild.addChild(nodeToWrap)
 			nodeToWrap.text = text
@@ -225,7 +227,26 @@ const getMockElement = function(styleableText) {
 	const root = new MockElement('span')
 	root.addChild(new MockTextNode(styleableText.value))
 
-	for (const styleType of Array.from(ORDER)) {
+	// If any unexpected style ranges are encountered, they'll be stored here for later use
+	const unhandledTypes = []
+
+	// Loop through the style types we track explicitly in a predictable order
+	// This will apply all the <b>'s before all the <del>'s etc.
+	// The resulting output will make sure tag order is the same everywhere
+	for (const styleType of STYLE_ORDER) {
+		for (const styleRange of styleableText.styleList.styles) {
+			if (styleRange.type === styleType) {
+				applyStyle(root, styleRange)
+			} else if (!STYLE_ORDER.includes(styleRange.type)) {
+				// If we encounter a style that's not in the style order list,
+				// put it in the list of unhandled styles we already have
+				unhandledTypes[styleRange.type] = true
+			}
+		}
+	}
+
+	// Same as above, but for any unexpected styles encountered
+	for (const styleType in unhandledTypes) {
 		for (const styleRange of Array.from(styleableText.styleList.styles)) {
 			if (styleRange.type === styleType) {
 				applyStyle(root, styleRange)

--- a/packages/app/obojobo-document-xml-parser/__tests__/src/text-group-parser.test.js
+++ b/packages/app/obojobo-document-xml-parser/__tests__/src/text-group-parser.test.js
@@ -1,0 +1,134 @@
+const textGroupParser = require('../../src/text-group-parser')
+
+describe('TextGroup parser', () => {
+	const textGroup = {
+		name: 'textGroup',
+		elements: [
+			{
+				name: 't',
+				attributes: { indent: '0' },
+				value: []
+			}
+		]
+	}
+
+	function generateElement(name, text, attributes) {
+		return {
+			name,
+			attributes,
+			value: [
+				{
+					type: 'text',
+					text
+				}
+			]
+		}
+	}
+
+	function setTextGroupElements(elements) {
+		textGroup.elements[0].value = elements
+	}
+
+	function checkStyleExpectations(style, type, start, end, data) {
+		expect(style.type).toBe(type)
+		expect(style.data).toEqual(data)
+		expect(style.start).toBe(start)
+		expect(style.end).toBe(end)
+	}
+
+	beforeEach(function() {
+		setTextGroupElements([])
+	})
+
+	test('Parses "latex" tags with alt attributes', () => {
+		setTextGroupElements([generateElement('latex', 'dog', { alt: 'test' })])
+
+		const parsed = textGroupParser(textGroup)
+		const parsedStyles = parsed[0].text.styleList
+
+		expect(parsed[0].text.value).toBe('dog')
+		checkStyleExpectations(parsedStyles[0], '_latex', 0, 3, { alt: 'test' })
+	})
+
+	test('Parses "latex" tags without alt attributes', () => {
+		setTextGroupElements([generateElement('latex', 'dog')])
+
+		const parsed = textGroupParser(textGroup)
+		const parsedStyles = parsed[0].text.styleList
+
+		expect(parsed[0].text.value).toBe('dog')
+		checkStyleExpectations(parsedStyles[0], '_latex', 0, 3, {})
+	})
+
+	test('Parses two "a" tags with different href attributes', () => {
+		setTextGroupElements([
+			generateElement('a', 'dog', { href: 'testUrlOne' }),
+			generateElement('a', ' fox', { href: 'testUrlTwo' })
+		])
+
+		const parsed = textGroupParser(textGroup)
+		const parsedStyles = parsed[0].text.styleList
+
+		expect(parsed[0].text.value).toBe('dog fox')
+		checkStyleExpectations(parsedStyles[0], 'a', 0, 3, { href: 'testUrlOne' })
+		checkStyleExpectations(parsedStyles[1], 'a', 3, 7, { href: 'testUrlTwo' })
+	})
+
+	test('Strips nonstandard attributes from "a" tags', () => {
+		setTextGroupElements([
+			generateElement('a', 'dog', { href: 'testUrlOne' }),
+			generateElement('a', ' fox', { href: 'testUrlTwo', prop: 'val' })
+		])
+
+		const parsed = textGroupParser(textGroup)
+		const parsedStyles = parsed[0].text.styleList
+
+		expect(parsed[0].text.value).toBe('dog fox')
+		checkStyleExpectations(parsedStyles[0], 'a', 0, 3, { href: 'testUrlOne' })
+		checkStyleExpectations(parsedStyles[1], 'a', 3, 7, { href: 'testUrlTwo' })
+	})
+
+	test('Enforces expected data on "sup" tags', () => {
+		setTextGroupElements([generateElement('sup', 'dog')])
+
+		const parsed = textGroupParser(textGroup)
+		const parsedStyles = parsed[0].text.styleList
+
+		expect(parsed[0].text.value).toBe('dog')
+		checkStyleExpectations(parsedStyles[0], 'sup', 0, 3, 1)
+	})
+
+	test('Enforces expected data on "sub" tags and converts them to "sup" tags', () => {
+		setTextGroupElements([generateElement('sub', 'dog')])
+
+		const parsed = textGroupParser(textGroup)
+		const parsedStyles = parsed[0].text.styleList
+
+		expect(parsed[0].text.value).toBe('dog')
+		checkStyleExpectations(parsedStyles[0], 'sup', 0, 3, -1)
+	})
+
+	test('Converts "code" tags to "monospace" tags', () => {
+		setTextGroupElements([generateElement('code', 'dog')])
+
+		const parsed = textGroupParser(textGroup)
+		const parsedStyles = parsed[0].text.styleList
+
+		expect(parsed[0].text.value).toBe('dog')
+		checkStyleExpectations(parsedStyles[0], 'monospace', 0, 3, {})
+	})
+
+	test('Parses two unhandled ranges that use the same tag but have different attributes', () => {
+		setTextGroupElements([
+			generateElement('extra', 'dog', { prop: 'val' }),
+			generateElement('extra', ' fox')
+		])
+
+		const parsed = textGroupParser(textGroup)
+		const parsedStyles = parsed[0].text.styleList
+
+		expect(parsed[0].text.value).toBe('dog fox')
+		checkStyleExpectations(parsedStyles[0], 'extra', 0, 3, { prop: 'val' })
+		checkStyleExpectations(parsedStyles[1], 'extra', 3, 7, {})
+	})
+})

--- a/packages/app/obojobo-document-xml-parser/package.json
+++ b/packages/app/obojobo-document-xml-parser/package.json
@@ -37,7 +37,6 @@
       "src/draft-json-transform.js",
       "src/extension-transform.js",
       "src/generate-id.js",
-      "src/text-group-parser.js",
       "src/html-transform.js",
       "src/list-styles-parser.js",
       "src/triggers-parser.js",

--- a/packages/app/obojobo-document-xml-parser/src/text-group-parser.js
+++ b/packages/app/obojobo-document-xml-parser/src/text-group-parser.js
@@ -1,8 +1,8 @@
 const parseTg = el => {
 	const tg = []
 
-	for (const i in el.elements) {
-		tg.push(parseT(el.elements[i]))
+	for (const element of el.elements) {
+		tg.push(parseT(element))
 	}
 
 	return tg
@@ -17,19 +17,15 @@ const parseT = el => {
 		data: el.attributes || null
 	}
 
-	for (const i in el.value) {
-		parseText(el.value[i], t.text)
+	for (const value of el.value) {
+		parseText(value, t.text)
 	}
 
 	return t
 }
 
-const parseText = (node, textItem, foundText) => {
+const parseText = (node, textItem) => {
 	if (node.type === 'text') {
-		if (!foundText && typeof node.text === 'string') {
-			foundText = true
-		}
-
 		textItem.value += node.text
 		return
 	}
@@ -63,6 +59,13 @@ const parseText = (node, textItem, foundText) => {
 		case 'code':
 			type = 'monospace'
 			break
+
+		// Preserve any abnormal attribution
+		default:
+			if (node.attributes) {
+				data = node.attributes
+			}
+			break
 	}
 
 	const styleRange = {
@@ -74,8 +77,8 @@ const parseText = (node, textItem, foundText) => {
 
 	textItem.styleList.push(styleRange)
 
-	for (const i in node.value) {
-		parseText(node.value[i], textItem)
+	for (const value of node.value) {
+		parseText(value, textItem)
 	}
 
 	styleRange.end = textItem.value.length


### PR DESCRIPTION
Fixes #1151.

Adjusts style range normalization and rendering processes to enable end users to use previously unsupported (or arbitrary) XML tags in the XML editor. Unsupported tags will be preserved and displayed in the XML (and JSON) editor(s) between edits.