### PR TITLE
Collapsable question banks

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/common/components/button.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/components/button.js
@@ -51,6 +51,9 @@ export default class Button extends React.Component {
 					aria-label={this.props.ariaLabel}
 					aria-selected={this.props.ariaSelected}
 					contentEditable={false}
+					onKeyDown={this.props.onKeyDown}
+					onFocus={this.props.onFocus}
+					onBlur={this.props.onBlur}
 				>
 					{children}
 				</button>

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
@@ -145,7 +145,7 @@ class Node extends React.Component {
 
 		return (
 			<div className={className} data-obo-component="true">
-				{this.props.selected ? (
+				{this.props.selected && !this.props.hideInsertMenus ? (
 					<div className={'component-toolbar'}>
 						<InsertMenu
 							dropOptions={Common.Registry.insertableItems}

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/util/selection-util.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/util/selection-util.js
@@ -1,0 +1,110 @@
+import { Editor, Transforms, Point, Range } from 'slate'
+
+const SelectionUtil = {
+	/**
+	 * Reset a selection point when changing between nodes of different depths
+	 * This is promarily used when converting to and from lists, as the nested levels
+	 * cause the selection to be lost
+	 * 
+	 * @param {Object} editor A Slate editor
+	 * @param {Array} path The path to the Obojobo node
+	 * @param {Object} point The original point that needs to be reset
+	 * @param {Array} leafPath The path to the leaf-most Element that contained the point (a child of path before conversion)
+	 * @param {String} leafSubtype The subtype of the leaf-most node that the new point will be inside
+	 * @param {start | anchor | end | focus} edge Which selection point is being set
+	 */
+
+	resetPointAtUncertainDepth(editor, path, point, leafPath, leafSubtype, edge) {
+		// Since the depth is uncertian, we use the given path to find any matching children
+		// If we are resetting the start || anchor, we want the first node
+		// Otherwise (resetting end or focus), we want the last node
+		const [foundNode] = Array.from(
+			Editor.nodes(editor, {
+				at: path,
+				match: n => n.subtype === leafSubtype,
+				reverse: edge === 'end' || edge ==='focus'
+			})
+		)
+
+		// The difference between startPath and start Point indicates what inline
+		// and what text leaf is currently selected
+		const leafDepth = point.path.length - leafPath.length
+		const relativeLeafPath = point.path.slice(point.path.length - leafDepth)
+
+		// Therefore, the point to focus on is
+		// the line's path
+		// + the relative leaf path
+		// + the original offset
+		Transforms.setPoint(
+			editor,
+			{
+				path: foundNode[1].concat(relativeLeafPath),
+				offset: point.offset
+			},
+			{ edge }
+		)
+	},
+
+	moveSelectionOutsideNode(editor, path) {
+		const selection = editor.selection || editor.prevSelection
+		const nodeRange = Editor.range(editor, path)
+
+		// If the current selection is not in the node, don't do anything
+		if(!Range.intersection(selection, nodeRange)) return
+
+		// If the start point is before the qb, move the selection to before the qb
+		const nodeStart = Range.start(nodeRange)
+		const selectionStart = Range.start(selection)
+		const before = Editor.before(editor, nodeStart)
+		if(Point.isBefore(selectionStart, nodeStart)) {
+			return Transforms.setSelection(
+				editor, 
+				{ 
+					anchor: selectionStart,
+					focus: before,
+				}
+			)
+		}
+
+		// If the start point is after the qb, move the selection to after the qb
+		const nodeEnd = Range.end(nodeRange)
+		const selectionEnd = Range.end(selection)
+		const after = Editor.after(editor, nodeEnd)
+		if(Point.isAfter(selectionEnd, nodeEnd)) {
+			return Transforms.setSelection(
+				editor, 
+				{ 
+					anchor: after,
+					focus: selectionEnd
+				}
+			)
+		}
+		// Otherwise, try to move the selection to before the qb
+		// If a point before the question bank exists, move to it
+		if(before) {
+			return Transforms.setSelection(
+				editor, 
+				{ 
+					anchor: before,
+					focus: before
+				}
+			)
+		}
+
+		// If a point after the question bank exists, move to it
+		if(after) {
+			return Transforms.setSelection(
+				editor, 
+				{ 
+					anchor: after,
+					focus: after
+				}
+			)
+		}
+
+		// If no before and after points exist, de-focus the editor
+		Transforms.deselect(editor)
+	}
+}
+
+export default SelectionUtil

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/editor-component.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/editor-component.js
@@ -2,10 +2,12 @@ import React from 'react'
 import { Transforms } from 'slate'
 import { ReactEditor } from 'slate-react'
 import Common from 'obojobo-document-engine/src/scripts/common'
+import SelectionUtil from 'obojobo-document-engine/src/scripts/oboeditor/util/selection-util'
 import withSlateWrapper from 'obojobo-document-engine/src/scripts/oboeditor/components/node/with-slate-wrapper'
 
 import './editor-component.scss'
 
+const isOrNot = Common.util.isOrNot
 const { Button, Switch } = Common.components
 const MCCHOICE_NODE = 'ObojoboDraft.Chunks.MCAssessment.MCChoice'
 const MCANSWER_NODE = 'ObojoboDraft.Chunks.MCAssessment.MCAnswer'
@@ -13,6 +15,23 @@ const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
 const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
 
 class MCAssessment extends React.Component {
+	constructor(props) {
+		super(props)
+
+		this.state = {
+			open: true
+		}
+
+		this.toggleOpen = this.toggleOpen.bind(this)
+	}
+
+	componentDidUpdate(prevProps) {
+		// When the cursor moves into the mcassessment, expand it
+		if(!prevProps.selected && this.props.selected) {
+			this.setState({ open: true })
+		}
+	}
+
 	changeResponseType(event) {
 		const path = ReactEditor.findPath(this.props.editor, this.props.element)
 		return Transforms.setNodes(
@@ -63,33 +82,91 @@ class MCAssessment extends React.Component {
 		)
 	}
 
+	toggleOpen() {
+		this.setState(prevState => {
+			if(prevState.open) {
+				// Move the selection outside of the mcassess if it is currently in there
+				const path = ReactEditor.findPath(this.props.editor, this.props.element)
+				SelectionUtil.moveSelectionOutsideNode(this.props.editor, path)
+				
+				// Close the mcassess
+				return ({ open: false })
+			}
+
+			return ({ open: true })
+		})
+	}
+
+	displaySummary() {
+		const { element } = this.props
+
+		if(element.questionType === 'survey') {
+			const answers = element.children.length
+			const answerText = answers > 1 ? answers + ' choices' : answers + ' choice'
+			return (
+				<div contentEditable={false}>
+				{ answerText + ' hidden' }
+				</div>
+			)
+		}
+
+		const correctChoices = element.children.filter(node => node.content.score === 100).length
+		const incorrectChoices = element.children.filter(node => node.content.score !== 100).length
+
+		// Parse the number of children into readable text
+		let correctText = correctChoices > 0 ? correctChoices + ' correct choice' : ''
+		correctText = correctChoices > 1 ? correctText + 's' : correctText
+		correctText = correctText && incorrectChoices > 0 ? correctText + ' and ' : correctText
+
+		let incorrectText = incorrectChoices > 0 ? incorrectChoices + ' incorrect choice' : ''
+		incorrectText = incorrectChoices > 1 ? incorrectText + 's' : incorrectText
+
+		// There will always be at least one question/questionbank inside a question bank
+		// so we will always need to display this text.
+		return (
+			<div contentEditable={false}>
+				{ correctText + incorrectText + ' hidden' }
+			</div>
+		)
+	}
+
 	render() {
 		const questionType = this.props.element.questionType || 'default'
 		const content = this.props.element.content
 
+		const className = `component obojobo-draft--chunks--mc-assessment editor--mc-assessment is-type-${questionType}` 
+			+ isOrNot(this.state.open, 'open')
+
 		return (
-			<div
-				className={`component obojobo-draft--chunks--mc-assessment editor--mc-assessment is-type-${questionType}`}
-			>
-				<div className="mc-settings" contentEditable={false}>
-					<label>
-						Response Type
-						<select value={content.responseType} onChange={this.changeResponseType.bind(this)}>
-							<option value="pick-one">Pick one correct answer</option>
-							<option value="pick-all">Pick all correct answers</option>
-						</select>
-					</label>
-					<Switch
-						title="Shuffle Choices"
-						initialChecked={content.shuffle}
-						handleCheckChange={this.changeShuffle.bind(this)}
-					/>
-				</div>
-				<div>
-					{this.props.children}
-					<Button className={'choice-button pad'} onClick={this.addChoice.bind(this)}>
-						{'+ Add Choice'}
-					</Button>
+			<div className={className}>
+				<Button
+					className="collapse-button"
+					onClick={this.toggleOpen}
+					contentEditable={false}>
+					{'⌃'}
+				</Button>
+				{!this.state.open ? this.displaySummary() : null}
+				<div className="mc-content">
+					<div className="mc-settings" contentEditable={false}>
+						<label>
+							Response Type
+							<select value={content.responseType} onChange={this.changeResponseType.bind(this)}>
+								<option value="pick-one">Pick one correct answer</option>
+								<option value="pick-all">Pick all correct answers</option>
+							</select>
+						</label>
+						<Switch
+							title="Shuffle Choices"
+							initialChecked={content.shuffle}
+							handleCheckChange={this.changeShuffle.bind(this)}
+						/>
+					</div>
+					<div>
+						{this.props.children}
+						<Button className={'choice-button pad'} onClick={this.addChoice.bind(this)}>
+							{'+ Add Choice'}
+						</Button>
+					</div>
 				</div>
 			</div>
 		)

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/editor-component.scss
@@ -4,6 +4,8 @@
 	background-color: $color-bg2;
 	padding: 0.5em;
 	margin-top: 0;
+	position: relative;
+	min-height: 1em;
 
 	> div {
 		background-color: $color-bg;
@@ -12,6 +14,50 @@
 		.obojobo-draft--components--button {
 			padding-top: 0.5em;
 			padding-bottom: 0.5em;
+		}
+	}
+
+	.collapse-button {
+		position: absolute;
+		left: 0.5em;
+		right: auto;
+		top: 0.5em;
+		z-index: 3;
+		transform: rotate(-180deg);
+		background: none;
+
+		.button {
+			font-size: 1.2em;
+			padding: 0;
+			min-width: 1.4em;
+			border-radius: 50%;
+			border: none;
+			background: none;
+			font-weight: bold;
+			color: $color-shadow;
+
+			&:hover {
+				background: none;
+				color: $color-obojobo-blue;
+			}
+		}
+	}
+
+	&.is-not-open {
+		> div {
+			background: none;
+			text-align: center;
+		}
+
+		.mc-content {
+			display: none;
+			text-align: center;
+		}
+
+		.collapse-button {	
+			top: 0.5em;
+			left: 0em;
+			transform: rotate(90deg);
 		}
 	}
 

--- a/packages/obonode/obojobo-chunks-question-bank/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-question-bank/__snapshots__/editor-component.test.js.snap
@@ -1,115 +1,145 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`QuestionBank editor QuestionBank builds the expected component 1`] = `
-<div
-  className="oboeditor-component component "
-  data-obo-component="true"
->
+<div>
   <div
-    className="obojobo-draft--chunks--question-bank editor-bank"
+    className="obojobo-draft--chunks--question-bank editor-bank  is-open"
   >
     <div
-      className="obojobo-draft--components--button is-not-dangerous align-center delete-button"
+      className="obojobo-draft--components--button is-not-dangerous align-center collapse-button"
     >
       <button
         className="button"
         contentEditable={false}
         onClick={[Function]}
       >
+        ⌃
+      </button>
+    </div>
+    <div
+      className="obojobo-draft--components--button is-not-dangerous align-center delete-button"
+    >
+      <button
+        className="button"
+        contentEditable={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+      >
         ×
       </button>
     </div>
     <div
-      className="qb-settings"
+      className="question-bank-content"
     >
-      <fieldset
-        className="choose"
+      <div
+        className="qb-settings"
+        contentEditable={false}
       >
-        <legend>
-          How many questions should be displayed?
-        </legend>
-        <label>
-          <input
-            name="undefined-choose"
-            onChange={[Function]}
-            type="radio"
-            value="all"
-          />
-          All questions
-        </label>
-        <span>
-           or
-        </span>
-        <label>
-          <input
-            checked={true}
-            name="undefined-choose"
-            onChange={[Function]}
-            type="radio"
-            value="pick"
-          />
-          Pick
-        </label>
-        <input
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          type="number"
-        />
-      </fieldset>
-      <label
-        className="select"
-      >
-        How should questions be selected?
-        <select
-          onChange={[Function]}
-          onClick={[Function]}
+        <fieldset
+          className="choose"
         >
-          <option
+          <legend>
+            How many questions should be displayed?
+          </legend>
+          <label>
+            <input
+              name="undefined-choose"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="radio"
+              value="all"
+            />
+            All questions
+          </label>
+          <span>
+             or
+          </span>
+          <label>
+            <input
+              checked={true}
+              name="undefined-choose"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="radio"
+              value="pick"
+            />
+            Pick
+          </label>
+          <input
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            type="number"
+            value={1}
+          />
+        </fieldset>
+        <label
+          className="select"
+        >
+          How should questions be selected?
+          <select
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
             value="sequential"
           >
-            In order
-          </option>
-          <option
-            value="random"
-          >
-            Randomly
-          </option>
-          <option
-            value="random-unseen"
-          >
-            Randomly, with no repeats
-          </option>
-        </select>
-      </label>
-    </div>
-    <div
-      className="button-bar"
-    >
-      <div
-        className="obojobo-draft--components--button is-not-dangerous align-center"
-      >
-        <button
-          className="button"
-          contentEditable={false}
-          onClick={[Function]}
-        >
-          Add Question
-        </button>
+            <option
+              value="sequential"
+            >
+              In order
+            </option>
+            <option
+              value="random"
+            >
+              Randomly
+            </option>
+            <option
+              value="random-unseen"
+            >
+              Randomly, with no repeats
+            </option>
+          </select>
+        </label>
       </div>
       <div
-        className="obojobo-draft--components--button is-not-dangerous align-center"
+        className="button-bar"
+        contentEditable={false}
       >
-        <button
-          className="button"
-          contentEditable={false}
-          onClick={[Function]}
+        <div
+          className="obojobo-draft--components--button is-not-dangerous align-center"
         >
-          Add Question Bank
-        </button>
+          <button
+            className="button"
+            contentEditable={false}
+            onClick={[Function]}
+          >
+            Add Question
+          </button>
+        </div>
+        <div
+          className="obojobo-draft--components--button is-not-dangerous align-center"
+        >
+          <button
+            className="button"
+            contentEditable={false}
+            onClick={[Function]}
+          >
+            Add Question Bank
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </div>
 `;
+
+exports[`QuestionBank editor QuestionBank component changes choose amount 1`] = `"<div><div class=\\"obojobo-draft--chunks--question-bank editor-bank  is-open\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center collapse-button\\"><button class=\\"button\\" contenteditable=\\"false\\">⌃</button></div><div class=\\"obojobo-draft--components--button is-not-dangerous align-center delete-button\\"><button class=\\"button\\" contenteditable=\\"false\\">×</button></div><div class=\\"question-bank-content\\"><div class=\\"qb-settings\\" contenteditable=\\"false\\"><fieldset class=\\"choose\\"><legend>How many questions should be displayed?</legend><label><input type=\\"radio\\" name=\\"undefined-choose\\" value=\\"all\\">All questions</label><span> or</span><label><input type=\\"radio\\" name=\\"undefined-choose\\" value=\\"pick\\" checked=\\"\\">Pick</label><input type=\\"number\\" value=\\"7\\"></fieldset><label class=\\"select\\">How should questions be selected?<select><option value=\\"sequential\\">In order</option><option value=\\"random\\">Randomly</option><option value=\\"random-unseen\\">Randomly, with no repeats</option></select></label></div><div class=\\"button-bar\\" contenteditable=\\"false\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center\\"><button class=\\"button\\" contenteditable=\\"false\\">Add Question</button></div><div class=\\"obojobo-draft--components--button is-not-dangerous align-center\\"><button class=\\"button\\" contenteditable=\\"false\\">Add Question Bank</button></div></div></div></div></div>"`;
+
+exports[`QuestionBank editor QuestionBank component changes choose type 1`] = `"<div><div class=\\"obojobo-draft--chunks--question-bank editor-bank  is-open\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center collapse-button\\"><button class=\\"button\\" contenteditable=\\"false\\">⌃</button></div><div class=\\"obojobo-draft--components--button is-not-dangerous align-center delete-button\\"><button class=\\"button\\" contenteditable=\\"false\\">×</button></div><div class=\\"question-bank-content\\"><div class=\\"qb-settings\\" contenteditable=\\"false\\"><fieldset class=\\"choose\\"><legend>How many questions should be displayed?</legend><label><input type=\\"radio\\" name=\\"undefined-choose\\" value=\\"all\\">All questions</label><span> or</span><label><input type=\\"radio\\" name=\\"undefined-choose\\" value=\\"pick\\" checked=\\"\\">Pick</label><input type=\\"number\\" value=\\"8\\" disabled=\\"\\"></fieldset><label class=\\"select\\">How should questions be selected?<select><option value=\\"sequential\\">In order</option><option value=\\"random\\">Randomly</option><option value=\\"random-unseen\\">Randomly, with no repeats</option></select></label></div><div class=\\"button-bar\\" contenteditable=\\"false\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center\\"><button class=\\"button\\" contenteditable=\\"false\\">Add Question</button></div><div class=\\"obojobo-draft--components--button is-not-dangerous align-center\\"><button class=\\"button\\" contenteditable=\\"false\\">Add Question Bank</button></div></div></div></div></div>"`;
+
+exports[`QuestionBank editor QuestionBank component changes select type 1`] = `"<div><div class=\\"obojobo-draft--chunks--question-bank editor-bank  is-open\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center collapse-button\\"><button class=\\"button\\" contenteditable=\\"false\\">⌃</button></div><div class=\\"obojobo-draft--components--button is-not-dangerous align-center delete-button\\"><button class=\\"button\\" contenteditable=\\"false\\">×</button></div><div class=\\"question-bank-content\\"><div class=\\"qb-settings\\" contenteditable=\\"false\\"><fieldset class=\\"choose\\"><legend>How many questions should be displayed?</legend><label><input type=\\"radio\\" name=\\"undefined-choose\\" value=\\"all\\">All questions</label><span> or</span><label><input type=\\"radio\\" name=\\"undefined-choose\\" value=\\"pick\\" checked=\\"\\">Pick</label><input type=\\"number\\" value=\\"8\\"></fieldset><label class=\\"select\\">How should questions be selected?<select><option value=\\"sequential\\">In order</option><option value=\\"random\\">Randomly</option><option value=\\"random-unseen\\">Randomly, with no repeats</option></select></label></div><div class=\\"button-bar\\" contenteditable=\\"false\\"><div class=\\"obojobo-draft--components--button is-not-dangerous align-center\\"><button class=\\"button\\" contenteditable=\\"false\\">Add Question</button></div><div class=\\"obojobo-draft--components--button is-not-dangerous align-center\\"><button class=\\"button\\" contenteditable=\\"false\\">Add Question Bank</button></div></div></div></div></div>"`;

--- a/packages/obonode/obojobo-chunks-question-bank/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question-bank/editor-component.js
@@ -7,6 +7,7 @@ import { ReactEditor } from 'slate-react'
 import Common from 'obojobo-document-engine/src/scripts/common'
 import Node from 'obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component'
 import withSlateWrapper from 'obojobo-document-engine/src/scripts/oboeditor/components/node/with-slate-wrapper'
+import debounce from 'obojobo-document-engine/src/scripts/common/util/debounce'
 
 import emptyQB from './empty-node.json'
 
@@ -15,130 +16,140 @@ const isOrNot = Common.util.isOrNot
 const QUESTION_NODE = 'ObojoboDraft.Chunks.Question'
 const QUESTION_BANK_NODE = 'ObojoboDraft.Chunks.QuestionBank'
 
-const remove = (editor, element) => {
-	const path = ReactEditor.findPath(editor, element)
-	return Transforms.removeNodes(editor, { at: path })
-}
-
-const addQuestion = (editor, element) => {
-	const Question = Common.Registry.getItemForType(QUESTION_NODE)
-	const path = ReactEditor.findPath(editor, element)
-	return Transforms.insertNodes(
-		editor,
-		Question.insertJSON,
-		{ at: path.concat(element.children.length) }
-	)
-}
-
-const addQuestionBank = (editor, element) => {
-	const path = ReactEditor.findPath(editor, element)
-	return Transforms.insertNodes(
-		editor,
-		emptyQB,
-		{ at: path.concat(element.children.length) }
-	)
-}
-
-const changeChooseType = (editor, element, event) => {
-	event.stopPropagation()
-	const chooseAll = event.target.value === 'all'
-
-	const path = ReactEditor.findPath(editor, element)
-	Transforms.setNodes(
-		editor, 
-		{ content: { ...element.content, chooseAll } },
-		{ at: path }
-	)
-}
-
-const changeChooseAmount = (editor, element, event) => {
-	const path = ReactEditor.findPath(editor, element)
-	Transforms.setNodes(
-		editor, 
-		{ content: { ...element.content, choose: event.target.value } },
-		{ at: path }
-	)
-}
-
-const changeSelect = (editor, element, event) => {
-	const path = ReactEditor.findPath(editor, element)
-	Transforms.setNodes(
-		editor, 
-		{ content: { ...element.content, select: event.target.value } },
-		{ at: path }
-	)
-}
-
-const freezeEditor = (editor) => {
-	editor.toggleEditable(false)
-}
-
-const unfreezeEditor = (editor) => {
-	editor.toggleEditable(true)
-}
-
-const displaySettings = (editor, element, content) => {
-	const radioGroupName = `${element.id}-choose`
-	return (
-		<div className={'qb-settings'}>
-			<fieldset className="choose">
-				<legend>How many questions should be displayed?</legend>
-				<label>
-					<input
-						type="radio"
-						name={radioGroupName}
-						value="all"
-						checked={content.chooseAll}
-						onChange={changeChooseType.bind(this, editor, element)}/>
-					All questions
-				</label>
-				<span> or</span>
-				<label>
-					<input
-						type="radio"
-						name={radioGroupName}
-						value="pick"
-						checked={!content.chooseAll}
-						onChange={changeChooseType.bind(this, editor, element)}/>
-					Pick
-				</label>
-				<input
-					type="number"
-					value={content.choose}
-					disabled={content.chooseAll}
-					onClick={event => event.stopPropagation()}
-					onChange={changeChooseAmount.bind(this, editor, element)}
-					onFocus={freezeEditor.bind(this, editor)}
-					onBlur={unfreezeEditor.bind(this, editor)}/>
-			</fieldset>
-			<label className="select">
-				How should questions be selected?
-				<select
-					value={content.select}
-					onClick={event => event.stopPropagation()}
-					onChange={changeSelect.bind(this, editor, element)}>
-					<option value="sequential">In order</option>
-					<option value="random">Randomly</option>
-					<option value="random-unseen">Randomly, with no repeats</option>
-				</select>
-			</label>
-		</div>
-	)
-}
-
 class QuestionBank extends React.Component {
 	constructor(props) {
 		super(props)
 
-		this.state = {
-			open: true
-		}
+		// This debounce is necessary to get slate to update the node data.
+		// I've tried several ways to remove it but haven't been able to
+		// get it work :(
+		// If you have a solution please have at it!
+		this.updateNodeFromState = debounce(1, this.updateNodeFromState)
+
+		// copy the attributes we want into state
+		const content = this.props.element.content
+		this.state = this.contentToStateObj(content)
+
+		this.freezeEditor = this.freezeEditor.bind(this)
+		this.unfreezeEditor = this.unfreezeEditor.bind(this)
 
 		this.toggleOpen = this.toggleOpen.bind(this)
 	}
 
-	// When the selected prop changes from false to true, toggle state open
+	onChangeContent(key, event) {
+		const newContent = { [key]: event.target.value }
+		this.setState(newContent) // update the display now
+	}
 
+
+	contentToStateObj(content) {
+		return {
+			chooseAll: content.chooseAll,
+			choose: content.choose || 1,
+			select: content.select || 'sequential',
+			open: true
+		}
+	}
+
+	componentDidUpdate(prevProps) {
+		if (prevProps.selected && !this.props.selected) {
+			this.updateNodeFromState()
+		}
+	}
+
+	updateNodeFromState() {
+		const content = this.props.element.content
+		delete this.state.open
+		const path = ReactEditor.findPath(this.props.editor, this.props.element)
+		Transforms.setNodes(this.props.editor, { content: { ...content, ...this.state } }, { at: path })
+	}
+
+	remove() {
+		const path = ReactEditor.findPath(this.props.editor, this.props.element)
+		return Transforms.removeNodes(this.props.editor, { at: path })
+	}
+
+	addQuestion() {
+		const Question = Common.Registry.getItemForType(QUESTION_NODE)
+		const path = ReactEditor.findPath(this.props.editor, this.props.element)
+		return Transforms.insertNodes(this.props.editor, Question.insertJSON, {
+			at: path.concat(this.props.element.children.length)
+		})
+	}
+
+	addQuestionBank() {
+		const path = ReactEditor.findPath(this.props.editor, this.props.element)
+		return Transforms.insertNodes(this.props.editor, emptyQB, {
+			at: path.concat(this.props.element.children.length)
+		})
+	}
+
+	changeChooseType(event) {
+		event.stopPropagation()
+		const chooseAll = event.target.value === 'all'
+		this.setState({ chooseAll }) // update the display now
+	}
+
+	displaySettings(editor, element) {
+		const radioGroupName = `${element.id}-choose`
+		return (
+			<div className={'qb-settings'} contentEditable={false}>
+				<fieldset className="choose">
+					<legend>How many questions should be displayed?</legend>
+					<label>
+						<input
+							type="radio"
+							name={radioGroupName}
+							value="all"
+							checked={this.state.chooseAll}
+							onChange={this.changeChooseType.bind(this)}
+							onFocus={this.freezeEditor}
+							onBlur={this.unfreezeEditor}
+						/>
+						All questions
+					</label>
+					<span> or</span>
+					<label>
+						<input
+							type="radio"
+							name={radioGroupName}
+							value="pick"
+							checked={!this.state.chooseAll}
+							onChange={this.changeChooseType.bind(this)}
+							onFocus={this.freezeEditor}
+							onBlur={this.unfreezeEditor}
+						/>
+						Pick
+					</label>
+					<input
+						type="number"
+						value={this.state.choose}
+						disabled={this.state.chooseAll}
+						onClick={event => event.stopPropagation()}
+						onChange={this.onChangeContent.bind(this, 'choose')}
+						onFocus={this.freezeEditor}
+						onBlur={this.unfreezeEditor}
+					/>
+				</fieldset>
+				<label className="select">
+					How should questions be selected?
+					<select
+						value={this.state.select}
+						onClick={event => event.stopPropagation()}
+						onChange={this.onChangeContent.bind(this, 'select')}
+						onFocus={this.freezeEditor}
+						onBlur={this.unfreezeEditor}
+					>
+						<option value="sequential">In order</option>
+						<option value="random">Randomly</option>
+						<option value="random-unseen">Randomly, with no repeats</option>
+					</select>
+				</label>
+			</div>
+		)
+	}
+
+	// When the selected prop changes from false to true, toggle state open
 	toggleOpen() {
 		this.setState(prevState => {
 			if(prevState.open) {
@@ -175,6 +186,18 @@ class QuestionBank extends React.Component {
 		)
 	}
 
+	freezeEditor() {
+		clearTimeout(window.restoreEditorFocusId)
+		this.props.editor.toggleEditable(false)
+	}
+
+	unfreezeEditor() {
+		window.restoreEditorFocusId = setTimeout(() => {
+			this.updateNodeFromState()
+			this.props.editor.toggleEditable(true)
+		})
+	}
+
 	render() {
 		const { editor, element, children } = this.props
 
@@ -192,29 +215,19 @@ class QuestionBank extends React.Component {
 					</Button>
 					<Button
 						className="delete-button"
-						onClick={() => {
-							remove(editor, element)
-						}}
+						onClick={this.remove.bind(this)}
+						onFocus={this.freezeEditor}
+						onBlur={this.unfreezeEditor}
 						contentEditable={false}>
 						&times;
 					</Button>
 					{!this.state.open ? this.displaySummary() : null}
 					<div className="question-bank-content">
-						{displaySettings(editor, element, element.content)}
+						{this.displaySettings(editor, element, element.content)}
 						{children}
-						<div className="button-bar">
-							<Button
-								onClick={() => {
-									addQuestion(editor, element)
-								}}>
-								Add Question
-							</Button>
-							<Button
-								onClick={() => {
-									addQuestionBank(editor, element)
-								}}>
-								Add Question Bank
-							</Button>
+						<div className="button-bar" contentEditable={false}>
+							<Button onClick={this.addQuestion.bind(this)}>Add Question</Button>
+							<Button onClick={this.addQuestionBank.bind(this)}>Add Question Bank</Button>
 						</div>
 					</div>
 				</div>

--- a/packages/obonode/obojobo-chunks-question-bank/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-question-bank/editor-component.scss
@@ -45,11 +45,19 @@
 		}
 	}
 
-	// Remove padding for nested questionbanks
+	// Remove padding for nested questionbanks and questions
 	.obojobo-draft--chunks--question-bank {
 		margin-left: 0;
 		margin-right: 0;
 		font-size: 0.9em;
+	}
+
+	.obojobo-draft--chunks--question {
+		&.pad {
+			padding-left: 0;
+			padding-right: 0;
+			font-size: 0.9em;
+		}
 	}
 
 	.qb-settings {
@@ -59,12 +67,15 @@
 		display: flex;
 		flex-flow: row wrap;
 		justify-content: center;
+		user-select: none;
 
 		.choose {
 			display: inline-block;
 			border: none;
 			margin-inline-start: 0;
 			padding-inline-start: 0;
+			padding-block-end: 0;
+			padding-inline-end: 0;
 			margin: 0.5em;
 			text-align: center;
 

--- a/packages/obonode/obojobo-chunks-question-bank/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-question-bank/editor-component.scss
@@ -56,10 +56,17 @@
 		font-size: 0.85em;
 		font-family: $font-default;
 		font-weight: bold;
+		display: flex;
+		flex-flow: row wrap;
+		justify-content: center;
 
 		.choose {
 			display: inline-block;
 			border: none;
+			margin-inline-start: 0;
+			padding-inline-start: 0;
+			margin: 0.5em;
+			text-align: center;
 
 			input[type='radio'] {
 				margin-right: 0.5em;
@@ -85,11 +92,10 @@
 
 		.select {
 			display: inline-block;
-			text-align: right;
-			min-width: 19em;
-			position: absolute;
-			top: 1.8em;
-			right: 2.5em;
+			display: flex;
+			flex-direction: column;
+			padding-bottom: 0.5em;
+			margin: 0.5em;
 
 			select {
 				display: block;
@@ -97,7 +103,7 @@
 				border-radius: $dimension-rounded-radius;
 				font-size: 0.7em;
 				background-color: $color-bg;
-				min-width: 24em;
+				width: 24em;
 				padding: 0.7em 2.5em 0.7em 0.5em;
 				appearance: none;
 				//stylelint-disable-next-line declaration-colon-newline-after, value-list-comma-newline-after
@@ -110,8 +116,6 @@
 				background-repeat: no-repeat;
 				margin-top: 0.5em;
 				direction: rtl;
-				position: relative;
-				left: 3em;
 
 				option {
 					direction: rtl;

--- a/packages/obonode/obojobo-chunks-question-bank/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-question-bank/editor-component.scss
@@ -8,6 +8,43 @@
 	margin-right: 3em;
 	padding: 1.5em;
 
+	.collapse-button {
+		position: absolute;
+		left: 0;
+		right: auto;
+		top: -0.2em;
+		z-index: 3;
+		transform: rotate(-180deg);
+
+		.button {
+			font-size: 1.2em;
+			padding: 0;
+			min-width: 1.4em;
+			border-radius: 50%;
+			border: none;
+			background: none;
+			font-weight: bold;
+			color: $color-shadow;
+
+			&:hover {
+				background: none;
+				color: $color-obojobo-blue;
+			}
+		}
+	}
+
+	&.is-not-open {
+		.question-bank-content {
+			display: none;
+		}
+
+		.collapse-button {	
+			top: 0;
+			left: -0.2em;
+			transform: rotate(90deg);
+		}
+	}
+
 	// Remove padding for nested questionbanks
 	.obojobo-draft--chunks--question-bank {
 		margin-left: 0;

--- a/packages/obonode/obojobo-chunks-question-bank/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-question-bank/editor-component.test.js
@@ -20,6 +20,12 @@ jest.mock(
 	'obojobo-document-engine/src/scripts/oboeditor/components/node/with-slate-wrapper',
 	() => item => item
 )
+jest.mock(
+	'obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component',
+	() => props => <div>{props.children}</div>
+)
+
+jest.useFakeTimers()
 
 describe('QuestionBank editor', () => {
 	test('QuestionBank builds the expected component', () => {
@@ -75,7 +81,7 @@ describe('QuestionBank editor', () => {
 			.at(0)
 			.simulate('change', { target: { value: 'all' } })
 
-		expect(Transforms.setNodes).toHaveBeenCalled()
+		expect(component.html()).toMatchSnapshot()
 	})
 
 	test('QuestionBank component changes choose amount', () => {
@@ -125,8 +131,9 @@ describe('QuestionBank editor', () => {
 			.find('input')
 			.at(2)
 			.simulate('blur')
+		jest.runAllTimers()
 
-		expect(Transforms.setNodes).toHaveBeenCalled()
+		expect(component.html()).toMatchSnapshot()
 	})
 
 	test('QuestionBank component changes select type', () => {
@@ -157,7 +164,7 @@ describe('QuestionBank editor', () => {
 			.at(0)
 			.simulate('change', { target: { value: 'pick' } })
 
-		expect(Transforms.setNodes).toHaveBeenCalled()
+		expect(component.html()).toMatchSnapshot()
 	})
 
 	test('QuestionBank component deletes self', () => {
@@ -273,5 +280,23 @@ describe('QuestionBank editor', () => {
 			expect.objectContaining({ type: 'ObojoboDraft.Chunks.QuestionBank' }),
 			{ at: [0] }
 		)
+	})
+
+	test('QuestionBank component sets properties', () => {
+		const props = {
+			element: {
+				content: {},
+				children: []
+			},
+			editor: {},
+			selected: true
+		}
+
+		ReactEditor.findPath.mockReturnValueOnce([])
+
+		const component = mount(<QuestionBank {...props} />)
+
+		component.setProps({ selected: false })
+		expect(Transforms.setNodes).toHaveBeenCalled()
 	})
 })

--- a/packages/obonode/obojobo-chunks-question/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-question/__snapshots__/editor-component.test.js.snap
@@ -13,6 +13,7 @@ exports[`Question Editor Node Question builds the expected component 1`] = `
       >
         <div
           className="question-settings"
+          contentEditable={false}
         >
           <label>
             Question Type
@@ -44,6 +45,7 @@ exports[`Question Editor Node Question builds the expected component 1`] = `
     </div>
     <button
       className="delete-button"
+      contentEditable={false}
       onClick={[Function]}
     >
       ×
@@ -52,7 +54,7 @@ exports[`Question Editor Node Question builds the expected component 1`] = `
 </div>
 `;
 
-exports[`Question Editor Node Question component adds Solution 1`] = `"<div><div class=\\"component obojobo-draft--chunks--question is-viewed pad is-type-default\\"><div class=\\"flipper question-editor\\"><div class=\\"content-back\\"><div class=\\"question-settings\\"><label>Question Type</label><select contenteditable=\\"false\\"><option value=\\"ObojoboDraft.Chunks.MCAssessment\\">Multiple Choice</option></select><label class=\\"question-type\\" contenteditable=\\"false\\"><input type=\\"checkbox\\" name=\\"vehicle1\\" value=\\"Bike\\">Survey Only</label></div><button class=\\"add-solution\\" contenteditable=\\"false\\">Add Solution</button></div></div><button class=\\"delete-button\\">×</button></div></div>"`;
+exports[`Question Editor Node Question component adds Solution 1`] = `"<div><div class=\\"component obojobo-draft--chunks--question is-viewed pad is-type-default\\"><div class=\\"flipper question-editor\\"><div class=\\"content-back\\"><div class=\\"question-settings\\" contenteditable=\\"false\\"><label>Question Type</label><select contenteditable=\\"false\\"><option value=\\"ObojoboDraft.Chunks.MCAssessment\\">Multiple Choice</option></select><label class=\\"question-type\\" contenteditable=\\"false\\"><input type=\\"checkbox\\" name=\\"vehicle1\\" value=\\"Bike\\">Survey Only</label></div><button class=\\"add-solution\\" contenteditable=\\"false\\">Add Solution</button></div></div><button class=\\"delete-button\\" contenteditable=\\"false\\">×</button></div></div>"`;
 
 exports[`Question Editor Node Survey Question builds the expected component 1`] = `
 <div>
@@ -67,6 +69,7 @@ exports[`Question Editor Node Survey Question builds the expected component 1`] 
       >
         <div
           className="question-settings"
+          contentEditable={false}
         >
           <label>
             Question Type
@@ -106,6 +109,7 @@ exports[`Question Editor Node Survey Question builds the expected component 1`] 
     </div>
     <button
       className="delete-button"
+      contentEditable={false}
       onClick={[Function]}
     >
       ×

--- a/packages/obonode/obojobo-chunks-question/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question/editor-component.js
@@ -95,10 +95,12 @@ class Question extends React.Component {
 		}
 
 		return (
-			<Node {...this.props} className="obojobo-draft--chunks--question--wrapper">
+			<Node 
+				{...this.props} 
+				className="obojobo-draft--chunks--question--wrapper"
+				hideInsertMenus={ ReactEditor.findPath(this.props.editor, this.props.element).length > 1 }>
 				<div
-					className={`component obojobo-draft--chunks--question is-viewed pad is-type-${content.type}`}
-				>
+					className={`component obojobo-draft--chunks--question is-viewed pad is-type-${content.type}`}>
 					<div className="flipper question-editor">
 						<div className="content-back">
 							<div className="question-settings" contentEditable={false}>

--- a/packages/obonode/obojobo-chunks-question/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question/editor-component.js
@@ -29,14 +29,14 @@ class Question extends React.Component {
 
 		const path = ReactEditor.findPath(this.props.editor, this.props.element)
 		Transforms.setNodes(
-			this.props.editor, 
+			this.props.editor,
 			{ content: { ...this.props.element.content, type } },
 			{ at: path }
 		)
 
 		const lastChildIndex = this.props.element.children.length - 1
 		return Transforms.setNodes(
-			this.props.editor, 
+			this.props.editor,
 			{ questionType: type },
 			{ at: path.concat(lastChildIndex) }
 		)
@@ -101,7 +101,7 @@ class Question extends React.Component {
 				>
 					<div className="flipper question-editor">
 						<div className="content-back">
-							<div className="question-settings">
+							<div className="question-settings" contentEditable={false}>
 								<label>Question Type</label>
 								<select contentEditable={false} defaultValue={questionType}>
 									<option value={MCASSESSMENT_NODE}>Multiple Choice</option>
@@ -119,16 +119,13 @@ class Question extends React.Component {
 							</div>
 							{this.props.children}
 							{hasSolution ? null : (
-								<Button 
-									className="add-solution" 
-									onClick={this.addSolution} 
-									contentEditable={false}>
+								<Button className="add-solution" onClick={this.addSolution} contentEditable={false}>
 									Add Solution
 								</Button>
 							)}
 						</div>
 					</div>
-					<Button className="delete-button" onClick={() => this.delete()}>
+					<Button className="delete-button" onClick={() => this.delete()} contentEditable={false}>
 						×
 					</Button>
 				</div>
@@ -137,4 +134,4 @@ class Question extends React.Component {
 	}
 }
 
-export default withSlateWrapper(Question) 
+export default withSlateWrapper(Question)


### PR DESCRIPTION
Adds a collapse/expand button to QuestionBanks and MCAssessments to allow users to hide them when not editing
When a question bank/multiple-choice is collapsed, any selection that is inside the question bank is moved outside, and a summary of the contents is displayed.