### PR TITLE
removes whitelist and blacklist terminology

### DIFF
--- a/packages/app/obojobo-document-json-parser/src/process-attrs.js
+++ b/packages/app/obojobo-document-json-parser/src/process-attrs.js
@@ -1,12 +1,12 @@
 const xmlEncode = require('./xml-encode')
 
-const processAttrs = (content, blackListedAttributes) => {
+const processAttrs = (content, blockedAttributes) => {
 	let attrs = ''
 	for (const attr in content) {
 		if (
 			content[attr] === null ||
 			typeof content[attr] === 'object' ||
-			blackListedAttributes.includes(attr)
+			blockedAttributes.includes(attr)
 		) {
 			continue
 		}

--- a/packages/app/obojobo-express/server/express_response_decorator.js
+++ b/packages/app/obojobo-express/server/express_response_decorator.js
@@ -5,7 +5,7 @@ const apiUrlRegex = /\/api\/.*/
 const oboEvents = oboRequire('server/obo_events')
 
 const getSanitizedErrorMessage = e => {
-	// If the error is in our blacklist only return the error name:
+	// If the error is in our blockList only return the error name:
 	if (e instanceof QueryResultError) {
 		return e.constructor.name
 	}

--- a/packages/obonode/obojobo-sections-assessment/assessment-rubric.js
+++ b/packages/obonode/obojobo-sections-assessment/assessment-rubric.js
@@ -35,7 +35,7 @@ const MOD_AMOUNT_LIMIT = 20
 const getRubricType = rubric =>
 	!rubric || !rubric.type ? AssessmentRubric.TYPE_ATTEMPT : rubric.type
 
-const createStandizedRubric = rubric => {
+const createStandardizedRubric = rubric => {
 	const rubricType = getRubricType(rubric)
 
 	let standardizedRubric
@@ -87,10 +87,10 @@ const createStandardizedMod = mod => {
 	}
 }
 
-const modToObject = standarizedMod => {
+const modToObject = standardizedMod => {
 	return {
-		attemptCondition: getRangeString(standarizedMod.attemptCondition),
-		reward: standarizedMod.reward
+		attemptCondition: getRangeString(standardizedMod.attemptCondition),
+		reward: standardizedMod.reward
 	}
 }
 
@@ -111,7 +111,7 @@ class AssessmentRubric {
 
 		const mods = rubric && rubric.mods ? rubric.mods.slice(0, MOD_AMOUNT_LIMIT) : []
 
-		this.rubric = createStandizedRubric(rubric)
+		this.rubric = createStandardizedRubric(rubric)
 		this.type = getRubricType(rubric)
 		this.mods = mods.map(createStandardizedMod).filter(mod => mod !== null)
 	}

--- a/packages/obonode/obojobo-sections-assessment/assessment-rubric.js
+++ b/packages/obonode/obojobo-sections-assessment/assessment-rubric.js
@@ -35,14 +35,14 @@ const MOD_AMOUNT_LIMIT = 20
 const getRubricType = rubric =>
 	!rubric || !rubric.type ? AssessmentRubric.TYPE_ATTEMPT : rubric.type
 
-const createWhitelistedRubric = rubric => {
+const createStandizedRubric = rubric => {
 	const rubricType = getRubricType(rubric)
 
-	let whitelistedRubric
+	let standardizedRubric
 
 	switch (rubricType) {
 		case AssessmentRubric.TYPE_PASS_FAIL:
-			whitelistedRubric = Object.assign(
+			standardizedRubric = Object.assign(
 				{
 					passingAttemptScore: 100,
 					passedResult: 100,
@@ -55,7 +55,7 @@ const createWhitelistedRubric = rubric => {
 
 		case AssessmentRubric.TYPE_ATTEMPT:
 		default:
-			whitelistedRubric = {
+			standardizedRubric = {
 				passingAttemptScore: 0,
 				passedResult: AssessmentRubric.VAR_ATTEMPT_SCORE,
 				failedResult: 0,
@@ -64,10 +64,10 @@ const createWhitelistedRubric = rubric => {
 			break
 	}
 
-	return whitelistedRubric
+	return standardizedRubric
 }
 
-const createWhitelistedMod = mod => {
+const createStandardizedMod = mod => {
 	// Ensure at least one condition exists:
 	if (!mod.attemptCondition) {
 		return null
@@ -87,10 +87,10 @@ const createWhitelistedMod = mod => {
 	}
 }
 
-const modToObject = whitelistedMod => {
+const modToObject = standarizedMod => {
 	return {
-		attemptCondition: getRangeString(whitelistedMod.attemptCondition),
-		reward: whitelistedMod.reward
+		attemptCondition: getRangeString(standarizedMod.attemptCondition),
+		reward: standarizedMod.reward
 	}
 }
 
@@ -111,9 +111,9 @@ class AssessmentRubric {
 
 		const mods = rubric && rubric.mods ? rubric.mods.slice(0, MOD_AMOUNT_LIMIT) : []
 
-		this.rubric = createWhitelistedRubric(rubric)
+		this.rubric = createStandizedRubric(rubric)
 		this.type = getRubricType(rubric)
-		this.mods = mods.map(createWhitelistedMod).filter(mod => mod !== null)
+		this.mods = mods.map(createStandardizedMod).filter(mod => mod !== null)
 	}
 
 	toObject() {


### PR DESCRIPTION
Given recent events and after reading over https://tools.ietf.org/id/draft-knodel-terminology-00.html#rfc.section.1.3 I figured we might as well purge some of these terms from our codebase.

Blacklist is still heavily used in eslint, but we can keep an eye open for https://github.com/eslint/eslint/issues/13407

If anyone here is extra motivated, perhaps contribute to eslint here: https://github.com/eslint/eslint/pull/13408