### PR TITLE
Updates AssessmentUtil.getAssessmentScoreForModel to use the assessmentSummary data, which is ready on page load from the visit data

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/Viewer/util/assessment-util.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/util/assessment-util.test.js
@@ -172,30 +172,33 @@ describe('AssessmentUtil', () => {
 	})
 
 	test('getAssessmentScoreForModel returns null when no attempts', () => {
-		const model = {
-			get: jest
-				.fn()
-				.mockReturnValueOnce(TYPE_ASSESSMENT)
-				.mockReturnValueOnce('testId')
-		}
 		const state = {
-			assessments: {}
+			assessmentSummary: []
 		}
 
-		const score = AssessmentUtil.getAssessmentScoreForModel(state, model)
+		const score = AssessmentUtil.getAssessmentScoreForModel(state)
 
 		expect(score).toEqual(null)
 	})
 
 	test('getAssessmentScoreForModel returns highest score', () => {
-		jest.spyOn(AssessmentUtil, 'getHighestAttemptsForModelByAssessmentScore')
-		AssessmentUtil.getHighestAttemptsForModelByAssessmentScore.mockReturnValueOnce([
-			{ assessmentScore: 'mockScore' }
-		])
+		const state = {
+			assessmentSummary: [{ scores: [null, 99, 88] }]
+		}
 
-		const score = AssessmentUtil.getAssessmentScoreForModel()
+		const score = AssessmentUtil.getAssessmentScoreForModel(state)
 
-		expect(score).toEqual('mockScore')
+		expect(score).toEqual(99)
+	})
+
+	test('getAssessmentScoreForModel returns null if the highest score is null', () => {
+		const state = {
+			assessmentSummary: [{ scores: [null, null, null] }]
+		}
+
+		const score = AssessmentUtil.getAssessmentScoreForModel(state)
+
+		expect(score).toEqual(null)
 	})
 
 	test('getLastAttemptScoresForModel returns null with no assessment', () => {

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/util/assessment-util.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/util/assessment-util.js
@@ -57,17 +57,20 @@ const AssessmentUtil = {
 		return assessment.highestAttemptScoreAttempts
 	},
 
-	getAssessmentScoreForModel(state, model) {
-		const highestAttemptsByAssessmentScore = AssessmentUtil.getHighestAttemptsForModelByAssessmentScore(
-			state,
-			model
-		)
-
-		if (highestAttemptsByAssessmentScore.length === 0) {
+	getAssessmentScoreForModel(state /*, model*/) {
+		// currently assuming there's only one assessment per module!
+		if (
+			!state.assessmentSummary ||
+			!state.assessmentSummary[0] ||
+			!state.assessmentSummary[0].scores
+		) {
 			return null
 		}
 
-		return highestAttemptsByAssessmentScore[0].assessmentScore
+		const scores = state.assessmentSummary[0].scores.map(s => (s === null ? -1 : s))
+		const max = Math.max.apply(null, scores)
+
+		return max === -1 ? null : max
 	},
 
 	getLastAttemptScoresForModel(state, model) {


### PR DESCRIPTION
Fixes #1559 