### PR TITLE
Make keys for ActionButtonEditorAction components more specific to avoid collisions for duplicate actions.

### DIFF
--- a/packages/obonode/obojobo-chunks-action-button/editor-component.js
+++ b/packages/obonode/obojobo-chunks-action-button/editor-component.js
@@ -55,8 +55,8 @@ class ActionButton extends React.Component {
 					<div className="trigger-list">
 						<div className="title">When the button is clicked:</div>
 						{isAnOnClickActionSet ? (
-							onClickTrigger.actions.map(action => (
-								<ActionButtonEditorAction key={action.type} {...action} />
+							onClickTrigger.actions.map((action, index) => (
+								<ActionButtonEditorAction key={`${action.type}-${index}`} {...action} />
 							))
 						) : (
 							<div className="trigger no-actions">(No action set)</div>

--- a/packages/obonode/obojobo-chunks-action-button/editor-component.js
+++ b/packages/obonode/obojobo-chunks-action-button/editor-component.js
@@ -56,7 +56,7 @@ class ActionButton extends React.Component {
 						<div className="title">When the button is clicked:</div>
 						{isAnOnClickActionSet ? (
 							onClickTrigger.actions.map((action, index) => (
-								<ActionButtonEditorAction key={`${action.type}-${index}`} {...action} />
+								<ActionButtonEditorAction key={index} {...action} />
 							))
 						) : (
 							<div className="trigger no-actions">(No action set)</div>


### PR DESCRIPTION
Fixes #1180.

Appends the index of a click trigger's action to the action type when generating a key for the React component to prevent errors due to duplicate keys.