### PR TITLE
Fix Enter-created text failing

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/util/keydown-util.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/util/keydown-util.test.js
@@ -343,6 +343,12 @@ describe('KeyDown Util', () => {
 		expect(event.preventDefault).toHaveBeenCalled()
 		expect(Transforms.insertNodes).toHaveBeenCalled()
 		expect(Transforms.collapse).toHaveBeenCalled()
+
+		// make sure the inserted node is correct type
+		const insertedNode = Transforms.insertNodes.mock.calls[0][1]
+		expect(insertedNode.children[0]).toHaveProperty('type', 'ObojoboDraft.Chunks.Text')
+		expect(insertedNode.children[0]).toHaveProperty('subtype', 'ObojoboDraft.Chunks.Text.TextLine')
+		expect(insertedNode.children[0].children[0]).toEqual({ text: '' })
 	})
 
 	test('breakToText converts to text', () => {

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/util/keydown-util.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/util/keydown-util.js
@@ -1,7 +1,7 @@
 import { Text, Editor, Transforms, Range, Path, Element, Point } from 'slate'
 
 const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
-const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.Line'
+const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
 
 const KeyDownUtil = {
 	deleteNodeContents: (event, editor, entry, deleteForward) => {


### PR DESCRIPTION
In Dev/10, when you create a new text node by pressing Enter in a heading, the created node does not behave like text is expected to, and causes saving issues.  I discovered that the culprit was a mistyped constant.