### PR TITLE
Fix heading menu in Safari

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/paragraph-styles.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/paragraph-styles.test.js
@@ -154,7 +154,7 @@ describe('Paragraph Styles', () => {
 				preventDefault: jest.fn()
 			})
 
-		expect(mockChangeToType).toHaveBeenCalledWith(TEXT_NODE)
+		expect(mockChangeToType).toHaveBeenCalledWith(TEXT_NODE, {})
 
 		component
 			.find('div')

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/paragraph-styles.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/paragraph-styles.test.js
@@ -120,6 +120,61 @@ describe('Paragraph Styles', () => {
 		expect(editor.changeToType).toHaveBeenCalledTimes(8)
 	})
 
+	test('Paragraph Styles calls editor.changeToType on Enter pressed', () => {
+		const mockChangeToType = jest.fn()
+		const editor = {
+			children: [
+				{
+					type: 'MockNode',
+					children: [{ text: 'mockText' }]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0], offset: 1 },
+				focus: { path: [0, 0], offset: 1 }
+			},
+			isInline: () => false,
+			isVoid: () => false,
+			changeToType: mockChangeToType
+		}
+
+		const component = mount(<ParagraphStyles editor={editor} />)
+
+		component
+			.find('div')
+			.at(0)
+			.simulate('keyDown', {
+				key: 'ArrowRight',
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn()
+			})
+			.simulate('keyDown', {
+				key: 'Enter',
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn()
+			})
+
+		expect(mockChangeToType).toHaveBeenCalledWith(TEXT_NODE)
+
+		component
+			.find('div')
+			.at(0)
+			.simulate('keyDown', {
+				key: 'ArrowUp',
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn()
+			})
+			.simulate('keyDown', {
+				key: 'Enter',
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn()
+			})
+
+		expect(mockChangeToType).toHaveBeenCalledWith(HEADING_NODE, {
+			headingLevel: 6
+		})
+	})
+
 	test('Paragraph Styles component opens and closes menu with keys', () => {
 		const editor = {
 			children: [

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/paragraph-styles.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/paragraph-styles.test.js
@@ -87,35 +87,35 @@ describe('Paragraph Styles', () => {
 		component
 			.find('button')
 			.at(1)
-			.simulate('click')
+			.simulate('mousedown')
 		component
 			.find('button')
 			.at(2)
-			.simulate('click')
+			.simulate('mousedown')
 		component
 			.find('button')
 			.at(3)
-			.simulate('click')
+			.simulate('mousedown')
 		component
 			.find('button')
 			.at(4)
-			.simulate('click')
+			.simulate('mousedown')
 		component
 			.find('button')
 			.at(5)
-			.simulate('click')
+			.simulate('mousedown')
 		component
 			.find('button')
 			.at(6)
-			.simulate('click')
+			.simulate('mousedown')
 		component
 			.find('button')
 			.at(7)
-			.simulate('click')
+			.simulate('mousedown')
 		component
 			.find('button')
 			.at(8)
-			.simulate('click')
+			.simulate('mousedown')
 
 		expect(editor.changeToType).toHaveBeenCalledTimes(8)
 	})
@@ -143,7 +143,8 @@ describe('Paragraph Styles', () => {
 			.at(0)
 			.simulate('keyDown', {
 				key: 'ArrowRight',
-				stopPropagation: jest.fn()
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn()
 			})
 
 		expect(component.html()).toMatchSnapshot()
@@ -153,7 +154,8 @@ describe('Paragraph Styles', () => {
 			.at(0)
 			.simulate('keyDown', {
 				key: 'ArrowLeft',
-				stopPropagation: jest.fn()
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn()
 			})
 
 		expect(component.html()).toMatchSnapshot()
@@ -179,7 +181,8 @@ describe('Paragraph Styles', () => {
 			.at(0)
 			.simulate('keyDown', {
 				key: 'ArrowUp',
-				stopPropagation: jest.fn()
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn()
 			})
 
 		expect(component.state()).toMatchSnapshot()
@@ -189,7 +192,8 @@ describe('Paragraph Styles', () => {
 			.at(0)
 			.simulate('keyDown', {
 				key: 'ArrowDown',
-				stopPropagation: jest.fn()
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn()
 			})
 
 		expect(component.state()).toMatchSnapshot()

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/paragraph-styles.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/paragraph-styles.js
@@ -28,8 +28,8 @@ class ParagraphStyles extends React.Component {
 	componentDidUpdate() {
 		// When the menu is open, focus on the current dropdown item
 		if (this.state.isOpen) {
-			this.menu = this.menu.filter(Boolean)
-			this.menu[this.state.currentFocus].focus()
+			this.menu = this.menu.filter(item => !!item.htmlElement)
+			this.menu[this.state.currentFocus].htmlElement.focus()
 		}
 	}
 
@@ -48,24 +48,29 @@ class ParagraphStyles extends React.Component {
 	}
 
 	onKeyDown(event) {
-		this.menu = this.menu.filter(Boolean)
+		this.menu = this.menu.filter(item => !!item.htmlElement)
+		const menuItem = this.menu[this.state.currentFocus]
+
 		if (this.state.isOpen) event.stopPropagation()
 
 		switch (event.key) {
 			// Open the menu and set the first item as the current focus
 			case 'ArrowRight':
+				event.preventDefault()
 				this.setState({ isOpen: true, currentFocus: 0 })
 				event.stopPropagation()
 				break
 
 			// Close the menu and return focus to the link item
 			case 'ArrowLeft':
+				event.preventDefault()
 				this.setState({ isOpen: false })
 				this.menuButton.current.focus()
 				break
 
 			// Move down through the submenu
 			case 'ArrowDown':
+				event.preventDefault()
 				this.setState(currentState => ({
 					currentFocus: (currentState.currentFocus + 1) % this.menu.length
 				}))
@@ -73,10 +78,20 @@ class ParagraphStyles extends React.Component {
 
 			// Move up through the submenu
 			case 'ArrowUp':
+				event.preventDefault()
 				this.setState(currentState => ({
 					currentFocus: (currentState.currentFocus + this.menu.length - 1) % this.menu.length
 				}))
 				break
+			case 'Enter':
+				event.preventDefault()
+				if (menuItem.node === HEADING_NODE) {
+					this.props.editor.changeToType(menuItem.node, {
+						headingLevel: menuItem.headingLevel
+					})
+				} else {
+					this.props.editor.changeToType(menuItem.node)
+				}
 		}
 	}
 
@@ -142,65 +157,97 @@ class ParagraphStyles extends React.Component {
 				</button>
 				<div className={'paragraph-styles-menu ' + isOrNot(this.state.isOpen, 'open')}>
 					<button
-						onClick={() => this.props.editor.changeToType(TEXT_NODE)}
+						onMouseDown={() => this.props.editor.changeToType(TEXT_NODE)}
 						ref={item => {
-							this.menu.push(item)
+							this.menu.push({
+								htmlElement: item,
+								node: TEXT_NODE
+							})
 						}}
 					>
 						<p>Normal Text</p>
 					</button>
 					<button
-						onClick={() => this.props.editor.changeToType(CODE_NODE)}
+						onMouseDown={() => {
+							this.props.editor.changeToType(CODE_NODE)
+						}}
 						ref={item => {
-							this.menu.push(item)
+							this.menu.push({
+								htmlElement: item,
+								node: CODE_NODE
+							})
 						}}
 					>
 						<pre>Code</pre>
 					</button>
 					<button
-						onClick={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 1 })}
+						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 1 })}
 						ref={item => {
-							this.menu.push(item)
+							this.menu.push({
+								htmlElement: item,
+								node: HEADING_NODE,
+								headingLevel: 1
+							})
 						}}
 					>
 						<h1>Heading 1</h1>
 					</button>
 					<button
-						onClick={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 2 })}
+						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 2 })}
 						ref={item => {
-							this.menu.push(item)
+							this.menu.push({
+								htmlElement: item,
+								node: HEADING_NODE,
+								headingLevel: 2
+							})
 						}}
 					>
 						<h2>Heading 2</h2>
 					</button>
 					<button
-						onClick={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 3 })}
+						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 3 })}
 						ref={item => {
-							this.menu.push(item)
+							this.menu.push({
+								htmlElement: item,
+								node: HEADING_NODE,
+								headingLevel: 3
+							})
 						}}
 					>
 						<h3>Heading 3</h3>
 					</button>
 					<button
-						onClick={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 4 })}
+						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 4 })}
 						ref={item => {
-							this.menu.push(item)
+							this.menu.push({
+								htmlElement: item,
+								node: HEADING_NODE,
+								headingLevel: 4
+							})
 						}}
 					>
 						<h4>Heading 4</h4>
 					</button>
 					<button
-						onClick={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 5 })}
+						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 5 })}
 						ref={item => {
-							this.menu.push(item)
+							this.menu.push({
+								htmlElement: item,
+								node: HEADING_NODE,
+								headingLevel: 5
+							})
 						}}
 					>
 						<h5>Heading 5</h5>
 					</button>
 					<button
-						onClick={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 6 })}
+						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 6 })}
 						ref={item => {
-							this.menu.push(item)
+							this.menu.push({
+								htmlElement: item,
+								node: HEADING_NODE,
+								headingLevel: 6
+							})
 						}}
 					>
 						<h6>Heading 6</h6>

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/paragraph-styles.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/paragraph-styles.js
@@ -22,6 +22,7 @@ class ParagraphStyles extends React.Component {
 		this.onBlurHandler = this.onBlurHandler.bind(this)
 		this.onFocusHandler = this.onFocusHandler.bind(this)
 		this.onKeyDown = this.onKeyDown.bind(this)
+		this.changeToType = this.changeToType.bind(this)
 		this.menuButton = React.createRef()
 	}
 
@@ -85,14 +86,18 @@ class ParagraphStyles extends React.Component {
 				break
 			case 'Enter':
 				event.preventDefault()
+
 				if (menuItem.node === HEADING_NODE) {
-					this.props.editor.changeToType(menuItem.node, {
-						headingLevel: menuItem.headingLevel
-					})
+					this.changeToType(menuItem.node, { headingLevel: menuItem.headingLevel })
 				} else {
-					this.props.editor.changeToType(menuItem.node)
+					this.changeToType(menuItem.node)
 				}
 		}
+	}
+
+	changeToType(nodeType, opts = {}) {
+		this.props.editor.changeToType(nodeType, opts)
+		this.setState({ isOpen: false })
 	}
 
 	toggleLevelSelect() {
@@ -157,7 +162,7 @@ class ParagraphStyles extends React.Component {
 				</button>
 				<div className={'paragraph-styles-menu ' + isOrNot(this.state.isOpen, 'open')}>
 					<button
-						onMouseDown={() => this.props.editor.changeToType(TEXT_NODE)}
+						onMouseDown={() => this.changeToType(TEXT_NODE)}
 						ref={item => {
 							this.menu.push({
 								htmlElement: item,
@@ -168,9 +173,7 @@ class ParagraphStyles extends React.Component {
 						<p>Normal Text</p>
 					</button>
 					<button
-						onMouseDown={() => {
-							this.props.editor.changeToType(CODE_NODE)
-						}}
+						onMouseDown={() => this.changeToType(CODE_NODE)}
 						ref={item => {
 							this.menu.push({
 								htmlElement: item,
@@ -181,7 +184,7 @@ class ParagraphStyles extends React.Component {
 						<pre>Code</pre>
 					</button>
 					<button
-						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 1 })}
+						onMouseDown={() => this.changeToType(HEADING_NODE, { headingLevel: 1 })}
 						ref={item => {
 							this.menu.push({
 								htmlElement: item,
@@ -193,7 +196,7 @@ class ParagraphStyles extends React.Component {
 						<h1>Heading 1</h1>
 					</button>
 					<button
-						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 2 })}
+						onMouseDown={() => this.changeToType(HEADING_NODE, { headingLevel: 2 })}
 						ref={item => {
 							this.menu.push({
 								htmlElement: item,
@@ -205,7 +208,7 @@ class ParagraphStyles extends React.Component {
 						<h2>Heading 2</h2>
 					</button>
 					<button
-						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 3 })}
+						onMouseDown={() => this.changeToType(HEADING_NODE, { headingLevel: 3 })}
 						ref={item => {
 							this.menu.push({
 								htmlElement: item,
@@ -217,7 +220,7 @@ class ParagraphStyles extends React.Component {
 						<h3>Heading 3</h3>
 					</button>
 					<button
-						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 4 })}
+						onMouseDown={() => this.changeToType(HEADING_NODE, { headingLevel: 4 })}
 						ref={item => {
 							this.menu.push({
 								htmlElement: item,
@@ -229,7 +232,7 @@ class ParagraphStyles extends React.Component {
 						<h4>Heading 4</h4>
 					</button>
 					<button
-						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 5 })}
+						onMouseDown={() => this.changeToType(HEADING_NODE, { headingLevel: 5 })}
 						ref={item => {
 							this.menu.push({
 								htmlElement: item,
@@ -241,7 +244,7 @@ class ParagraphStyles extends React.Component {
 						<h5>Heading 5</h5>
 					</button>
 					<button
-						onMouseDown={() => this.props.editor.changeToType(HEADING_NODE, { headingLevel: 6 })}
+						onMouseDown={() => this.changeToType(HEADING_NODE, { headingLevel: 6 })}
 						ref={item => {
 							this.menu.push({
 								htmlElement: item,


### PR DESCRIPTION
The problem was that `onClick` fired after `onBlur`. This meant that the menu would close without doing anything. Changing the menu buttons `onClick` to `onMouseDown` lets the event fire before `onBlur`. However, this means that we need to manually listen for an `Enter` keypress since pressing Enter called `onClick`.

Fixes #1471.