### PR TITLE
Shift+L prevents capital L in list

### DIFF
--- a/packages/obonode/obojobo-chunks-list/editor-registration.js
+++ b/packages/obonode/obojobo-chunks-list/editor-registration.js
@@ -92,7 +92,7 @@ const plugins = {
 			case 'K':
 			case 'l':
 			case 'L':
-				if (event.shiftKey) {
+				if (event.shiftKey && (event.ctrlKey || event.metaKey)) {
 					event.preventDefault()
 					ListUtil.toggleType(entry[0], editor)
 				}


### PR DESCRIPTION
Replaced with `Cmd+Shift+L` or `Ctrl+Shift+L`
Fixed the same issue for `Shift+K`

Resolve #1429 