### PR TITLE
Fix crashing problem when deleting an assessment

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
@@ -9,6 +9,7 @@ import Component from 'src/scripts/oboeditor/components/node/editor'
 import EditorUtil from 'src/scripts/oboeditor/util/editor-util'
 import ModalStore from '../../../src/scripts/common/stores/modal-store'
 import Dispatcher from '../../../src/scripts/common/flux/dispatcher'
+import OboModel from 'src/scripts/common/models/obo-model'
 
 import { Editor } from 'slate'
 import { ReactEditor } from 'slate-react'
@@ -20,6 +21,7 @@ jest.mock('src/scripts/oboeditor/components/node/editor', () => ({
 		oboToSlate: jest.fn().mockReturnValue({ text: '' })
 	}
 }))
+jest.mock('src/scripts/common/models/obo-model')
 // Editor Store
 jest.mock('src/scripts/oboeditor/stores/editor-store', () => ({
 	state: { startingId: 'mock-id' }
@@ -286,7 +288,75 @@ describe('VisualEditor', () => {
 		expect(thing.toJSON()).toMatchSnapshot()
 	})
 
+	test('VisualEditor component with deleted page to another page', () => {
+		const prevProps = {
+			page: {
+				id: 122,
+				set: jest.fn(),
+				attributes: {
+					children: [
+						{
+							type: BREAK_NODE,
+							content: {},
+							children: []
+						}
+					]
+				},
+				get: jest.fn().mockReturnValue(ASSESSMENT_NODE),
+				toJSON: () => ({
+					children: [
+						{
+							type: BREAK_NODE,
+							content: {},
+							children: []
+						}
+					]
+				})
+			},
+			model: { title: 'Mock Title' }
+		}
+
+		const newProps = {
+			page: {
+				id: 123,
+				set: jest.fn(),
+				attributes: {
+					children: [
+						{
+							type: BREAK_NODE,
+							content: {},
+							children: []
+						}
+					]
+				},
+				get: jest.fn(),
+				toJSON: () => ({
+					children: [
+						{
+							type: BREAK_NODE,
+							content: {},
+							children: []
+						}
+					]
+				})
+			},
+			model: { title: 'Mock Title' }
+		}
+
+		const spy = jest.spyOn(VisualEditor.prototype, 'exportToJSON').mockReturnValueOnce()
+
+		// render
+		const thing = mount(<VisualEditor {...prevProps} />)
+		thing.setProps(newProps)
+		thing.update()
+
+		// save action should have occured
+		expect(spy).not.toHaveBeenCalled()
+		spy.mockClear()
+	})
+
 	test('VisualEditor component with page updating to another page', () => {
+		OboModel.models = { 122: 'mock content' }
 		const prevProps = {
 			page: {
 				id: 122,

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
@@ -349,7 +349,9 @@ class VisualEditor extends React.Component {
 		if (prevProps.page.id !== this.props.page.id) {
 			this.editor.selection = null
 			this.editor.prevSelection = null
-			this.exportToJSON(prevProps.page, prevState.value)
+			if (OboModel.models[prevProps.page.id]) {
+				this.exportToJSON(prevProps.page, prevState.value)
+			}
 			return this.setState({ value: this.importFromJSON(), editable: true }, () => {
 				Transforms.select(this.editor, Editor.start(this.editor, []))
 				this.setEditorFocus()


### PR DESCRIPTION
Fixes #1506 

Problem: the editor attempts to update the state when changing pages. We don't need to do it when deleting.