### PR TITLE
[fix] cannot undo move up and move down

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/node/editor-component.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/node/editor-component.test.js
@@ -279,10 +279,8 @@ describe('Component Editor Node', () => {
 		const component = rtr.create(<Node {...mockProps} />)
 		component.getInstance().moveNode(0)
 
-		expect(Transforms.moveNodes).toHaveBeenCalledWith(mockProps.editor, {
-			at: [0],
-			to: 'mock-previous-return'
-		})
+		expect(Transforms.insertNodes).toHaveBeenCalled()
+		expect(Transforms.removeNodes).toHaveBeenCalled()
 	})
 
 	test('Node component move node up', () => {
@@ -291,10 +289,8 @@ describe('Component Editor Node', () => {
 		const component = rtr.create(<Node {...mockProps} />)
 		component.getInstance().moveNode(1)
 
-		expect(Transforms.moveNodes).toHaveBeenCalledWith(mockProps.editor, {
-			at: [0],
-			to: 'mock-next-return'
-		})
+		expect(Transforms.insertNodes).toHaveBeenCalled()
+		expect(Transforms.removeNodes).toHaveBeenCalled()
 	})
 
 	test('onOpen and onClose call toggleEditable', () => {

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
@@ -159,16 +159,15 @@ class Node extends React.Component {
 		const targetPath =
 			thisSiblingIndex < targetIndex ? Path.next(thisPath) : Path.previous(thisPath)
 
-		const options = {
-			at: thisPath,
-			to: targetPath
-		}
-
 		// All kinds of issues pop up if the selection spans multiple chunks
 		// when using moveNode.  So set the selection to the start of the currently moving element
 		Transforms.select(this.props.editor, Editor.start(this.props.editor, thisPath))
 
-		Transforms.moveNodes(this.props.editor, options)
+		// As for slate 0.57.2 does not support undo/redo for Transforms.moveNodes,
+		// this bypass solution will delete the current node and insert it to the appropriate location
+		const curNode = { ...this.props.element }
+		this.deleteNode()
+		Transforms.insertNodes(this.props.editor, curNode, { at: targetPath })
 	}
 
 	renderMoreInfo() {


### PR DESCRIPTION
Fixes #1396

Solution: Use `Transforms.removeNodes` and `Transforms.insertNodes` instead of `Transforms.moveNodes`
Note: the problem with undo shortcut (#1468) is still present in the current branch, use undo in the toolbar instead