### PR TITLE
Fix the More Info Box when editing Assessment

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/stores/editor-store.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/stores/editor-store.test.js
@@ -486,16 +486,19 @@ describe('EditorStore', () => {
 		jest.spyOn(EditorStore, 'triggerChange')
 		EditorStore.triggerChange.mockReturnValueOnce(true)
 
+		const mockSet = jest.fn()
 		Common.models.OboModel.models['mockId'] = {
 			get: () => ({
-				title: 'mock-title'
-			})
+				title: 'mock-title',
+				value: 'other-value'
+			}),
+			set: mockSet
 		}
 		Common.models.OboModel.getRoot.mockReturnValueOnce('mockRoot')
 
 		EditorStore.renamePageOrModule('mockId', 'mockTitle')
 
-		expect(Common.models.OboModel.models.mockId.title).toEqual('mockTitle')
+		expect(mockSet).toHaveBeenCalledWith('content', { title: 'mockTitle', value: 'other-value' })
 		expect(EditorUtil.rebuildMenu).toHaveBeenCalled()
 		expect(EditorStore.triggerChange).toHaveBeenCalled()
 	})

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/stores/editor-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/stores/editor-store.js
@@ -229,8 +229,8 @@ class EditorStore extends Store {
 
 	renamePageOrModule(nodeId, newName) {
 		const pageOrModule = OboModel.models[nodeId]
-		pageOrModule.get('content').title = newName
-		pageOrModule.title = newName
+		const content = pageOrModule.get('content')
+		pageOrModule.set('content', { ...content, title: newName })
 
 		EditorUtil.rebuildMenu(OboModel.getRoot())
 		this.triggerChange()


### PR DESCRIPTION
Resolves #1549 
Renaming a page in the editor now uses the correct Backbone set method instead of mutating the object