### PR TITLE
[fix] multi-node select crash when moving nodes

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
@@ -164,6 +164,10 @@ class Node extends React.Component {
 			to: targetPath
 		}
 
+		// All kinds of issues pop up if the selection spans multiple chunks
+		// when using moveNode.  So set the selection to the start of the currently moving element
+		Transforms.select(this.props.editor, Editor.start(this.props.editor, thisPath))
+
 		Transforms.moveNodes(this.props.editor, options)
 	}
 


### PR DESCRIPTION
when the select spanned multiple nodes, slate died horribly when moving nodes - the node would move then - I assume - slate would try to find the leading and trailing edges of the selection in the nodes and things would go badly

* sets the selection to the start of the node that's moving

Fixes #1388 