### PR TITLE
Change dashboard default order to be newest first

### DIFF
--- a/packages/app/obojobo-repository/server/routes/dashboard.js
+++ b/packages/app/obojobo-repository/server/routes/dashboard.js
@@ -14,7 +14,7 @@ router
 	.route('/dashboard')
 	.get([requireCurrentUser, requireCanPreviewDrafts])
 	.get((req, res) => {
-		let sortOrder = 'alphabetical'
+		let sortOrder = 'newest'
 		const cookies = req.headers.cookie.split(';')
 		const cookieSort = cookies.find(cookie => cookie.includes('sortOrder'))
 

--- a/packages/app/obojobo-repository/shared/components/module.scss
+++ b/packages/app/obojobo-repository/shared/components/module.scss
@@ -10,7 +10,7 @@
 	font-size: 0.75em;
 	text-align: center;
 	border: 1px solid rgba(0, 0, 0, 0);
-	animation: slide-up 0.4s ease;
+	animation: slide-up 2s ease;
 	cursor: pointer;
 
 	> button {

--- a/packages/app/obojobo-repository/shared/components/module.scss
+++ b/packages/app/obojobo-repository/shared/components/module.scss
@@ -10,7 +10,7 @@
 	font-size: 0.75em;
 	text-align: center;
 	border: 1px solid rgba(0, 0, 0, 0);
-	animation: slide-up 2s ease;
+	animation: slide-up 0.4s ease;
 	cursor: pointer;
 
 	> button {


### PR DESCRIPTION
Note: order setting is saved in cookie.
Also, increase the animation time to highlight the newly created item.

Resolves #1430 
