### PR TITLE
[fix] saving issue in xml/json editor

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
@@ -1071,58 +1071,6 @@ describe('VisualEditor', () => {
 		expect(onKeyDown).toHaveBeenCalled()
 	})
 
-	test('saveModule calls APIUtil', () => {
-		const editor = {
-			undo: jest.fn(),
-			redo: jest.fn()
-		}
-
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mock node' }] }),
-				set: jest.fn(),
-				children: {
-					reset: jest.fn()
-				}
-			},
-			model: {
-				title: 'Mock Title',
-				flatJSON: () => ({ content: {}, children: [] }),
-				children: [
-					{
-						get: () => CONTENT_NODE,
-						flatJSON: () => ({ children: [] }),
-						children: {
-							models: [
-								{
-									get: () => 'mock value'
-								}
-							]
-						}
-					},
-					{
-						get: () => ASSESSMENT_NODE
-					}
-				]
-			}
-		}
-
-		const component = mount(<VisualEditor {...props} />)
-		const instance = component.instance()
-		instance.editor = editor
-
-		instance.onKeyDown({
-			preventDefault: jest.fn(),
-			key: 's',
-			metaKey: true
-		})
-
-		expect(APIUtil.postDraft).toHaveBeenCalled()
-	})
-
 	test('reload disables event listener and calls location.reload', () => {
 		jest.spyOn(window, 'removeEventListener').mockReturnValueOnce()
 		Object.defineProperty(window, 'location', {

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
@@ -19,9 +19,8 @@ jest.mock('src/scripts/oboeditor/components/node/editor', () => ({
 	}
 }))
 // Editor Store
-import EditorStore from 'src/scripts/oboeditor/stores/editor-store'
 jest.mock('src/scripts/oboeditor/stores/editor-store', () => ({
-	state: { startingId: 'mock-id', mode: 'visual' }
+	state: { startingId: 'mock-id' }
 }))
 
 jest.mock('src/scripts/oboeditor/util/editor-util')
@@ -1122,59 +1121,6 @@ describe('VisualEditor', () => {
 		})
 
 		expect(APIUtil.postDraft).toHaveBeenCalled()
-	})
-
-	test('saveModule does not call APIUtil when mode is not "visual"', () => {
-		EditorStore.state.mode = 'xml'
-		const editor = {
-			undo: jest.fn(),
-			redo: jest.fn()
-		}
-
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mock node' }] }),
-				set: jest.fn(),
-				children: {
-					reset: jest.fn()
-				}
-			},
-			model: {
-				title: 'Mock Title',
-				flatJSON: () => ({ content: {}, children: [] }),
-				children: [
-					{
-						get: () => CONTENT_NODE,
-						flatJSON: () => ({ children: [] }),
-						children: {
-							models: [
-								{
-									get: () => 'mock value'
-								}
-							]
-						}
-					},
-					{
-						get: () => ASSESSMENT_NODE
-					}
-				]
-			}
-		}
-
-		const component = mount(<VisualEditor {...props} />)
-		const instance = component.instance()
-		instance.editor = editor
-
-		instance.onKeyDown({
-			preventDefault: jest.fn(),
-			key: 's',
-			metaKey: true
-		})
-
-		expect(APIUtil.postDraft).not.toHaveBeenCalled()
 	})
 
 	test('reload disables event listener and calls location.reload', () => {

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
@@ -151,7 +151,7 @@ class VisualEditor extends React.Component {
 		// Setup unload to prompt user before closing
 		window.addEventListener('beforeunload', this.checkIfSaved)
 		// Setup global keydown to listen to all global keys
-		document.addEventListener('keydown', this.onKeyDownGlobal)
+		window.addEventListener('keydown', this.onKeyDownGlobal)
 
 		// Set keyboard focus to the editor
 		Transforms.select(this.editor, Editor.start(this.editor, []))
@@ -441,9 +441,6 @@ class VisualEditor extends React.Component {
 
 	// All the 'plugin' methods that allow the obonodes to extend the default functionality
 	onKeyDown(event) {
-		// Run the global keydowns, stopping if one executes
-		this.onKeyDownGlobal(event)
-
 		for (const plugin of this.globalPlugins) {
 			if (plugin.onKeyDown) plugin.onKeyDown(event, this.editor)
 			if (event.defaultPrevented) return

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
@@ -354,6 +354,8 @@ class VisualEditor extends React.Component {
 	}
 
 	saveModule(draftId) {
+		if (EditorStore.state.mode !== 'visual') return
+
 		this.exportCurrentToJSON()
 		const json = this.props.model.flatJSON()
 		json.content.start = EditorStore.state.startingId

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
@@ -354,8 +354,6 @@ class VisualEditor extends React.Component {
 	}
 
 	saveModule(draftId) {
-		if (EditorStore.state.mode !== 'visual') return
-
 		this.exportCurrentToJSON()
 		const json = this.props.model.flatJSON()
 		json.content.start = EditorStore.state.startingId


### PR DESCRIPTION
Resolves: #1365 

When the user hits `Cmd + S`, two functions are being fired:`sendSave` in `code-editor.js` and `saveModule` in `visual-editor.js`
The second call reverts the document back to its original state