### PR TITLE
[fix] undo/redo are called twice

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/code-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/code-editor.test.js
@@ -351,23 +351,10 @@ describe('CodeEditor', () => {
 
 		component.instance().onKeyDown({
 			preventDefault: jest.fn(),
-			key: 'z',
-			metaKey: true
-		})
-
-		component.instance().onKeyDown({
-			preventDefault: jest.fn(),
-			key: 'y',
-			metaKey: true
-		})
-
-		component.instance().onKeyDown({
-			preventDefault: jest.fn(),
 			key: 's'
 		})
 
-		expect(editor.undo).toHaveBeenCalled()
-		expect(editor.redo).toHaveBeenCalled()
+		expect(EditorUtil.getTitleFromString).toHaveBeenCalled()
 	})
 
 	test('setEditor changes state', () => {

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
@@ -915,12 +915,6 @@ describe('VisualEditor', () => {
 
 		instance.onKeyDownGlobal({
 			preventDefault: jest.fn(),
-			key: 'z',
-			metaKey: true
-		})
-
-		instance.onKeyDownGlobal({
-			preventDefault: jest.fn(),
 			key: 'y',
 			metaKey: true
 		})
@@ -954,7 +948,6 @@ describe('VisualEditor', () => {
 			shiftKey: true
 		})
 
-		expect(editor.undo).toHaveBeenCalled()
 		expect(editor.redo).toHaveBeenCalled()
 	})
 

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/code-editor.js
@@ -158,16 +158,6 @@ class CodeEditor extends React.Component {
 			event.preventDefault()
 			this.saveAndGetTitleFromCode()
 		}
-
-		if (event.key === 'z' && (event.ctrlKey || event.metaKey)) {
-			event.preventDefault()
-			this.state.editor.undo()
-		}
-
-		if (event.key === 'y' && (event.ctrlKey || event.metaKey)) {
-			event.preventDefault()
-			this.state.editor.redo()
-		}
 	}
 
 	setEditor(editor) {

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
@@ -200,19 +200,9 @@ class VisualEditor extends React.Component {
 			return this.saveModule(this.props.draftId)
 		}
 
-		if (
-			(event.key === 'y' && (event.ctrlKey || event.metaKey)) ||
-			((event.key === 'z' || event.key === 'Z') &&
-				(event.ctrlKey || event.metaKey) &&
-				event.shiftKey)
-		) {
+		if (event.key === 'y' && (event.ctrlKey || event.metaKey)) {
 			event.preventDefault()
 			return this.editor.redo()
-		}
-
-		if (event.key === 'z' && (event.ctrlKey || event.metaKey)) {
-			event.preventDefault()
-			return this.editor.undo()
 		}
 
 		if (event.key === 'Escape') {


### PR DESCRIPTION
Fixes #1464 

Both visual editor and json/xml editor have their own undo/redo shortcut so we don't have to do it ourselves.