### PR TITLE
dashboard crashes if user search returns 500

### DIFF
--- a/packages/app/obojobo-repository/package.json
+++ b/packages/app/obojobo-repository/package.json
@@ -28,6 +28,7 @@
 	},
 	"dependencies": {
 		"dayjs": "1.8.22",
+		"debounce-promise": "^3.1.2",
 		"express": "~4.16.4",
 		"express-react-views-custom": "https://github.com/ucfcdl/express-react-views.git#0ea22b3a3a5846adaae4b7bc86fe0e8f13a38051",
 		"express-validator": "^5.2.0",

--- a/packages/app/obojobo-repository/server/migrations/20200407043313-create-immutable-concat-ws-function.js
+++ b/packages/app/obojobo-repository/server/migrations/20200407043313-create-immutable-concat-ws-function.js
@@ -1,0 +1,35 @@
+'use strict'
+
+var dbm
+var type
+var seed
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+	dbm = options.dbmigrate
+	type = dbm.dataType
+	seed = seedLink
+}
+
+exports.up = function(db) {
+	// creates a function to make searching multiple text columns concatinated together faster
+	return db.runSql(
+		`CREATE OR REPLACE FUNCTION obo_immutable_concat_ws(s text, t1 text, t2 text)
+			RETURNS text AS
+			$func$
+			SELECT concat_ws(s, t1, t2)
+			$func$ LANGUAGE sql IMMUTABLE;
+			`
+	)
+}
+
+exports.down = function(db) {
+	return db.runSql('DROP FUNCTION IF EXISTS obo_immutable_concat_ws(text, text, text)')
+}
+
+exports._meta = {
+	version: 1
+}

--- a/packages/app/obojobo-repository/server/services/search.js
+++ b/packages/app/obojobo-repository/server/services/search.js
@@ -2,37 +2,25 @@ const db = require('obojobo-express/server/db')
 const UserModel = require('obojobo-express/server/models/user')
 
 const searchForUserByString = async searchString => {
-	return db.taskIf(async t => {
-		// creates a function to make searching firstname and lastname together faster
-		await t.none(
-			`CREATE OR REPLACE FUNCTION obo_immutable_concat_ws(s text, t1 text, t2 text)
-				RETURNS text AS
-				$func$
-				SELECT concat_ws(s, t1, t2)
-				$func$ LANGUAGE sql IMMUTABLE;
-				`
-		)
-
-		const users = await t.manyOrNone(
+	return db
+		.manyOrNone(
 			`SELECT
-					id,
-					first_name AS "firstName",
-					last_name AS "lastName",
-					email,
-					username,
-					created_at AS "createdAt",
-					roles
-				FROM users
-				WHERE obo_immutable_concat_ws(' ', first_name, last_name) ILIKE $[search]
-				OR email ILIKE $[search]
-				OR username ILIKE $[search]
-				ORDER BY first_name, last_name
-				LIMIT 25`,
+			id,
+			first_name AS "firstName",
+			last_name AS "lastName",
+			email,
+			username,
+			created_at AS "createdAt",
+			roles
+		FROM users
+		WHERE obo_immutable_concat_ws(' ', first_name, last_name) ILIKE $[search]
+		OR email ILIKE $[search]
+		OR username ILIKE $[search]
+		ORDER BY first_name, last_name
+		LIMIT 25`,
 			{ search: `%${searchString}%` }
 		)
-
-		return users.map(u => new UserModel(u))
-	})
+		.then(users => users.map(u => new UserModel(u)))
 }
 
 module.exports = {

--- a/packages/app/obojobo-repository/shared/actions/dashboard-actions.js
+++ b/packages/app/obojobo-repository/shared/actions/dashboard-actions.js
@@ -9,8 +9,15 @@ const defaultOptions = () => ({
 	}
 })
 
+const throwIfNotOk = res => {
+	if (!res.ok) throw Error(`Error requesting ${res.url}, status code: ${res.status}`)
+	return res
+}
+
 const apiSearchForUser = searchString => {
-	return fetch(`/api/users/search?q=${searchString}`, defaultOptions()).then(res => res.json())
+	return fetch(`/api/users/search?q=${searchString}`, defaultOptions())
+		.then(throwIfNotOk)
+		.then(res => res.json())
 }
 
 const apiAddPermissionsToModule = (draftId, userId) => {

--- a/packages/app/obojobo-repository/shared/actions/dashboard-actions.js
+++ b/packages/app/obojobo-repository/shared/actions/dashboard-actions.js
@@ -1,3 +1,5 @@
+const debouncePromise = require('debounce-promise')
+
 // =================== API =======================
 
 const defaultOptions = () => ({
@@ -19,6 +21,8 @@ const apiSearchForUser = searchString => {
 		.then(throwIfNotOk)
 		.then(res => res.json())
 }
+
+const apiSearchForUserDebounced = debouncePromise(apiSearchForUser, 300)
 
 const apiAddPermissionsToModule = (draftId, userId) => {
 	const options = { ...defaultOptions(), method: 'POST', body: `{"userId":${userId}}` }
@@ -69,7 +73,7 @@ const searchForUser = searchString => ({
 	meta: {
 		searchString
 	},
-	promise: apiSearchForUser(searchString)
+	promise: apiSearchForUserDebounced(searchString)
 })
 
 const ADD_USER_TO_MODULE = 'ADD_USER_TO_MODULE'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4923,6 +4923,11 @@ debounce@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
+  
+debounce-promise@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/debounce-promise/-/debounce-promise-3.1.2.tgz#320fb8c7d15a344455cd33cee5ab63530b6dc7c5"
+  integrity sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg==
 
 debug-logger@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This was partially fixed on v8.0.2, but the source of the problem is handled in this PR.

at least partially fixes #1199 

## Contains a Migration

Moves a `CREATE OR REPLACE FUNCTION` from being called every api request to a migration so we can speed up user searching.