### PR TITLE
 ENV var change for db ssl settings

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,9 +10,9 @@
 		"purgedata": "yarn run obojobo_purge_data"
 	},
 	"env": {
-		"DB_SSL": {
-			"description": "Do not change. Connects to the database using SSL.",
-			"value": "true"
+		"DB_SSL_JSON": {
+			"description": "PG-Promise SSL Configuration. https://github.com/vitaly-t/pg-promise/wiki/Connection-Syntax",
+			"value": "{\"rejectUnauthorized\":false}"
 		},
 		"OBO_LTI_KEYS_JSON": {
 			"description": "Edit the secret value. JSON string for LTI key:secret values.",

--- a/packages/app/obojobo-express/server/config/db.json
+++ b/packages/app/obojobo-express/server/config/db.json
@@ -16,7 +16,7 @@
 		"host": {"ENV": "DB_HOST"},
 		"database": {"ENV": "DB_NAME"},
 		"port": {"ENV": "DB_PORT"},
-		"ssl": {"ENV": "DB_SSL"},
+		"ssl": {"ENV": "DB_SSL_JSON"},
 		"useBluebird": false
 	}
 }


### PR DESCRIPTION
Changes ENV DB_SSL to DB_SSL_JSON to support supplying an object to pg-promise connection settings.  This is mainly to allow Heorku's postgress self-signed certs to authenticate and still connect using ssl.

**This pr will require changes in your configuration settings**