### PR TITLE
Fix heading text outline

### DIFF
--- a/packages/app/obojobo-repository/shared/components/repository-banner.scss
+++ b/packages/app/obojobo-repository/shared/components/repository-banner.scss
@@ -66,6 +66,7 @@
 	// Nudge the text slightly left to line up:
 	margin-left: -3px;
 	word-break: break-word;
+	position: relative;
 }
 
 .default-bg .repository--title-banner--title {


### PR DESCRIPTION
Fixes #1353.  The heading needed `position: relative;` so that the `::before` element takes up the full space.