### PR TITLE
Cleaned up intersection observer when the component unmounts

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/Viewer/components/viewer-app.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/components/viewer-app.test.js
@@ -727,7 +727,7 @@ describe('ViewerApp', () => {
 		expect(window.IntersectionObserver).toHaveBeenCalledWith(thisValue.onIntersectionChange, {
 			root: null,
 			rootMargin: '0px',
-			threshhold: 0
+			threshold: 0
 		})
 		expect(thisValue.observer.observe).toHaveBeenCalledWith(
 			FocusUtil.getVisuallyFocussedModel().getDomEl()

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -170,6 +170,9 @@ export default class ViewerApp extends React.Component {
 	componentWillUnmount() {
 		this.unRegisterStores()
 		document.removeEventListener('visibilitychange', this.onVisibilityChange)
+
+		// Removing the intersection observer.
+		this.stopObservingForIntersectionChanges();
 	}
 
 	shouldComponentUpdate(nextProps, nextState) {
@@ -387,6 +390,8 @@ export default class ViewerApp extends React.Component {
 		this.stopObservingForIntersectionChanges()
 		const focusState = this.state.focusState
 
+		// Only creates an Intersection Observer object when the 'visualFocusTarget'
+		// property of 'focusState' is set.
 		if (!focusState.visualFocusTarget) {
 			return
 		}
@@ -401,6 +406,8 @@ export default class ViewerApp extends React.Component {
 			return
 		}
 
+		// If an intersection observer is created below, we're 100% sure that
+		// 'focusState.visualFocusTarget' is set.
 		this.observer = new IntersectionObserver(this.onIntersectionChange, {
 			root: null,
 			rootMargin: '0px',

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -172,7 +172,7 @@ export default class ViewerApp extends React.Component {
 		document.removeEventListener('visibilitychange', this.onVisibilityChange)
 
 		// Removing the intersection observer.
-		this.stopObservingForIntersectionChanges();
+		this.stopObservingForIntersectionChanges()
 	}
 
 	shouldComponentUpdate(nextProps, nextState) {
@@ -391,7 +391,9 @@ export default class ViewerApp extends React.Component {
 		const focusState = this.state.focusState
 
 		// Only creates an Intersection Observer object when the 'visualFocusTarget'
-		// property of 'focusState' is set.
+		// property of 'focusState' is set - this is when all of the elements of the
+		// page are faded except for the visualFocusTarget (for example, when answering
+		// a practice question)
 		if (!focusState.visualFocusTarget) {
 			return
 		}
@@ -411,7 +413,7 @@ export default class ViewerApp extends React.Component {
 		this.observer = new IntersectionObserver(this.onIntersectionChange, {
 			root: null,
 			rootMargin: '0px',
-			threshhold: 0
+			threshold: 0
 		})
 
 		this.observer.observe(el)


### PR DESCRIPTION
Cleaned up the intersection observer at the viewer app when it unmounts and added the requested comments to avoid future confusion.
Fixes #1552 