### PR TITLE
Heroku deploy fixes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: yarn obojobo-migrate up -e production
+web: yarn start

--- a/app.json
+++ b/app.json
@@ -6,7 +6,6 @@
 	"logo": "https://ucfopen.github.io/Obojobo-Docs/assets/images/obojobo_blue.svg",
 	"success_url": "/",
 	"scripts": {
-		"release": "cd node_modules/obojobo-express && yarn db:migrateup",
 		"postdeploy": "cd node_modules/obojobo-express && yarn sampleDraft:seed",
 		"purgedata": "yarn run obojobo_purge_data"
 	},

--- a/packages/util/obojobo-lib-utils/bin/obojobo-migrate
+++ b/packages/util/obojobo-lib-utils/bin/obojobo-migrate
@@ -18,7 +18,7 @@ const fs = require('fs-extra')
 const os = require('os')
 const { execSync } = require('child_process')
 const dbMigratePath = require.resolve('db-migrate/bin/db-migrate')
-const configPath = require.resolve('obojobo-express/server/config/db.json')
+const config = require('obojobo-express/server/config')
 const args = process.argv.slice(2).join(' ')
 const isCreateMode = args.includes('create')
 
@@ -26,10 +26,14 @@ let command
 
 if (!isCreateMode) {
 	const tempDir = fs.mkdtempSync(`${os.tmpdir()}/obojobo-migrations-`)
-
+	const configPath = `${tempDir}/dbconfig.json`
+	console.log(tempDir)
 	try {
 		// useful to understand how args are being inserted into the command
 		command = `${dbMigratePath} ${args} --config ${configPath} --migrations-dir ${tempDir}`
+
+		// use obojobo's config parser to create a json file for db-migrate
+		fs.writeFileSync(configPath, JSON.stringify({development: config.db, production: config.db}, null, '\t'))
 
 		// gather all the migrations into a tmp dir
 		utils.gatherAllMigrations().forEach(dir => fs.copySync(dir, tempDir))

--- a/packages/util/obojobo-lib-utils/bin/obojobo-migrate
+++ b/packages/util/obojobo-lib-utils/bin/obojobo-migrate
@@ -27,7 +27,7 @@ let command
 if (!isCreateMode) {
 	const tempDir = fs.mkdtempSync(`${os.tmpdir()}/obojobo-migrations-`)
 	const configPath = `${tempDir}/dbconfig.json`
-	console.log(tempDir)
+
 	try {
 		// useful to understand how args are being inserted into the command
 		command = `${dbMigratePath} ${args} --config ${configPath} --migrations-dir ${tempDir}`


### PR DESCRIPTION
Heroku deploy broke due to 2 reasons - the post deploy mechanism wasn't running the migration scripts and new ssl config options / requirments for bypassing self-signed certs on free heroku dbs - combined with the fact that obojobo config supports json env var expansion but db-migrate doesn't have these features.

* post-deploy processes moved to Procfile from app.json
* objobo-migrate upgraded to provide obojobo config abilities to db-migrate