### PR TITLE
Ignore EJS changes for dev server reload

### DIFF
--- a/packages/app/obojobo-express/package.json
+++ b/packages/app/obojobo-express/package.json
@@ -133,7 +133,7 @@
 		}
 	},
 	"nodemonConfig": {
-		"ext": "js ejs",
+		"ext": "js",
 		"watch": [
 			"./",
 			"../../obonode/obojobo-sections-assessment/server",


### PR DESCRIPTION
nodemon was monitoring ejs, but it looks like ejs changes
are handled automatically in dev mode - so no need to
restart the server