### PR TITLE
Fix focus issue on link menu modal

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
@@ -7,6 +7,8 @@ import mockConsole from 'jest-mock-console'
 import Common from 'src/scripts/common'
 import Component from 'src/scripts/oboeditor/components/node/editor'
 import EditorUtil from 'src/scripts/oboeditor/util/editor-util'
+import ModalStore from '../../../src/scripts/common/stores/modal-store'
+import Dispatcher from '../../../src/scripts/common/flux/dispatcher'
 
 import { Editor } from 'slate'
 import { ReactEditor } from 'slate-react'
@@ -73,6 +75,42 @@ describe('VisualEditor', () => {
 		}
 		const component = renderer.create(<VisualEditor {...props} />)
 		expect(component.toJSON()).toMatchSnapshot()
+	})
+
+	test('VisualEditor component - editor is disable when modal is opened', () => {
+		ModalStore.init()
+
+		const props = {
+			insertableItems: 'mock-insertable-items',
+			page: {
+				attributes: { children: [{ type: 'mockNode' }] },
+				get: jest.fn(),
+				toJSON: () => ({ children: [{ type: 'mockNode' }] })
+			},
+			model: { title: 'Mock Title' }
+		}
+		const component = renderer.create(<VisualEditor {...props} />)
+
+		Dispatcher.trigger('modal:show', { value: 'mockValue' })
+		expect(component.getInstance().state.editable).toEqual(false)
+	})
+
+	test('VisualEditor component - editor is disable when modal is closed', () => {
+		ModalStore.init()
+
+		const props = {
+			insertableItems: 'mock-insertable-items',
+			page: {
+				attributes: { children: [{ type: 'mockNode' }] },
+				get: jest.fn(),
+				toJSON: () => ({ children: [{ type: 'mockNode' }] })
+			},
+			model: { title: 'Mock Title' }
+		}
+		const component = renderer.create(<VisualEditor {...props} />)
+
+		Dispatcher.trigger('modal:hide', { value: 'mockValue' })
+		expect(component.getInstance().state.editable).toEqual(true)
 	})
 
 	test('VisualEditor component with decoration', () => {

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
@@ -23,6 +23,7 @@ import HoveringPreview from './hovering-preview'
 
 const { OboModel } = Common.models
 const { Button } = Common.components
+const { Dispatcher } = Common.flux
 
 const CONTENT_NODE = 'ObojoboDraft.Sections.Content'
 const ASSESSMENT_NODE = 'ObojoboDraft.Sections.Assessment'
@@ -148,6 +149,12 @@ class VisualEditor extends React.Component {
 	}
 
 	componentDidMount() {
+		Dispatcher.on('modal:show', () => {
+			this.toggleEditable(false)
+		})
+		Dispatcher.on('modal:hide', () => {
+			this.toggleEditable(true)
+		})
 		// Setup unload to prompt user before closing
 		window.addEventListener('beforeunload', this.checkIfSaved)
 		// Setup global keydown to listen to all global keys


### PR DESCRIPTION
Resolve #1360 

Fixed a similar issue for 'Make a copy...'
 
Solution:
- Disable the editor when `modal:show` is triggered
- Enable the editor when `modal:hide` is triggered