### PR TITLE
[clean] use const for list type checking

### DIFF
--- a/packages/obonode/obojobo-chunks-list/adapter.js
+++ b/packages/obonode/obojobo-chunks-list/adapter.js
@@ -11,7 +11,7 @@ const Adapter = {
 		if (attrs && attrs.content && attrs.content.listStyles) {
 			model.modelState.listStyles = ListStyles.fromDescriptor(attrs.content.listStyles)
 		} else {
-			model.modelState.listStyles = new ListStyles('unordered')
+			model.modelState.listStyles = new ListStyles(ListStyles.TYPE_UNORDERED)
 		}
 	},
 

--- a/packages/obonode/obojobo-chunks-list/changes/normalize-node.js
+++ b/packages/obonode/obojobo-chunks-list/changes/normalize-node.js
@@ -28,7 +28,7 @@ const normalizeNode = (entry, editor, next) => {
 			// Wrap loose ListLine children
 			if (Element.isElement(child) && child.subtype === LIST_LINE_NODE) {
 				const bulletList =
-					node.content.listStyles.type === 'unordered'
+					node.content.listStyles.type === ListStyles.TYPE_UNORDERED
 						? ListStyles.UNORDERED_LIST_BULLETS
 						: ListStyles.ORDERED_LIST_BULLETS
 				const bulletStyle = bulletList[0]
@@ -90,7 +90,7 @@ const normalizeNode = (entry, editor, next) => {
 			// Maintain list type integrity between levels
 			if (child.subtype === LIST_LEVEL_NODE && child.content.type !== node.content.type) {
 				const bulletList =
-					node.content.type === 'unordered'
+					node.content.type === ListStyles.TYPE_UNORDERED
 						? ListStyles.UNORDERED_LIST_BULLETS
 						: ListStyles.ORDERED_LIST_BULLETS
 				const bulletStyle =
@@ -174,7 +174,7 @@ const normalizeNode = (entry, editor, next) => {
 				{
 					type: LIST_NODE,
 					content: {
-						listStyles: { type: 'unordered' }
+						listStyles: { type: ListStyles.TYPE_UNORDERED }
 					},
 					children: []
 				},

--- a/packages/obonode/obojobo-chunks-list/changes/wrap-level-or-tab.js
+++ b/packages/obonode/obojobo-chunks-list/changes/wrap-level-or-tab.js
@@ -5,23 +5,28 @@ const LIST_NODE = 'ObojoboDraft.Chunks.List'
 const LIST_LEVEL_NODE = 'ObojoboDraft.Chunks.List.Level'
 const LIST_LINE_NODE = 'ObojoboDraft.Chunks.List.Line'
 
-
 const wrapLevelOrTab = (entry, editor, event) => {
 	event.preventDefault()
 	const [, nodePath] = entry
 	const nodeRange = Editor.range(editor, nodePath)
 	const selectedInsideNode = Range.intersection(editor.selection, nodeRange)
 
-	const list = Array.from(Editor.nodes(editor, {
-		at: selectedInsideNode,
-		mode: 'lowest',
-		match: child => child.subtype === LIST_LINE_NODE
-	}))
+	const list = Array.from(
+		Editor.nodes(editor, {
+			at: selectedInsideNode,
+			mode: 'lowest',
+			match: child => child.subtype === LIST_LINE_NODE
+		})
+	)
 
 	// If there is only one line selected and the selection is not at the start of the line
 	// insert a tab instead of indenting
-	if(Range.equals(selectedInsideNode, editor.selection) && list.length === 1 
-		&& editor.selection.anchor.offset !== 0 && editor.selection.focus.offset !== 0){
+	if (
+		Range.equals(selectedInsideNode, editor.selection) &&
+		list.length === 1 &&
+		editor.selection.anchor.offset !== 0 &&
+		editor.selection.focus.offset !== 0
+	) {
 		return editor.insertText('\t')
 	}
 
@@ -29,25 +34,28 @@ const wrapLevelOrTab = (entry, editor, event) => {
 	// which can change the paths of subsequent ListLines. To keep the paths consistant,
 	// prevent normalization until all Lines have been indented
 	Editor.withoutNormalizing(editor, () => {
-		for(const [, path] of list) {
+		for (const [, path] of list) {
 			// Do not allow indenting past 20 (18 levels), because it will cause display errors
-			if(path.length >= 20) continue
-				
-			const [parent,] = Editor.parent(editor, path)
+			if (path.length >= 20) continue
+
+			const [parent] = Editor.parent(editor, path)
 
 			const bulletList =
-			parent.content.type === 'unordered' ? ListStyles.UNORDERED_LIST_BULLETS : ListStyles.ORDERED_LIST_BULLETS
-			const bulletStyle = bulletList[(bulletList.indexOf(parent.content.bulletStyle) + 1) % bulletList.length]
-			
+				parent.content.type === ListStyles.TYPE_UNORDERED
+					? ListStyles.UNORDERED_LIST_BULLETS
+					: ListStyles.ORDERED_LIST_BULLETS
+			const bulletStyle =
+				bulletList[(bulletList.indexOf(parent.content.bulletStyle) + 1) % bulletList.length]
+
 			Transforms.wrapNodes(
-				editor, 
+				editor,
 				{
 					type: LIST_NODE,
 					subtype: LIST_LEVEL_NODE,
 					content: { type: parent.content.type, bulletStyle }
 				},
 				{
-					at: path,
+					at: path
 				}
 			)
 		}

--- a/packages/obonode/obojobo-chunks-list/changes/wrap-level.js
+++ b/packages/obonode/obojobo-chunks-list/changes/wrap-level.js
@@ -5,41 +5,45 @@ const LIST_NODE = 'ObojoboDraft.Chunks.List'
 const LIST_LEVEL_NODE = 'ObojoboDraft.Chunks.List.Level'
 const LIST_LINE_NODE = 'ObojoboDraft.Chunks.List.Line'
 
-
 const wrapLevel = (entry, editor, event) => {
 	event.preventDefault()
 	const [, nodePath] = entry
 	const nodeRange = Editor.range(editor, nodePath)
 
-	const list = Array.from(Editor.nodes(editor, {
-		at: Range.intersection(editor.selection, nodeRange),
-		mode: 'lowest',
-		match: child => child.subtype === LIST_LINE_NODE
-	}))
+	const list = Array.from(
+		Editor.nodes(editor, {
+			at: Range.intersection(editor.selection, nodeRange),
+			mode: 'lowest',
+			match: child => child.subtype === LIST_LINE_NODE
+		})
+	)
 
 	// Normalization will merge consecutive ListLevels into a single node,
 	// which can change the paths of subsequent ListLines. To keep the paths consistant,
 	// prevent normalization until all Lines have been indented
 	Editor.withoutNormalizing(editor, () => {
-		for(const [, path] of list) {
+		for (const [, path] of list) {
 			// Do not allow indenting past 20 (18 levels), because it will cause display errors
-			if(path.length >= 20) continue
-				
-			const [parent,] = Editor.parent(editor, path)
+			if (path.length >= 20) continue
+
+			const [parent] = Editor.parent(editor, path)
 
 			const bulletList =
-			parent.content.type === 'unordered' ? ListStyles.UNORDERED_LIST_BULLETS : ListStyles.ORDERED_LIST_BULLETS
-			const bulletStyle = bulletList[(bulletList.indexOf(parent.content.bulletStyle) + 1) % bulletList.length]
-			
+				parent.content.type === ListStyles.TYPE_UNORDERED
+					? ListStyles.UNORDERED_LIST_BULLETS
+					: ListStyles.ORDERED_LIST_BULLETS
+			const bulletStyle =
+				bulletList[(bulletList.indexOf(parent.content.bulletStyle) + 1) % bulletList.length]
+
 			Transforms.wrapNodes(
-				editor, 
+				editor,
 				{
 					type: LIST_NODE,
 					subtype: LIST_LEVEL_NODE,
 					content: { type: parent.content.type, bulletStyle }
 				},
 				{
-					at: path,
+					at: path
 				}
 			)
 		}


### PR DESCRIPTION
Mostly cut and dry, prettier made things a little harder to see

Converts `'unordered'` to >> `ListStyles.TYPE_UNORDERED` where ListStyles was already imported