### PR TITLE
empty title error disappears on save

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/navigation/more-info-box.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/navigation/more-info-box.test.js
@@ -741,4 +741,31 @@ describe('MoreInfoBox', () => {
 		})(mockProps)
 		expect(mockSetState).toHaveBeenCalledWith({ content: 'newMockValue' })
 	})
+
+	test('onSave sets and clears state.error', () => {
+		const component = mount(
+			<MoreInfoBox
+				id="mock-id"
+				content={{}}
+				saveId={jest
+					.fn()
+					.mockReturnValueOnce('error!')
+					.mockReturnValueOnce(null)}
+				saveContent={jest.fn().mockReturnValue(null)}
+				markUnsaved={jest.fn()}
+				contentDescription={[]}
+				isAssessment
+			/>
+		)
+
+		// saveId() will return an error, make sure its on state
+		component.instance().onSave()
+		const aftState = component.state()
+		expect(aftState).toHaveProperty('error', 'error!')
+
+		// saveId() returns null this time, make sure state gets updated
+		component.instance().onSave()
+		const aftState2 = component.state()
+		expect(aftState2).toHaveProperty('error', null)
+	})
 })

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/more-info-box.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/more-info-box.js
@@ -140,7 +140,6 @@ class MoreInfoBox extends React.Component {
 			this.props.saveContent(this.props.content, this.state.content) ||
 			this.props.saveId(this.props.id, this.state.currentId)
 		if (!error) {
-			// Wrapping these methods in a Timeout prevents a race condition with editor updates
 			this.setState({ error })
 			this.props.markUnsaved()
 			this.close()

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/more-info-box.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/more-info-box.js
@@ -141,6 +141,7 @@ class MoreInfoBox extends React.Component {
 			this.props.saveId(this.props.id, this.state.currentId)
 		if (!error) {
 			// Wrapping these methods in a Timeout prevents a race condition with editor updates
+			this.setState({ error })
 			this.props.markUnsaved()
 			this.close()
 			return


### PR DESCRIPTION
Resolves #1547 

Updates the state when saving, so the error now disappears once a non-empty title has been entered.