### PR TITLE
Ensures that the renaming of pages and modules work again

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/stores/editor-store.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/stores/editor-store.test.js
@@ -481,7 +481,7 @@ describe('EditorStore', () => {
 		expect(EditorUtil.goto).toHaveBeenCalled()
 	})
 
-	test('renamePageOrModule rebuilds menu', () => {
+	test('renamePageOrModule updates a page title and rebuilds menu', () => {
 		jest.spyOn(Common.models.OboModel, 'getRoot')
 		jest.spyOn(EditorStore, 'triggerChange')
 		EditorStore.triggerChange.mockReturnValueOnce(true)
@@ -499,6 +499,7 @@ describe('EditorStore', () => {
 		EditorStore.renamePageOrModule('mockId', 'mockTitle')
 
 		expect(mockSet).toHaveBeenCalledWith('content', { title: 'mockTitle', value: 'other-value' })
+		expect(Common.models.OboModel.models['mockId'].title).toBe('mockTitle')
 		expect(EditorUtil.rebuildMenu).toHaveBeenCalled()
 		expect(EditorStore.triggerChange).toHaveBeenCalled()
 	})

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/stores/editor-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/stores/editor-store.js
@@ -231,7 +231,12 @@ class EditorStore extends Store {
 		const pageOrModule = OboModel.models[nodeId]
 		const content = pageOrModule.get('content')
 
+		// clone content object and replace the title
 		pageOrModule.set('content', { ...content, title: newName })
+		// Module has title implemented on the object itself instead of inside content
+		// The other types don't, but due to confusion between the two,
+		// the code across obojobo has started to expect it.
+		// This makes sure module and page titles change in the editor right away.
 		pageOrModule.title = newName
 
 		EditorUtil.rebuildMenu(OboModel.getRoot())

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/stores/editor-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/stores/editor-store.js
@@ -230,7 +230,9 @@ class EditorStore extends Store {
 	renamePageOrModule(nodeId, newName) {
 		const pageOrModule = OboModel.models[nodeId]
 		const content = pageOrModule.get('content')
+
 		pageOrModule.set('content', { ...content, title: newName })
+		pageOrModule.title = newName
 
 		EditorUtil.rebuildMenu(OboModel.getRoot())
 		this.triggerChange()


### PR DESCRIPTION
Resolves #1560 

Different places of the editor try to determine the title in different places. Sometimes that's `oboModel.title`, sometime that's `oboModel.get('content').title`. That's a DRY violation, but this PR doesn't attempt to fix that bigger issue, it's a patch for now. I think we can tackle the code duplication when we do a refactor pass to strengthen the enforcement/validation/scrubbing of the node data models.