### PR TITLE
XML editor crashes with visual editor tutorial

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/common/text/styleable-text-renderer.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/text/styleable-text-renderer.test.js
@@ -1,6 +1,7 @@
 import styleableTextRenderer from '../../../src/scripts/common/text/styleable-text-renderer'
 import StyleableText from '../../../src/scripts/common/text/styleable-text'
 import StyleRange from '../../../src/scripts/common/text/style-range'
+import mockConsole from 'jest-mock-console'
 
 // convience function to easily compare a MockElement
 const mockElToHTMLString = el => {
@@ -24,7 +25,17 @@ const mockElToHTMLString = el => {
 	}>`
 }
 
+let restoreConsole
+
 describe('styleableTextRenderer', () => {
+	beforeEach(() => {
+		restoreConsole = mockConsole('error')
+	})
+
+	afterEach(() => {
+		restoreConsole()
+	})
+
 	test('Non-styled text', () => {
 		const st = new StyleableText('Test')
 		const mockEl = styleableTextRenderer(st)
@@ -159,6 +170,19 @@ describe('styleableTextRenderer', () => {
 
 		expect(mockElToHTMLString(mockEl)).toMatchInlineSnapshot(
 			`"<span>dog <span class=\\"latex\\" role=\\"math\\" alt=\\"alt-text\\"><span aria-hidden=\\"true\\">mock-katex-render-for-fox-with-options-{\\"throwOnError\\":false}</span></span> cat</span>"`
+		)
+	})
+
+	test('Latex when window.katex is invalid', () => {
+		window.katex = null
+		const st = new StyleableText('dog fox cat')
+		st.styleText('_latex', 4, 7, { a: 1 })
+		const mockEl = styleableTextRenderer(st)
+
+		// eslint-disable-next-line no-console
+		expect(console.error).toHaveBeenCalled()
+		expect(mockElToHTMLString(mockEl)).toMatchInlineSnapshot(
+			`"<span>dog <span class=\\"latex\\" role=\\"math\\" a=\\"1\\" alt=\\"fox\\">fox</span> cat</span>"`
 		)
 	})
 

--- a/packages/app/obojobo-document-engine/__tests__/common/text/styleable-text-renderer.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/text/styleable-text-renderer.test.js
@@ -1,7 +1,6 @@
 import styleableTextRenderer from '../../../src/scripts/common/text/styleable-text-renderer'
 import StyleableText from '../../../src/scripts/common/text/styleable-text'
 import StyleRange from '../../../src/scripts/common/text/style-range'
-import mockConsole from 'jest-mock-console'
 
 // convience function to easily compare a MockElement
 const mockElToHTMLString = el => {
@@ -25,17 +24,7 @@ const mockElToHTMLString = el => {
 	}>`
 }
 
-let restoreConsole
-
 describe('styleableTextRenderer', () => {
-	beforeEach(() => {
-		restoreConsole = mockConsole('error')
-	})
-
-	afterEach(() => {
-		restoreConsole()
-	})
-
 	test('Non-styled text', () => {
 		const st = new StyleableText('Test')
 		const mockEl = styleableTextRenderer(st)
@@ -173,14 +162,14 @@ describe('styleableTextRenderer', () => {
 		)
 	})
 
-	test('Latex when window.katex is invalid', () => {
-		window.katex = null
+	test('Latex when window is invalid', () => {
+		const windowSpy = jest.spyOn(global, 'window', 'get')
+		windowSpy.mockImplementation(() => undefined) // eslint-disable-line no-undefined
+
 		const st = new StyleableText('dog fox cat')
 		st.styleText('_latex', 4, 7, { a: 1 })
 		const mockEl = styleableTextRenderer(st)
 
-		// eslint-disable-next-line no-console
-		expect(console.error).toHaveBeenCalled()
 		expect(mockElToHTMLString(mockEl)).toMatchInlineSnapshot(
 			`"<span>dog <span class=\\"latex\\" role=\\"math\\" a=\\"1\\" alt=\\"fox\\">fox</span> cat</span>"`
 		)

--- a/packages/app/obojobo-document-engine/src/scripts/common/text/styleable-text-renderer.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/text/styleable-text-renderer.js
@@ -159,8 +159,13 @@ const wrapElement = function(styleRange, nodeToWrap, text) {
 			)
 			nodeToWrap.parent.replaceChild(nodeToWrap, newChild)
 			newChild.addChild(nodeToWrap)
-			const html = window.katex.renderToString(text, { throwOnError: false })
-			nodeToWrap.html = `<span aria-hidden="true">${html}</span>`
+
+			try {
+				const html = window.katex.renderToString(text, { throwOnError: false })
+				nodeToWrap.html = `<span aria-hidden="true">${html}</span>`
+			} catch (e) {
+				console.error(e) // eslint-disable-line
+			}
 			nodeToWrap.text = text
 			return newChild
 		}

--- a/packages/app/obojobo-document-engine/src/scripts/common/text/styleable-text-renderer.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/text/styleable-text-renderer.js
@@ -160,11 +160,11 @@ const wrapElement = function(styleRange, nodeToWrap, text) {
 			nodeToWrap.parent.replaceChild(nodeToWrap, newChild)
 			newChild.addChild(nodeToWrap)
 
-			try {
+			// if we're running in the browser, render katex
+			// note: this does get called on the server, but we don't need the rendered katex there
+			if (typeof window !== 'undefined') {
 				const html = window.katex.renderToString(text, { throwOnError: false })
 				nodeToWrap.html = `<span aria-hidden="true">${html}</span>`
-			} catch (e) {
-				console.error(e) // eslint-disable-line
 			}
 			nodeToWrap.text = text
 			return newChild


### PR DESCRIPTION
Resolve #1363 

Reason: json-to-xml parser crashes because `window.katex.renderToString` is undefined in nodejs
`nodeToWrap.html` is not necessary for the parser so I bypass it using try and catch