### PR TITLE
Dev/9 - Remove hyphens

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/editor-nav.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/editor-nav.scss
@@ -65,7 +65,6 @@
 		border-left: solid 1px rgba($color-nav-bg, 0.9);
 		text-align: center;
 		word-wrap: break-word;
-		hyphens: auto;
 
 		&::after {
 			content: '';

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/header.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/header.scss
@@ -34,7 +34,6 @@
 		text-transform: uppercase;
 		cursor: default;
 		word-wrap: break-word;
-		hyphens: auto;
 	}
 
 	.location {

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/inline-nav-button.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/inline-nav-button.scss
@@ -16,7 +16,6 @@
 	line-height: 1.5em;
 	transform: translate(0, -1px);
 	word-wrap: break-word;
-	hyphens: auto;
 
 	&.is-enabled {
 		&.is-prev {

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/nav.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/nav.scss
@@ -23,7 +23,6 @@
 	border-right: 1px solid transparentize($color-shadow, 0.1);
 	overflow-y: auto;
 	word-wrap: break-word;
-	hyphens: auto;
 
 	&:focus {
 		outline: none;

--- a/packages/app/obojobo-document-engine/src/scss/main.scss
+++ b/packages/app/obojobo-document-engine/src/scss/main.scss
@@ -86,7 +86,6 @@ body {
 	> .draft-title {
 		display: block;
 		font-weight: bold;
-		hyphens: auto;
 		word-break: break-word;
 	}
 
@@ -128,7 +127,6 @@ body {
 	white-space: pre-wrap;
 	width: 100%;
 	word-wrap: break-word;
-	hyphens: auto;
 	margin: 0 auto;
 	padding-top: 1em;
 	padding-bottom: 1em;

--- a/packages/app/obojobo-module-selector/client/css/module-selector.scss
+++ b/packages/app/obojobo-module-selector/client/css/module-selector.scss
@@ -358,7 +358,6 @@ header {
 	font-weight: 700;
 	margin: 0;
 	word-break: break-word;
-	hyphens: auto;
 }
 
 #section-progress header .heading-container h1 .remaining-tagline,
@@ -711,6 +710,5 @@ header {
 	.obo-item h2 {
 		font-size: 0.9em;
 		word-break: break-word;
-		hyphens: auto;
 	}
 }

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
@@ -38,7 +38,6 @@
 			transform: translate(0, -50%);
 			max-height: 1.2em;
 			overflow: hidden;
-			hyphens: auto;
 			word-break: break-word;
 		}
 

--- a/packages/app/obojobo-repository/shared/components/module.scss
+++ b/packages/app/obojobo-repository/shared/components/module.scss
@@ -21,7 +21,6 @@
 		cursor: pointer;
 		width: 100%;
 		word-wrap: break-word;
-		hyphens: auto;
 	}
 
 	> a {

--- a/packages/app/obojobo-repository/shared/components/repository-banner.scss
+++ b/packages/app/obojobo-repository/shared/components/repository-banner.scss
@@ -66,7 +66,6 @@
 	// Nudge the text slightly left to line up:
 	margin-left: -3px;
 	word-break: break-word;
-	hyphens: auto;
 }
 
 .default-bg .repository--title-banner--title {


### PR DESCRIPTION
Fixes #1200 

We added in CSS hyphens as a solution to very long single-text string names for modules, however this resulted in unpredictable results as to when the word would be hyphened. This reverts that change but still breaks the word so that the title fits.