### PR TITLE
[fix] pressing enter at the beginning of heading throws error

### DIFF
--- a/packages/obonode/obojobo-chunks-heading/editor-registration.js
+++ b/packages/obonode/obojobo-chunks-heading/editor-registration.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Element, Editor, Node, Transforms } from 'slate'
-import KeyDownUtil from 'obojobo-document-engine/src/scripts/oboeditor/util/keydown-util'
 
 import emptyNode from './empty-node.json'
 import Icon from './icon'
@@ -57,9 +56,6 @@ const Heading = {
 		},
 		onKeyDown(entry, editor, event) {
 			switch (event.key) {
-				case 'Enter':
-					return KeyDownUtil.breakToText(event, editor, entry)
-
 				case 'Tab':
 					event.preventDefault()
 					return editor.insertText('\t')

--- a/packages/obonode/obojobo-chunks-heading/editor-registration.test.js
+++ b/packages/obonode/obojobo-chunks-heading/editor-registration.test.js
@@ -2,7 +2,6 @@ import { Transforms } from 'slate'
 
 import Heading from './editor-registration'
 const HEADING_NODE = 'ObojoboDraft.Chunks.Heading'
-import KeyDownUtil from 'obojobo-document-engine/src/scripts/oboeditor/util/keydown-util'
 
 jest.mock('obojobo-document-engine/src/scripts/oboeditor/util/keydown-util')
 jest.mock('slate-react')
@@ -71,18 +70,6 @@ describe('Heading editor', () => {
 		Heading.plugins.onKeyDown([{}, [0]], {}, event)
 
 		expect(event.preventDefault).not.toHaveBeenCalled()
-	})
-
-	test('plugins.onKeyDown deals with [Enter]', () => {
-		jest.spyOn(Transforms, 'insertText').mockReturnValueOnce(true)
-
-		const event = {
-			key: 'Enter',
-			preventDefault: jest.fn()
-		}
-
-		Heading.plugins.onKeyDown([{}, [0]], {}, event)
-		expect(KeyDownUtil.breakToText).toHaveBeenCalled()
 	})
 
 	test('plugins.onKeyDown deals with [Tab]', () => {


### PR DESCRIPTION
Fixes #1469 