### PR TITLE
[fix] visual editor incorrectly restores module

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/common/models/obo-model.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/models/obo-model.test.js
@@ -92,7 +92,6 @@ describe('OboModel', () => {
 	})
 
 	test('should retrieve the root model', () => {
-		expect.assertions(2)
 		const o = OboModel.create({
 			id: 'root',
 			type: 'ObojoboDraft.Modules.Module',
@@ -105,6 +104,137 @@ describe('OboModel', () => {
 		})
 		expect(OboModel.models.root.getRoot()).toBe(o)
 		expect(OboModel.models.child.getRoot()).toBe(o)
+	})
+
+	test('getRoot returns expected references with multiple module trees', () => {
+		const modelA = {
+			id: 'modelA',
+			type: 'ObojoboDraft.Modules.Module',
+			children: [
+				{
+					id: 'duplicate-child-id',
+					type: 'ObojoboDraft.Sections.Content'
+				},
+				{
+					id: 'different-child-id-a',
+					type: 'ObojoboDraft.Sections.Content'
+				}
+			]
+		}
+		const modelB = {
+			id: 'modelB',
+			type: 'ObojoboDraft.Modules.Module',
+			children: [
+				{
+					id: 'duplicate-child-id',
+					type: 'ObojoboDraft.Sections.Content'
+				},
+				{
+					id: 'different-child-id-b',
+					type: 'ObojoboDraft.Sections.Content'
+				}
+			]
+		}
+
+		const a = OboModel.create(modelA)
+		const b = OboModel.create(modelB)
+
+		// bug/limitation - expect this to always return the first model
+		expect(OboModel.getRoot()).toBe(a)
+
+		// expect root nodes to return themselves
+		expect(OboModel.models['modelA'].getRoot()).toBe(a)
+		expect(OboModel.models['modelB'].getRoot()).toBe(b)
+
+		// expect the duplicate node's root to replace the
+		// first registered node with that id - resulting in it pointing
+		// at the newer root node (although correct, this can be unexpected)
+		expect(OboModel.models['duplicate-child-id'].getRoot()).toBe(b)
+
+		// expect unique new children root's to be correct
+		expect(OboModel.models['different-child-id-a'].getRoot()).toBe(a)
+		expect(OboModel.models['different-child-id-b'].getRoot()).toBe(b)
+	})
+
+	test('clearAll allows getRoot to return a new root model', () => {
+		const modelA = {
+			id: 'modelA',
+			type: 'ObojoboDraft.Modules.Module',
+			children: [
+				{
+					id: 'duplicate-child-id',
+					type: 'ObojoboDraft.Sections.Content'
+				},
+				{
+					id: 'different-child-id-a',
+					type: 'ObojoboDraft.Sections.Content'
+				}
+			]
+		}
+		const modelB = {
+			id: 'modelB',
+			type: 'ObojoboDraft.Modules.Module',
+			children: [
+				{
+					id: 'duplicate-child-id',
+					type: 'ObojoboDraft.Sections.Content'
+				},
+				{
+					id: 'different-child-id-b',
+					type: 'ObojoboDraft.Sections.Content'
+				}
+			]
+		}
+
+		// register A then clear it
+		OboModel.create(modelA)
+		OboModel.clearAll()
+		const b = OboModel.create(modelB)
+
+		// root should be the first tree created after clearAll()
+		expect(OboModel.getRoot()).toBe(b)
+
+		// expect all traces of modelA to be gone
+		expect(OboModel.models).not.toHaveProperty('modelA')
+		expect(OboModel.models).not.toHaveProperty('different-child-id-a')
+
+		expect(OboModel.models['modelB'].getRoot()).toBe(b)
+
+		// make sure the duplicate id is pointing at b
+		expect(OboModel.models['duplicate-child-id'].getRoot()).toBe(b)
+
+		// expect unique new children root's to be correct
+		expect(OboModel.models['different-child-id-b'].getRoot()).toBe(b)
+	})
+
+	test('clearAll allows getRoot to return a new root model', () => {
+		const modelA = {
+			id: 'modelA',
+			type: 'ObojoboDraft.Modules.Module',
+			children: [
+				{
+					id: 'duplicate-child-id',
+					type: 'ObojoboDraft.Sections.Content'
+				}
+			]
+		}
+		const modelB = {
+			id: 'modelB',
+			type: 'ObojoboDraft.Modules.Module',
+			children: [
+				{
+					id: 'duplicate-child-id',
+					type: 'ObojoboDraft.Sections.Content'
+				}
+			]
+		}
+
+		const a = OboModel.create(modelA)
+		const b = OboModel.create(modelB)
+
+		expect(OboModel.models['modelA'].getRoot()).toBe(a)
+		expect(OboModel.models['duplicate-child-id'].getRoot()).toBe(b)
+		expect(OboModel.models['modelB'].getRoot()).toBe(b)
 	})
 
 	test('should process a trigger', () => {
@@ -166,7 +296,6 @@ describe('OboModel', () => {
 	})
 
 	test('removing children sets their parent to null, marks them dirty and removes them from the model db', () => {
-		expect.assertions(4)
 		Registry.getItems(() => {
 			const o = OboModel.create({
 				id: 'root',

--- a/packages/app/obojobo-document-engine/src/scripts/common/models/obo-model.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/models/obo-model.js
@@ -32,6 +32,9 @@ class OboModel extends Backbone.Model {
 		}
 	}
 
+	// WARNING - it is not possible to have 2 different documents/modules
+	// loaded via OboModel at once. If you need to clear a previous
+	// OboModel Tree, call OboModel.clearAll()
 	static create(typeOrNameOrJson, attrs = {}) {
 		if (typeof typeOrNameOrJson === 'object') {
 			const oboModel = OboModel.create(typeOrNameOrJson.type, typeOrNameOrJson)
@@ -60,6 +63,10 @@ class OboModel extends Backbone.Model {
 		attrs.type = typeOrNameOrJson
 
 		return new OboModel(attrs, item.adapter)
+	}
+
+	static clearAll() {
+		OboModel.models = {}
 	}
 
 	constructor(attrs, adapter = {}) {
@@ -453,8 +460,6 @@ class OboModel extends Backbone.Model {
 	}
 }
 
-OboModel.models = {}
-
 OboModel.getRoot = function() {
 	for (const id in OboModel.models) {
 		return OboModel.models[id].getRoot()
@@ -462,6 +467,8 @@ OboModel.getRoot = function() {
 
 	return null
 }
+
+OboModel.clearAll() // initialize models object
 
 class OboModelCollection extends Backbone.Collection {}
 

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
@@ -50,6 +50,7 @@ class EditorApp extends React.Component {
 	}
 
 	getVisualEditorState(draftId, draftModel) {
+		OboModel.clearAll()
 		const json = JSON.parse(draftModel)
 		const obomodel = OboModel.create(json)
 		EditorStore.init(
@@ -71,6 +72,7 @@ class EditorApp extends React.Component {
 	}
 
 	getCodeEditorState(draftId, draftModel) {
+		OboModel.clearAll()
 		const obomodel = OboModel.create({
 			type: 'ObojoboDraft.Modules.Module',
 			content: {


### PR DESCRIPTION
per issue #1330 sometimes the visual editor could
restore an old version of the module unintentionally.
This would happen if a drastic change introduced in the
code editor, then switched back to visual, and you edit
the module's title in the header.

The problem stems from an issue I discovered some time ago
with OboModel not being friendly if you try to load a 2nd
draft module.  It breaks because of OboModel.getRoot was
not built to be able to differentiate between multiple root
models.

This fix adds an option to reset OboModel's state so you can
load a new model.

For this issue, that comes into play when switching from xml
or json back to the visual editor & renaming. This process will
no longer return references to old nodes.