### PR TITLE
Code node newline not working

### DIFF
--- a/packages/obonode/obojobo-chunks-code/components/line/__snapshots__/editor-component.js.snap
+++ b/packages/obonode/obojobo-chunks-code/components/line/__snapshots__/editor-component.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Line Editor Node Line builds the expected component 1`] = `
-<span
-  className="text align-left"
-/>
-`;

--- a/packages/obonode/obojobo-chunks-code/components/line/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-code/components/line/__snapshots__/editor-component.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Line Editor Node Line builds the expected component 1`] = `
 <span
-  className="text align-left"
+  className="obo-text align-left"
 />
 `;

--- a/packages/obonode/obojobo-chunks-code/components/line/editor-component.js
+++ b/packages/obonode/obojobo-chunks-code/components/line/editor-component.js
@@ -4,7 +4,7 @@ import React from 'react'
 
 const Line = props => {
 	return (
-		<span className={'text align-left'} data-indent={props.element.content.indent}>
+		<span className={'obo-text align-left'} data-indent={props.element.content.indent}>
 			{props.children}
 		</span>
 	)


### PR DESCRIPTION
Fixes #1527 

Modified code node class from `text` to `obo-text` in the editor component. I also deleted a snapshot file that wasn't being used by anything.