### PR TITLE
adds plugin-transform-runtime to optimize build

### DIFF
--- a/packages/app/obojobo-document-engine/babel.config.js
+++ b/packages/app/obojobo-document-engine/babel.config.js
@@ -3,7 +3,6 @@ module.exports = function(api) {
 	return {
 		compact: false,
 		presets: ['@babel/preset-env', '@babel/preset-react'],
-		plugins: [['@babel/transform-runtime']],
 		env: {
 			test: {
 				compact: false,

--- a/packages/app/obojobo-express/babel.config.js
+++ b/packages/app/obojobo-express/babel.config.js
@@ -2,11 +2,13 @@ module.exports = function(api) {
 	api.cache(true)
 	return {
 		presets: ['@babel/preset-env', '@babel/preset-react'],
+		plugins: [['@babel/plugin-transform-runtime', { useESModules: true, absoluteRuntime: true }]],
+		sourceType: 'unambiguous',
 		env: {
 			test: {
 				compact: false,
 				presets: ['@babel/preset-env', '@babel/preset-react'],
-				plugins: ['@babel/transform-runtime']
+				plugins: ['@babel/plugin-transform-runtime']
 			}
 		}
 	}

--- a/packages/app/obojobo-express/webpack.config.js
+++ b/packages/app/obojobo-express/webpack.config.js
@@ -54,7 +54,7 @@ module.exports =
 					},
 					{
 						test: /\.(js|jsx)$/,
-						exclude: '/node_modules',
+						exclude: /node_modules/,
 						use: {
 							loader: 'babel-loader',
 							options: {


### PR DESCRIPTION
adds plugin-transform-runtime to our babel config to optimize the build output sizes.

Most notably the editor and viewer get a nice size reduction from this.  Read more about it here: https://babeljs.io/docs/en/babel-plugin-transform-runtime

```
          editor.min.js    620 KiB ->    549 KiB
          viewer.min.js    356 KiB ->    310 KiB
```

As a nice bonus - this _should_ allow us to use aync/await in our client code