### PR TITLE
mathEquation editor saves more often

### DIFF
--- a/packages/obonode/obojobo-chunks-math-equation/editor-component.js
+++ b/packages/obonode/obojobo-chunks-math-equation/editor-component.js
@@ -26,19 +26,24 @@ class MathEquation extends React.Component {
 	constructor(props) {
 		super(props)
 
+		// copy the attributes we want into state
+		this.state = this.contentToStateObj(this.props.element.content)
+
+		// used to reduce the speed/cost of changes so typing isn't slow
+		// ALSO make sure changes are copied to slate after editing
+		// in case the edit window doesnt close before clicking save or preview
+		this.updateNodeFromStateAfterInput = debounce(200, this.updateNodeFromState)
+
 		// This debounce is necessary to get slate to update the node data.
 		// I've tried several ways to remove it but haven't been able to
 		// get it work :(
 		// If you have a solution please have at it!
 		this.updateNodeFromState = debounce(1, this.updateNodeFromState)
 
-		// copy the attributes we want into state
-		const content = this.props.element.content
-		this.state = this.contentToStateObj(content)
-
 		this.freezeEditor = this.freezeEditor.bind(this)
 		this.unfreezeEditor = this.unfreezeEditor.bind(this)
 		this.focusEquation = this.focusEquation.bind(this)
+		this.toggleOpen = this.toggleOpen.bind(this)
 	}
 
 	contentToStateObj(content) {
@@ -89,20 +94,30 @@ class MathEquation extends React.Component {
 
 	updateNodeFromState() {
 		const content = this.props.element.content
-		delete this.state.open
 		const path = ReactEditor.findPath(this.props.editor, this.props.element)
 		Transforms.setNodes(this.props.editor, { content: { ...content, ...this.state } }, { at: path })
 	}
 
 	onChangeContent(key, event) {
 		const newContent = { [key]: event.target.value }
-		this.setState(newContent) // update the display now
+		this.setState(newContent, this.updateNodeFromStateAfterInput) // update the display
 	}
 
-	componentDidUpdate(prevProps) {
-		if (prevProps.selected && !this.props.selected) {
+	componentDidUpdate(prevProps, prevState) {
+		const isClosing = prevState.open && !this.state.open
+		const isUnselecting = prevProps.selected && !this.props.selected
+
+		if (isClosing || isUnselecting) {
 			this.updateNodeFromState()
 		}
+
+		if (isUnselecting) {
+			this.setState({ open: false })
+		}
+	}
+
+	toggleOpen() {
+		this.setState({ open: !this.state.open })
 	}
 
 	freezeEditor() {
@@ -163,7 +178,7 @@ class MathEquation extends React.Component {
 					/>
 				</div>
 				<div>
-					<Button onClick={() => this.setState({ open: false })}>Done</Button>
+					<Button onClick={this.toggleOpen}>Done</Button>
 				</div>
 			</div>
 		)
@@ -176,7 +191,7 @@ class MathEquation extends React.Component {
 			<div className={className} contentEditable={false}>
 				<div className="box-border">
 					{!this.state.open ? (
-						<Button onClick={() => this.setState({ open: true })}>Edit</Button>
+						<Button onClick={this.toggleOpen}>Edit</Button>
 					) : (
 						this.renderAttributes()
 					)}

--- a/packages/obonode/obojobo-chunks-math-equation/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-math-equation/editor-component.test.js
@@ -19,6 +19,11 @@ jest.mock(
 jest.useFakeTimers()
 
 describe('MathEquation Editor Node', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		jest.clearAllTimers()
+	})
+
 	test('renders with no latex', () => {
 		const component = renderer.create(<MathEquation element={{ content: { latex: null } }} />)
 		const tree = component.toJSON()
@@ -99,7 +104,7 @@ describe('MathEquation Editor Node', () => {
 		expect(editor.toggleEditable).toHaveBeenCalledWith(true)
 	})
 
-	test('MathEquation component calls setNodeByKey once edit dialog disappears', () => {
+	test('MathEquation component calls setNode once edit dialog disappears', () => {
 		const component = mount(
 			<MathEquation element={{ content: { latex: '2x/3', label: '1.1' } }} selected={true} />
 		)
@@ -119,6 +124,7 @@ describe('MathEquation Editor Node', () => {
 		      "alt": "",
 		      "label": "1.1",
 		      "latex": "2x/3",
+		      "open": false,
 		      "size": 1,
 		    },
 		  },


### PR DESCRIPTION
MathEquation would previously only save when the edit dialog
switched from open to closed.  Unfortunately it doesn't close
when you click anywhere that's not in the slate display.

Ex: edit contents of the equation and click save or preview from the
toolbar.  The contents aren't copied to the slate document and when
save is called, the changes don't make it into the document

This adds a debounced function to make sure the document is saved
as the content changes.

It also second condition in componentDidUpdate that'll cause the
contents to be copied to slate - when the editor is closing (previously
was just when it lost selection)

At the same time I moved the code that closes the editor out
of the function intended to push updates to slate.

solves #1334 #1278