### PR TITLE
Keep the navigation bar stays on the left

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/editor-nav.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/editor-nav.scss
@@ -19,9 +19,12 @@
 	box-sizing: border-box;
 	transition: left $duration-animation-default $duration-animation-default;
 	border-right: 1px solid transparentize($color-shadow, 0.1);
-	overflow-y: visible;
 	border-radius: $dimension-rounded-radius 0 0 $dimension-rounded-radius;
 	align-items: stretch;
+	position: fixed;
+	overflow-y: scroll;
+	top: 7em;
+	bottom: 0;
 
 	hr {
 		border: none;

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.scss
@@ -6,11 +6,8 @@
 	$latex-defaults: inherit !important;
 
 	display: flex;
-	margin: 2em;
-	margin-top: 8em;
-	border: 1px solid $color-shadow;
+	margin-top: 6em;
 	background-color: $color-bg;
-	border-radius: $dimension-rounded-radius;
 	min-height: calc(100vh - 10.5em);
 	position: relative;
 
@@ -18,8 +15,8 @@
 		margin: 3em auto;
 		width: 100%;
 		display: table-cell;
-		margin-top: 3em;
 		margin-bottom: 1em;
+		padding-left: $dimension-nav-menu;
 	}
 
 	.parameter-node {


### PR DESCRIPTION
Resolves #1263 

Summary:
- Keep the navigation bar stay the left when scrolling
- Get rid of space around the main content