### PR TITLE
Fix long text breaking auto width tables

### DIFF
--- a/packages/obonode/obojobo-chunks-table/__snapshots__/viewer-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-table/__snapshots__/viewer-component.test.js.snap
@@ -11,7 +11,7 @@ exports[`Table Table component 1`] = `
   tabIndex={-1}
 >
   <div
-    className="obojobo-draft--chunks--table viewer pad"
+    className="obojobo-draft--chunks--table viewer pad  is-not-showing-scrollbar"
   >
     <div
       className="container"
@@ -116,7 +116,7 @@ exports[`Table Table component with flexible cell sizes 1`] = `
   tabIndex={-1}
 >
   <div
-    className="obojobo-draft--chunks--table viewer pad"
+    className="obojobo-draft--chunks--table viewer pad  is-not-showing-scrollbar"
   >
     <div
       className="container"
@@ -221,7 +221,7 @@ exports[`Table Table component without header 1`] = `
   tabIndex={-1}
 >
   <div
-    className="obojobo-draft--chunks--table viewer pad"
+    className="obojobo-draft--chunks--table viewer pad  is-not-showing-scrollbar"
   >
     <div
       className="container"

--- a/packages/obonode/obojobo-chunks-table/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-table/editor-component.scss
@@ -3,6 +3,12 @@
 .obojobo-draft--chunks--table.viewer {
 	$color-action-low-opacity: lighten($color-action, 50%);
 
+	> .container {
+		// We need to disable the overflow rule for auto-width table cells since this will hide
+		// the table insert/delete menu
+		overflow: inherit;
+	}
+
 	.view.is-display-type-auto {
 		table-layout: auto;
 	}
@@ -157,6 +163,14 @@
 
 			background-color: $color-bg2;
 			box-shadow: -$box-shadow-overlay;
+		}
+	}
+
+	&.is-showing-scrollbar {
+		> .container {
+			// Disable any additional padding provided by the viewer since we don't show scrollbars
+			// in the editor
+			padding-bottom: 0;
 		}
 	}
 }

--- a/packages/obonode/obojobo-chunks-table/viewer-component.js
+++ b/packages/obonode/obojobo-chunks-table/viewer-component.js
@@ -3,65 +3,97 @@ import './viewer-component.scss'
 import Common from 'obojobo-document-engine/src/scripts/common'
 import React from 'react'
 import Viewer from 'obojobo-document-engine/src/scripts/viewer'
+import isOrNot from 'obojobo-document-engine/src/scripts/common/util/isornot'
 
 const { TextGroupEl } = Common.chunk.textChunk
 const { OboComponent } = Viewer.components
 
-const Table = props => {
-	let header, row
-	const { model } = props
-	const modelState = model.modelState
-	const { numCols } = modelState.textGroup
+class Table extends React.Component {
+	constructor(props) {
+		super(props)
 
-	if (modelState.header) {
-		row = modelState.textGroup.items.slice(0, numCols).map((textGroupItem, index) => (
-			<th
-				key={index}
-				className={`cell row-0 col-${index}`}
-				data-table-position={model.get('id') + ',0,' + index}
-			>
-				<TextGroupEl parentModel={props.model} textItem={textGroupItem} groupIndex={index} />
-			</th>
-		))
+		this.state = {
+			isShowingScrollbar: false
+		}
 
-		header = <tr key="header">{row}</tr>
-	} else {
-		header = null
+		this.containerRef = React.createRef()
 	}
 
-	const startIndex = modelState.header ? 1 : 0
-	const rows = __range__(startIndex, modelState.textGroup.numRows, false).map(rowNum => {
-		row = modelState.textGroup.items
-			.slice(rowNum * numCols, (rowNum + 1) * numCols)
-			.map((textGroupItem, index) => (
-				<td
+	componentDidMount() {
+		const el = this.containerRef.current
+
+		if (!el) {
+			return
+		}
+
+		if (el.scrollWidth > el.clientWidth) {
+			this.setState({
+				isShowingScrollbar: true
+			})
+		}
+	}
+
+	render() {
+		let header, row
+		const { model } = this.props
+		const modelState = model.modelState
+		const { numCols } = modelState.textGroup
+
+		if (modelState.header) {
+			row = modelState.textGroup.items.slice(0, numCols).map((textGroupItem, index) => (
+				<th
 					key={index}
-					className={`cell row-${rowNum} col-${index}`}
-					data-table-position={model.get('id') + ',' + rowNum + ',' + index}
+					className={`cell row-0 col-${index}`}
+					data-table-position={model.get('id') + ',0,' + index}
 				>
-					<TextGroupEl
-						parentModel={props.model}
-						textItem={textGroupItem}
-						groupIndex={rowNum * numCols + index}
-					/>
-				</td>
+					<TextGroupEl parentModel={this.props.model} textItem={textGroupItem} groupIndex={index} />
+				</th>
 			))
 
-		return <tr key={rowNum}>{row}</tr>
-	})
+			header = <tr key="header">{row}</tr>
+		} else {
+			header = null
+		}
 
-	return (
-		<OboComponent model={props.model} moduleData={props.moduleData}>
-			<div className="obojobo-draft--chunks--table viewer pad">
-				<div className="container">
-					<table className={`view is-display-type-${modelState.display}`} key="table">
-						<thead key="thead">{header}</thead>
-						<tbody key="tbody">{rows}</tbody>
-					</table>
+		const startIndex = modelState.header ? 1 : 0
+		const rows = __range__(startIndex, modelState.textGroup.numRows, false).map(rowNum => {
+			row = modelState.textGroup.items
+				.slice(rowNum * numCols, (rowNum + 1) * numCols)
+				.map((textGroupItem, index) => (
+					<td
+						key={index}
+						className={`cell row-${rowNum} col-${index}`}
+						data-table-position={model.get('id') + ',' + rowNum + ',' + index}
+					>
+						<TextGroupEl
+							parentModel={this.props.model}
+							textItem={textGroupItem}
+							groupIndex={rowNum * numCols + index}
+						/>
+					</td>
+				))
+
+			return <tr key={rowNum}>{row}</tr>
+		})
+
+		return (
+			<OboComponent model={this.props.model} moduleData={this.props.moduleData}>
+				<div
+					className={`obojobo-draft--chunks--table viewer pad ${isOrNot(
+						this.state.isShowingScrollbar,
+						'showing-scrollbar'
+					)}`}
+				>
+					<div ref={this.containerRef} className="container">
+						<table className={`view is-display-type-${modelState.display}`} key="table">
+							<thead key="thead">{header}</thead>
+							<tbody key="tbody">{rows}</tbody>
+						</table>
+					</div>
 				</div>
-			</div>
-		</OboComponent>
-	)
+			</OboComponent>
+		)
+	}
 }
 
 function __range__(left, right) {

--- a/packages/obonode/obojobo-chunks-table/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-table/viewer-component.scss
@@ -2,6 +2,7 @@
 
 .obojobo-draft--chunks--table.viewer {
 	> .container {
+		// This allows auto-width tables with really long strings of text to still fit within the viewer
 		overflow: auto;
 	}
 
@@ -37,5 +38,11 @@
 
 	> .table-editor-buttons {
 		text-align: center;
+	}
+
+	&.is-showing-scrollbar {
+		> .container {
+			padding-bottom: 1em;
+		}
 	}
 }

--- a/packages/obonode/obojobo-chunks-table/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-table/viewer-component.scss
@@ -1,9 +1,12 @@
 @import '~styles/includes';
 
 .obojobo-draft--chunks--table.viewer {
+	> .container {
+		overflow: auto;
+	}
+
 	.view.is-display-type-auto {
 		table-layout: auto;
-		word-break: break-word;
 	}
 
 	.view {

--- a/packages/obonode/obojobo-chunks-table/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-table/viewer-component.scss
@@ -3,6 +3,7 @@
 .obojobo-draft--chunks--table.viewer {
 	.view.is-display-type-auto {
 		table-layout: auto;
+		word-break: break-word;
 	}
 
 	.view {

--- a/packages/obonode/obojobo-chunks-table/viewer-component.test.js
+++ b/packages/obonode/obojobo-chunks-table/viewer-component.test.js
@@ -141,4 +141,39 @@ describe('Table', () => {
 
 		expect(tree).toMatchSnapshot()
 	})
+
+	test('When the scrollbar is showing the state changes', () => {
+		const thisValue = {
+			containerRef: {
+				current: {
+					scrollWidth: 0,
+					clientWidth: 0
+				}
+			},
+			setState: jest.fn()
+		}
+
+		// scrollWidth < clientWidth
+		thisValue.containerRef.current.scrollWidth = 10
+		thisValue.containerRef.current.clientWidth = 20
+
+		Table.prototype.componentDidMount.bind(thisValue)()
+		expect(thisValue.setState).not.toHaveBeenCalled()
+
+		// scrollWidth === clientWidth
+		thisValue.containerRef.current.scrollWidth = 15
+		thisValue.containerRef.current.clientWidth = 15
+
+		Table.prototype.componentDidMount.bind(thisValue)()
+		expect(thisValue.setState).not.toHaveBeenCalled()
+
+		// scrollWidth > clientWidth
+		thisValue.containerRef.current.scrollWidth = 20
+		thisValue.containerRef.current.clientWidth = 10
+
+		Table.prototype.componentDidMount.bind(thisValue)()
+		expect(thisValue.setState).toHaveBeenCalledWith({
+			isShowingScrollbar: true
+		})
+	})
 })


### PR DESCRIPTION
Fixes #1518 

Adds the break word rule to the auto-width table, fixing an issue with really long strings of text extending the table past the available space