### PR TITLE
[fix] can't save once page is duplicated

### DIFF
--- a/packages/app/obojobo-express/__tests__/models/draft.test.js
+++ b/packages/app/obojobo-express/__tests__/models/draft.test.js
@@ -198,6 +198,17 @@ describe('Draft Model', () => {
 		expect(duplicate).toBe(null)
 	})
 
+	test('findDuplicateIds hanldes null children', () => {
+		const testTree = {
+			id: 'test-id',
+			children: null
+		}
+
+		const duplicate = DraftModel.findDuplicateIds(testTree)
+
+		expect(duplicate).toBe(null)
+	})
+
 	test('findDuplicateIds parses a single level draft with no ids', () => {
 		const testTree = {
 			children: []

--- a/packages/app/obojobo-express/server/models/draft.js
+++ b/packages/app/obojobo-express/server/models/draft.js
@@ -21,11 +21,13 @@ const findDuplicateIdsRecursive = (jsonTreeNode, idSet = new Set()) => {
 
 	// Check all children nodes
 	let duplicateId = null
-	for (const child of jsonTreeNode.children) {
-		duplicateId = findDuplicateIdsRecursive(child, idSet)
-		if (duplicateId) {
-			// return as soon as a duplicate is found
-			return duplicateId
+	if (Array.isArray(jsonTreeNode.children)) {
+		for (const child of jsonTreeNode.children) {
+			duplicateId = findDuplicateIdsRecursive(child, idSet)
+			if (duplicateId) {
+				// return as soon as a duplicate is found
+				return duplicateId
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolve #1342

Reason: the duplicate function (`OboModel.toJSON`) does not copy an empty array