### PR TITLE
[fix] iframe and figure focus select issues

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/util/freeze-unfreeze-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/util/freeze-unfreeze-editor.test.js
@@ -1,0 +1,49 @@
+import { freezeEditor, unfreezeEditor } from 'src/scripts/oboeditor/util/freeze-unfreeze-editor'
+import { ReactEditor } from 'slate-react'
+import { Transforms } from 'slate'
+
+jest.mock('slate')
+jest.mock('slate-react')
+
+describe('Freeze & Unfreeze Editor', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		jest.useFakeTimers()
+		jest.clearAllTimers()
+	})
+
+	test('freeze to disable the editor', () => {
+		const editor = {
+			toggleEditable: jest.fn()
+		}
+
+		freezeEditor(editor)
+		expect(editor.toggleEditable).toHaveBeenLastCalledWith(false)
+	})
+
+	test('unfreeze to enable the editor', () => {
+		const editor = {
+			toggleEditable: jest.fn()
+		}
+
+		unfreezeEditor(editor)
+		expect(editor.toggleEditable).toHaveBeenLastCalledWith(true)
+	})
+
+	test('unfreeze to reselect and focus the editor', () => {
+		const editor = {
+			toggleEditable: jest.fn(),
+			prevSelection: 'mock-prev-selection'
+		}
+
+		unfreezeEditor(editor)
+
+		expect(ReactEditor.focus).not.toHaveBeenCalled()
+		expect(Transforms.select).not.toHaveBeenCalled()
+
+		jest.runAllTimers()
+
+		expect(ReactEditor.focus).toHaveBeenLastCalledWith(editor)
+		expect(Transforms.select).toHaveBeenLastCalledWith(editor, 'mock-prev-selection')
+	})
+})

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/util/freeze-unfreeze-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/util/freeze-unfreeze-editor.js
@@ -1,0 +1,27 @@
+import { Transforms } from 'slate'
+import { ReactEditor } from 'slate-react'
+// in slate 0.57.2:
+// when the user clicks on a chunk that has it's own buttons
+// (like iframe's properties button)
+// the editor doesn't seem to know what's currently selected
+// sometimes it ends up selecting multiple nodes.
+// selection is then weird until the user selects/unselects nodes
+
+// This is used to pause the editor from editing in the background
+// for whatever reason it helps with selection
+// Use in conjunction w/ unfreeze editor
+export const freezeEditor = editor => {
+	editor.toggleEditable(false)
+}
+
+// return back to the editor to let it continue on as normal
+// using this SHOULD return editor selection to predictable behavior
+export const unfreezeEditor = editor => {
+	editor.toggleEditable(true)
+	// Waits for the readOnly state to percolate before focusing
+	setTimeout(() => {
+		// Focusing on the input causes the editor to lose selection
+		Transforms.select(editor, editor.prevSelection)
+		ReactEditor.focus(editor)
+	}, 200)
+}

--- a/packages/obonode/obojobo-chunks-figure/editor-component.js
+++ b/packages/obonode/obojobo-chunks-figure/editor-component.js
@@ -12,6 +12,10 @@ import Image from './image'
 import ImageProperties from './image-properties-modal'
 import React from 'react'
 import isOrNot from 'obojobo-document-engine/src/scripts/common/util/isornot'
+import {
+	freezeEditor,
+	unfreezeEditor
+} from 'obojobo-document-engine/src/scripts/oboeditor/util/freeze-unfreeze-editor'
 
 const { ModalUtil } = Common.util
 const { Button } = Common.components
@@ -32,7 +36,9 @@ class Figure extends React.Component {
 		this.changeProperties = this.changeProperties.bind(this)
 		this.returnFocusOnTab = this.returnFocusOnTab.bind(this)
 		this.returnFocusOnShiftTab = this.returnFocusOnShiftTab.bind(this)
+		this.onCloseImagePropertiesModal = this.onCloseImagePropertiesModal.bind(this)
 	}
+
 	focusFigure() {
 		if (!this.props.selected) {
 			const path = ReactEditor.findPath(this.props.editor, this.props.element)
@@ -50,13 +56,20 @@ class Figure extends React.Component {
 	}
 
 	showImagePropertiesModal() {
+		freezeEditor(this.props.editor)
 		ModalUtil.show(
 			<ImageProperties
 				allowedUploadTypes={EditorStore.state.settings.allowedUploadTypes}
 				content={this.props.element.content}
 				onConfirm={this.changeProperties}
+				onCancel={this.onCloseImagePropertiesModal}
 			/>
 		)
+	}
+
+	onCloseImagePropertiesModal() {
+		ModalUtil.hide()
+		unfreezeEditor(this.props.editor)
 	}
 
 	returnFocusOnTab(event) {
@@ -74,7 +87,7 @@ class Figure extends React.Component {
 	}
 
 	changeProperties(content) {
-		ModalUtil.hide()
+		this.onCloseImagePropertiesModal()
 		const path = ReactEditor.findPath(this.props.editor, this.props.element)
 		Transforms.setNodes(
 			this.props.editor,

--- a/packages/obonode/obojobo-chunks-figure/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-figure/editor-component.test.js
@@ -9,6 +9,7 @@ import Figure from './editor-component'
 
 jest.mock('obojobo-document-engine/src/scripts/oboeditor/stores/editor-store')
 jest.mock('obojobo-document-engine/src/scripts/common/util/modal-util')
+jest.mock('obojobo-document-engine/src/scripts/oboeditor/util/freeze-unfreeze-editor')
 jest.mock('slate')
 jest.mock('slate-react')
 jest.mock(

--- a/packages/obonode/obojobo-chunks-iframe/editor-component.js
+++ b/packages/obonode/obojobo-chunks-iframe/editor-component.js
@@ -7,6 +7,10 @@ import { Editor, Transforms } from 'slate'
 import Common from 'obojobo-document-engine/src/scripts/common'
 import Node from 'obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component'
 import withSlateWrapper from 'obojobo-document-engine/src/scripts/oboeditor/components/node/with-slate-wrapper'
+import {
+	freezeEditor,
+	unfreezeEditor
+} from 'obojobo-document-engine/src/scripts/oboeditor/util/freeze-unfreeze-editor'
 
 import IframeProperties from './iframe-properties-modal'
 
@@ -25,6 +29,7 @@ class IFrame extends React.Component {
 		this.changeProperties = this.changeProperties.bind(this)
 		this.returnFocusOnShiftTab = this.returnFocusOnShiftTab.bind(this)
 		this.returnFocusOnTab = this.returnFocusOnTab.bind(this)
+		this.onCloseIFramePropertiesModal = this.onCloseIFramePropertiesModal.bind(this)
 	}
 
 	focusIframe() {
@@ -38,18 +43,29 @@ class IFrame extends React.Component {
 
 	showIFramePropertiesModal() {
 		ModalUtil.show(
-			<IframeProperties content={this.props.element.content} onConfirm={this.changeProperties} />
+			<IframeProperties
+				content={this.props.element.content}
+				onConfirm={this.changeProperties}
+				onCancel={this.onCloseIFramePropertiesModal}
+			/>
 		)
+
+		freezeEditor(this.props.editor)
+	}
+
+	onCloseIFramePropertiesModal() {
+		ModalUtil.hide()
+		unfreezeEditor(this.props.editor)
 	}
 
 	changeProperties(content) {
-		ModalUtil.hide()
 		const path = ReactEditor.findPath(this.props.editor, this.props.element)
 		Transforms.setNodes(
 			this.props.editor,
 			{ content: { ...this.props.element.content, ...content } },
 			{ at: path }
 		)
+		this.onCloseIFramePropertiesModal()
 	}
 
 	getTitle(src, title) {

--- a/packages/obonode/obojobo-chunks-iframe/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-iframe/editor-component.test.js
@@ -6,6 +6,7 @@ import IFrame from './editor-component'
 
 import ModalUtil from 'obojobo-document-engine/src/scripts/common/util/modal-util'
 jest.mock('obojobo-document-engine/src/scripts/common/util/modal-util')
+jest.mock('obojobo-document-engine/src/scripts/oboeditor/util/freeze-unfreeze-editor')
 import { Transforms } from 'slate'
 jest.mock('slate')
 jest.mock('slate-react')

--- a/packages/obonode/obojobo-chunks-iframe/iframe-properties-modal.js
+++ b/packages/obonode/obojobo-chunks-iframe/iframe-properties-modal.js
@@ -109,6 +109,7 @@ class IFrameProperties extends React.Component {
 				cancelOk
 				title="IFrame Properties"
 				onConfirm={() => this.props.onConfirm(this.state)}
+				onCancel={this.props.onCancel}
 				focusOnFirstElement={this.focusOnFirstElement}
 			>
 				<div className={'iframe-properties'}>

--- a/packages/obonode/obojobo-chunks-math-equation/editor-component.js
+++ b/packages/obonode/obojobo-chunks-math-equation/editor-component.js
@@ -8,6 +8,10 @@ import Common from 'obojobo-document-engine/src/scripts/common'
 import Node from 'obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component'
 import withSlateWrapper from 'obojobo-document-engine/src/scripts/oboeditor/components/node/with-slate-wrapper'
 import debounce from 'obojobo-document-engine/src/scripts/common/util/debounce'
+import {
+	freezeEditor,
+	unfreezeEditor
+} from 'obojobo-document-engine/src/scripts/oboeditor/util/freeze-unfreeze-editor'
 
 const { Button } = Common.components
 const isOrNot = Common.util.isOrNot
@@ -176,7 +180,7 @@ class MathEquation extends React.Component {
 
 	openAndFreezeEditor() {
 		this.setState({ open: true })
-		this.props.editor.toggleEditable(false)
+		freezeEditor(this.props.editor)
 		// Waits for the readOnly state to percolate before focusing
 		setTimeout(() => {
 			this.equationInput.current.focus()
@@ -186,13 +190,7 @@ class MathEquation extends React.Component {
 
 	closeAndUnfreezeEditor() {
 		this.setState({ open: false })
-		this.props.editor.toggleEditable(true)
-		// Waits for the readOnly state to percolate before focusing
-		setTimeout(() => {
-			// Focusing on the input causes the editor to lose selection
-			Transforms.select(this.props.editor, this.props.editor.prevSelection)
-			ReactEditor.focus(this.props.editor)
-		}, 200)
+		unfreezeEditor(this.props.editor)
 	}
 
 	renderAttributes() {


### PR DESCRIPTION
When clicking on specialized chunks that open their
own modal, slate is having issues keep the selection
right after closing the modal - so this incorperates
fixes from math-equation into iframe and figure.

fixes #1358 