### PR TITLE
[fix] repository links to classic editor

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/editor-app.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/editor-app.test.js.snap
@@ -2,13 +2,9 @@
 
 exports[`EditorApp EditorApp component displays xml 1`] = `"<div class=\\"visual-editor--editor-app\\"></div>"`;
 
-exports[`EditorApp EditorApp component displays xml in classic mode 1`] = `"<div class=\\"viewer--viewer-app--visit-error\\"><h1>Error</h1><h2></h2><div>Unexpected token &lt; in JSON at position 0</div></div>"`;
-
 exports[`EditorApp EditorApp component renders error messsage 1`] = `"<div class=\\"viewer--viewer-app--visit-error\\"><h1>Error</h1><h2>someType</h2><div>someMessage</div></div>"`;
 
 exports[`EditorApp EditorApp component renders modal 1`] = `"<div class=\\"visual-editor--editor-app\\"><div class=\\"obojobo-draft--components--modal-container\\"><div class=\\"content\\">mock component</div></div></div>"`;
-
-exports[`EditorApp EditorApp component with classic mode 1`] = `"<div class=\\"visual-editor--editor-app\\"></div>"`;
 
 exports[`EditorApp EditorApp component with no draft 1`] = `"<div class=\\"visual-editor--editor-app\\"></div>"`;
 

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/editor-app.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/editor-app.test.js
@@ -19,7 +19,6 @@ import testObject from 'test-object.json'
 import mockConsole from 'jest-mock-console'
 let restoreConsole
 
-const CLASSIC_MODE = 'classic'
 const XML_MODE = 'xml'
 
 describe('EditorApp', () => {
@@ -60,32 +59,6 @@ describe('EditorApp', () => {
 		})
 	})
 
-	test('EditorApp component displays xml in classic mode', done => {
-		expect.assertions(1)
-
-		jest.spyOn(Common.models.OboModel, 'create')
-		Common.models.OboModel.create.mockReturnValueOnce({
-			modelState: { start: 'mockStart' }
-		})
-
-		APIUtil.getFullDraft
-			.mockResolvedValueOnce(JSON.stringify({ value: testObject }))
-			.mockResolvedValueOnce(
-				'<?xml version="1.0" encoding="utf-8"?><ObojoboDraftDoc></ObojoboDraftDoc>'
-			)
-		EditorStore.getState.mockReturnValueOnce({})
-
-		const component = mount(<EditorApp />)
-		component.instance().switchMode(CLASSIC_MODE)
-
-		setTimeout(() => {
-			component.update()
-			expect(component.html()).toMatchSnapshot()
-			component.unmount()
-			done()
-		})
-	})
-
 	test('EditorApp component displays xml', done => {
 		expect.assertions(1)
 
@@ -117,31 +90,6 @@ describe('EditorApp', () => {
 
 		// No visit or draft id
 		jest.spyOn(String.prototype, 'split').mockReturnValueOnce([])
-
-		jest.spyOn(Common.models.OboModel, 'create')
-		Common.models.OboModel.create.mockReturnValueOnce({
-			modelState: { start: 'mockStart' }
-		})
-
-		APIUtil.getFullDraft.mockResolvedValueOnce(JSON.stringify({ value: testObject }))
-		EditorStore.getState.mockReturnValueOnce({})
-
-		const component = mount(<EditorApp />)
-		setTimeout(() => {
-			component.update()
-
-			expect(component.html()).toMatchSnapshot()
-
-			component.unmount()
-			done()
-		})
-	})
-
-	test('EditorApp component with classic mode', done => {
-		expect.assertions(1)
-
-		// No visit or draft id
-		jest.spyOn(String.prototype, 'split').mockReturnValueOnce(['', '', CLASSIC_MODE])
 
 		jest.spyOn(Common.models.OboModel, 'create')
 		Common.models.OboModel.create.mockReturnValueOnce({

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
@@ -134,10 +134,6 @@ class EditorApp extends React.Component {
 		// get draftID from location
 		const draftId = urlTokens[3] ? urlTokens[3] : null
 
-		// get the mode from the location
-		let mode = urlTokens[2] || VISUAL_MODE // default to visual
-		if (mode === 'classic') mode = XML_MODE // convert classic to xml
-
 		ModalStore.init()
 		return this.reloadDraft(draftId, this.state.mode)
 	}

--- a/packages/app/obojobo-repository/server/models/draft_summary.js
+++ b/packages/app/obojobo-repository/server/models/draft_summary.js
@@ -11,11 +11,7 @@ const buildQueryWhere = (whereSQL, joinSQL = '') => {
 			count(drafts_content.id) OVER wnd as revision_count,
 			COALESCE(last_value(drafts_content.content->'content'->>'title') OVER wnd, '') as "title",
 			drafts.user_id AS user_id,
-			CASE
-				WHEN last_value(drafts_content.xml) OVER wnd IS NULL
-				THEN 'visual'
-				ELSE 'classic'
-			END AS editor
+			'visual' AS editor
 		FROM drafts
 		JOIN drafts_content
 			ON drafts_content.draft_id = drafts.id


### PR DESCRIPTION
some parts of the classic editor links were removed, but others remained.  It's long gone now, so it needed to be removed from the repository.

This should be every remaining part of the 'classic' mode editor urls.

fixes #1341 