### PR TITLE
Make sure the js template does not escape the returnUrl

### DIFF
--- a/packages/app/obojobo-express/server/obo_express_dev.js
+++ b/packages/app/obojobo-express/server/obo_express_dev.js
@@ -197,7 +197,7 @@ module.exports = app => {
 			accept_unsigned: 'false',
 			auto_create: 'true',
 			can_confirm: 'false',
-			content_item_return_url: `${baseUrl(req)}/lti/dev/return/resource_selection`,
+			content_item_return_url: `${baseUrl(req)}/lti/dev/return/resource_selection?test=this%20is%20a%20test`,
 			launch_presentation_css_url: 'https://example.fake/nope.css',
 			launch_presentation_locale: 'en-US',
 			lti_message_type: 'ContentItemSelectionRequest',
@@ -218,6 +218,7 @@ module.exports = app => {
 		res.set('Content-Type', 'text/html')
 		res.send(`<html><body><h1>Resource selected!</h1>
 			<ul>
+			<li>URL: ${req.originalUrl}</li>
 			<li>lti_message_type: ${req.body.lti_message_type}</li>
 			<li>Type: ${data['@graph'][0]['@type']}</li>
 			<li>URL: ${data['@graph'][0].url}</li>

--- a/packages/app/obojobo-module-selector/client/js/module-selector.js
+++ b/packages/app/obojobo-module-selector/client/js/module-selector.js
@@ -2,7 +2,6 @@ import '../css/module-selector.scss'
 ;(function() {
 	// settings set by the view
 	const SETTINGS_IS_ASSIGNMENT = __isAssignment // eslint-disable-line no-undef
-	const SETTINGS_RETURN_URL = __returnUrl // eslint-disable-line no-undef
 	const TAB_COMMUNITY = 'Community Library'
 	const TAB_PERSONAL = 'My Modules'
 	const SECTION_MODULE_SELECT = 'section-module-selection'
@@ -223,7 +222,6 @@ import '../css/module-selector.scss'
 			)
 			const formEl = document.getElementById('submit-form')
 			formEl.querySelector('input[name=content_items]').value = JSON.stringify(ltiData)
-			formEl.setAttribute('action', SETTINGS_RETURN_URL)
 			formEl.submit()
 		}, 1000)
 	}

--- a/packages/app/obojobo-module-selector/server/views/module-selector.ejs
+++ b/packages/app/obojobo-module-selector/server/views/module-selector.ejs
@@ -147,7 +147,7 @@
 			</p>
 		</div>
 
-		<form id="submit-form" action="" method="post" encType="application/x-www-form-urlencoded">
+		<form id="submit-form" action="<%- returnUrl %>" method="post" encType="application/x-www-form-urlencoded">
 			<input type="hidden" name="lti_message_type" value="ContentItemSelection" />
 			<input type="hidden" name="lti_version" value="LTI-1p0" />
 			<input type="hidden" name="content_items" value="" />
@@ -156,7 +156,6 @@
 
 
 		<script type="text/javascript">
-			window.__returnUrl = '<%= returnUrl %>';
 			window.__isAssignment = <%= isAssignment ? 'true' : 'false' %>
 		</script>
 


### PR DESCRIPTION
The return url is the route back into the launching LMS, so it's
crucial that is untouched.