### PR TITLE
[fix] typo in lti instruction page showing wrong url for resource selection

### DIFF
--- a/packages/app/obojobo-express/server/routes/lti.js
+++ b/packages/app/obojobo-express/server/routes/lti.js
@@ -14,7 +14,7 @@ router.route('/').get((req, res) => {
 		xml_url: `${protocol}://${hostname}/lti/config.xml`,
 		launch_url: `${protocol}://${hostname}/lti`,
 		course_navigation_url: `${protocol}://${hostname}/lti/canvas/course_navigation`,
-		assignment_selection_url: `${protocol}://${hostname}/lti/canvas/assignment_selection`,
+		assignment_selection_url: `${protocol}://${hostname}/lti/canvas/resource_selection`,
 		keys: Object.keys(config.lti.keys)
 	})
 })


### PR DESCRIPTION
The url was changed at some point from: `assignment_selection` to `resource_selection` and the instructions on the lti page weren't updated.