### PR TITLE
[fix] editor error for list lines missing hanging indent param

### DIFF
--- a/packages/obonode/obojobo-chunks-list/components/line/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-list/components/line/__snapshots__/editor-component.test.js.snap
@@ -1,9 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Line Editor Node Line component 1`] = `
+exports[`Line Editor Node renders as expected 1`] = `
 <div>
   <li
     data-hanging-indent={true}
   />
+</div>
+`;
+
+exports[`Line Editor Node renders with children 1`] = `
+<div>
+  <li>
+    children!
+  </li>
+</div>
+`;
+
+exports[`Line Editor Node renders without content 1`] = `
+<div>
+  <li />
+</div>
+`;
+
+exports[`Line Editor Node renders without hanging indent 1`] = `
+<div>
+  <li />
 </div>
 `;

--- a/packages/obonode/obojobo-chunks-list/components/line/editor-component.js
+++ b/packages/obonode/obojobo-chunks-list/components/line/editor-component.js
@@ -2,10 +2,14 @@ import '../../viewer-component.scss'
 
 import React from 'react'
 
-const Line = props => {
+const Line = ({ element, children }) => {
+	const attr = {}
+	if (element.content && element.content.hangingIndent) {
+		attr['data-hanging-indent'] = element.content.hangingIndent
+	}
 	return (
 		<div>
-			<li data-hanging-indent={props.element.content.hangingIndent}>{props.children}</li>
+			<li {...attr}>{children}</li>
 		</div>
 	)
 }

--- a/packages/obonode/obojobo-chunks-list/components/line/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-list/components/line/editor-component.test.js
@@ -4,13 +4,48 @@ import renderer from 'react-test-renderer'
 import Line from './editor-component'
 
 describe('Line Editor Node', () => {
-	test('Line component', () => {
+	test('renders as expected', () => {
 		const component = renderer.create(
 			<Line
 				element={{
 					content: { hangingIndent: true }
 				}}
 			/>
+		)
+		const tree = component.toJSON()
+
+		expect(tree).toMatchSnapshot()
+	})
+
+	test('renders without content', () => {
+		const component = renderer.create(<Line element={{}} />)
+		const tree = component.toJSON()
+
+		expect(tree).toMatchSnapshot()
+	})
+
+	test('renders without hanging indent', () => {
+		const component = renderer.create(
+			<Line
+				element={{
+					content: {}
+				}}
+			/>
+		)
+		const tree = component.toJSON()
+
+		expect(tree).toMatchSnapshot()
+	})
+
+	test('renders with children', () => {
+		const component = renderer.create(
+			<Line
+				element={{
+					content: {}
+				}}
+			>
+				children!
+			</Line>
 		)
 		const tree = component.toJSON()
 


### PR DESCRIPTION
The List Line component in the editor was expecting props to always contain content - sometimes they don't