### PR TITLE
Converts text to a list if list-like formatting is detected

### DIFF
--- a/packages/obonode/obojobo-chunks-list/list-detector.js
+++ b/packages/obonode/obojobo-chunks-list/list-detector.js
@@ -1,8 +1,8 @@
 import ListStyles from './list-styles'
 
 const regexes = {
-	bulletListItem: /^[ \t]*(\*)[ \t]+([\s\S]*)/, // Interpert text such as ' * list item' as a bullet in a list
-	numericListItem: /^[ \t]*([0-9]+|[A-Za-z]|VIII|VII|VI|IV|IX|III|II|viii|vii|vi|iv|ix|iii|ii)\.[ \t]+$/, // Interpret text such as ' 1. list item' as a bullet in a list
+	bulletListItem: /^[ \t]*(\*)/, // Interpert text such as ' * list item' as a bullet in a list
+	numericListItem: /^[ \t]*([0-9]+|[A-Za-z]|VIII|VII|VI|IV|IX|III|II|viii|vii|vi|iv|ix|iii|ii)\.+$/, // Interpret text such as ' 1. list item' as a bullet in a list
 
 	symbolUpperRoman: /VIII|VII|VI|IV|IX|V|III|II|I/,
 	symbolLowerRoman: /viii|vii|vi|iv|ix|v|iii|ii|i/,
@@ -15,7 +15,7 @@ const regexes = {
 const looksLikeListItem = function(s) {
 	let result = false
 
-	if (s.length === 2) {
+	if (s.length === 1) {
 		if (replace(s, 'bulletListItem')) {
 			result = {
 				type: ListStyles.TYPE_UNORDERED,
@@ -25,7 +25,7 @@ const looksLikeListItem = function(s) {
 				symbolStyle: ''
 			}
 		}
-	} else if (s.length >= 3) {
+	} else if (s.length >= 2) {
 		const numericList = replace(s, 'numericListItem')
 		if (numericList) {
 			const symbolStyle = getSymbolStyle(numericList.symbol)

--- a/packages/obonode/obojobo-chunks-list/list-detector.test.js
+++ b/packages/obonode/obojobo-chunks-list/list-detector.test.js
@@ -5,12 +5,10 @@ describe('List Detector', () => {
 		expect(looksLikeListItem('')).toBe(false)
 		expect(looksLikeListItem(' ')).toBe(false)
 		expect(looksLikeListItem('  ')).toBe(false)
-		expect(looksLikeListItem('*')).toBe(false)
 		expect(looksLikeListItem('*Text')).toBe(false)
 		expect(looksLikeListItem('* Text')).toBe(false)
 		expect(looksLikeListItem('1')).toBe(false)
 		expect(looksLikeListItem('1Text')).toBe(false)
-		expect(looksLikeListItem('1.')).toBe(false)
 		expect(looksLikeListItem('1.Text')).toBe(false)
 		expect(looksLikeListItem('1. Text')).toBe(false)
 		expect(looksLikeListItem('1 ')).toBe(false)
@@ -18,7 +16,7 @@ describe('List Detector', () => {
 	})
 
 	test('looksLikeListItem returns details about a text-representation of an unordered list', () => {
-		expect(looksLikeListItem('* ')).toEqual({
+		expect(looksLikeListItem('*')).toEqual({
 			type: 'unordered',
 			symbol: '*',
 			symbolIndex: 1,
@@ -28,7 +26,7 @@ describe('List Detector', () => {
 	})
 
 	test('looksLikeListItem returns details about a text-representation of an ordered list - Number', () => {
-		expect(looksLikeListItem('1. ')).toEqual({
+		expect(looksLikeListItem('1.')).toEqual({
 			type: 'ordered',
 			symbol: '1',
 			symbolIndex: 1,
@@ -36,7 +34,7 @@ describe('List Detector', () => {
 			symbolStyle: 'decimal'
 		})
 
-		expect(looksLikeListItem('01. ')).toEqual({
+		expect(looksLikeListItem('01.')).toEqual({
 			type: 'ordered',
 			symbol: '01',
 			symbolIndex: 1,
@@ -44,7 +42,7 @@ describe('List Detector', () => {
 			symbolStyle: 'decimal-leading-zero'
 		})
 
-		expect(looksLikeListItem('2. ')).toEqual({
+		expect(looksLikeListItem('2.')).toEqual({
 			type: 'ordered',
 			symbol: '2',
 			symbolIndex: 2,
@@ -54,7 +52,7 @@ describe('List Detector', () => {
 	})
 
 	test('looksLikeListItem returns details about a text-representation of an ordered list - Letter', () => {
-		expect(looksLikeListItem('a. ')).toEqual({
+		expect(looksLikeListItem('a.')).toEqual({
 			type: 'ordered',
 			symbol: 'a',
 			symbolIndex: 1,
@@ -62,7 +60,7 @@ describe('List Detector', () => {
 			symbolStyle: 'lower-alpha'
 		})
 
-		expect(looksLikeListItem('B. ')).toEqual({
+		expect(looksLikeListItem('B.')).toEqual({
 			type: 'ordered',
 			symbol: 'B',
 			symbolIndex: 2,
@@ -72,7 +70,7 @@ describe('List Detector', () => {
 	})
 
 	test('looksLikeListItem returns details about a text-representation of an ordered list - Roman', () => {
-		expect(looksLikeListItem('i. ')).toEqual({
+		expect(looksLikeListItem('i.')).toEqual({
 			type: 'ordered',
 			symbol: 'i',
 			symbolIndex: 1,
@@ -80,7 +78,7 @@ describe('List Detector', () => {
 			symbolStyle: 'lower-roman'
 		})
 
-		expect(looksLikeListItem('II. ')).toEqual({
+		expect(looksLikeListItem('II.')).toEqual({
 			type: 'ordered',
 			symbol: 'II',
 			symbolIndex: 2,
@@ -88,7 +86,7 @@ describe('List Detector', () => {
 			symbolStyle: 'upper-roman'
 		})
 
-		expect(looksLikeListItem('iii. ')).toEqual({
+		expect(looksLikeListItem('iii.')).toEqual({
 			type: 'ordered',
 			symbol: 'iii',
 			symbolIndex: 3,
@@ -96,7 +94,7 @@ describe('List Detector', () => {
 			symbolStyle: 'lower-roman'
 		})
 
-		expect(looksLikeListItem('IV. ')).toEqual({
+		expect(looksLikeListItem('IV.')).toEqual({
 			type: 'ordered',
 			symbol: 'IV',
 			symbolIndex: 4,
@@ -104,7 +102,7 @@ describe('List Detector', () => {
 			symbolStyle: 'upper-roman'
 		})
 
-		expect(looksLikeListItem('v. ')).toEqual({
+		expect(looksLikeListItem('v.')).toEqual({
 			type: 'ordered',
 			symbol: 'v',
 			symbolIndex: 5,
@@ -112,7 +110,7 @@ describe('List Detector', () => {
 			symbolStyle: 'lower-roman'
 		})
 
-		expect(looksLikeListItem('VI. ')).toEqual({
+		expect(looksLikeListItem('VI.')).toEqual({
 			type: 'ordered',
 			symbol: 'VI',
 			symbolIndex: 6,
@@ -120,7 +118,7 @@ describe('List Detector', () => {
 			symbolStyle: 'upper-roman'
 		})
 
-		expect(looksLikeListItem('vii. ')).toEqual({
+		expect(looksLikeListItem('vii.')).toEqual({
 			type: 'ordered',
 			symbol: 'vii',
 			symbolIndex: 7,
@@ -128,7 +126,7 @@ describe('List Detector', () => {
 			symbolStyle: 'lower-roman'
 		})
 
-		expect(looksLikeListItem('VIII. ')).toEqual({
+		expect(looksLikeListItem('VIII.')).toEqual({
 			type: 'ordered',
 			symbol: 'VIII',
 			symbolIndex: 8,
@@ -136,7 +134,7 @@ describe('List Detector', () => {
 			symbolStyle: 'upper-roman'
 		})
 
-		expect(looksLikeListItem('ix. ')).toEqual({
+		expect(looksLikeListItem('ix.')).toEqual({
 			type: 'ordered',
 			symbol: 'ix',
 			symbolIndex: 9,

--- a/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
+++ b/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
@@ -1,0 +1,65 @@
+import { Editor, Range, Transforms } from 'slate'
+
+import looksLikeListItem from '../../obojobo-chunks-list/list-detector'
+
+const LIST_NODE = 'ObojoboDraft.Chunks.List'
+const LIST_LINE_NODE = 'ObojoboDraft.Chunks.List.Line'
+
+const convertIfList = function(entry, editor, event) {
+	const [node, nodePath] = entry
+	const nodeRange = Editor.range(editor, nodePath)
+	const cursor = editor.selection
+	const cursorOffset = cursor.anchor.offset
+	const nodeIdx = cursor.anchor.path[1]
+	const nodeStr = node.children[nodeIdx].children[0].text
+	const listPrefix = nodeStr.substring(0, cursorOffset)
+
+	const isList = looksLikeListItem(listPrefix)
+
+	if (isList !== false) {
+		const toEndOfLine = {
+			anchor: cursor.anchor,
+			focus: { ...cursor.anchor, offset: nodeStr.length }
+		}
+
+		const toStartOfLine = {
+			anchor: cursor.anchor,
+			focus: { ...cursor.anchor, offset: 0 }
+		}
+
+		event.preventDefault()
+
+		// Delete any text after the cursor to prevent duplicated content
+		Transforms.delete(editor, { at: Range.intersection(nodeRange, toEndOfLine) })
+
+		Transforms.insertNodes(
+			editor,
+			{
+				type: LIST_NODE,
+				content: { listStyles: { type: isList.type } },
+				children: [
+					{
+						type: LIST_NODE,
+						subtype: LIST_LINE_NODE,
+						content: {},
+						children: [{ text: nodeStr.substring(cursorOffset) }]
+					}
+				]
+			},
+			{
+				at: cursor,
+				select: true
+			}
+		)
+
+		// Remove the list prefix from the original text node
+		Transforms.removeNodes(editor, { at: Range.intersection(nodeRange, toStartOfLine) })
+
+		// Remove original text node if it has no other content in it
+		if (node.children.length === 1) {
+			Transforms.removeNodes(editor, { at: nodePath })
+		}
+	}
+}
+
+export default convertIfList

--- a/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
+++ b/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
@@ -30,7 +30,9 @@ const convertIfList = function(entry, editor, event) {
 		event.preventDefault()
 
 		// Delete any text after the cursor to prevent duplicated content
-		Transforms.delete(editor, { at: Range.intersection(nodeRange, toEndOfLine) })
+		if (nodeStr.length > cursorOffset) {
+			Transforms.delete(editor, { at: Range.intersection(nodeRange, toEndOfLine) })
+		}
 
 		Transforms.insertNodes(
 			editor,

--- a/packages/obonode/obojobo-chunks-text/changes/convert-if-list.test.js
+++ b/packages/obonode/obojobo-chunks-text/changes/convert-if-list.test.js
@@ -155,8 +155,8 @@ describe('Convert Text to List', () => {
 				}
 			],
 			selection: {
-				anchor: { path: [0, 0, 0], offset: 2 },
-				focus: { path: [0, 0, 0], offset: 2 }
+				anchor: { path: [0, 0, 0], offset: 1 },
+				focus: { path: [0, 0, 0], offset: 1 }
 			},
 			isInline: () => false,
 			isVoid: () => false,
@@ -173,5 +173,46 @@ describe('Convert Text to List', () => {
 
 		const removedNode = Transforms.removeNodes.mock.calls[1][1].at
 		expect(removedNode).toEqual([0])
+	})
+
+	test('convertIfList does not call Transforms.delete if no text after cursor', () => {
+		jest.spyOn(Transforms, 'delete').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'insertNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'removeNodes').mockReturnValue(true)
+		ReactEditor.findPath.mockReturnValueOnce([0])
+		looksLikeListItem.mockReturnValueOnce({ type: 'mockType' })
+
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: TEXT_NODE,
+					content: {},
+					children: [
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: {},
+							children: [{ text: '*' }]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0, 0], offset: 1 },
+				focus: { path: [0, 0, 0], offset: 1 }
+			},
+			isInline: () => false,
+			isVoid: () => false,
+			apply: jest.fn()
+		}
+		const event = { preventDefault: jest.fn() }
+
+		convertIfList([editor.children[0], [0]], editor, event)
+
+		expect(looksLikeListItem).toHaveBeenCalled()
+		expect(Transforms.delete).not.toHaveBeenCalled()
+		expect(Transforms.insertNodes).toHaveBeenCalled()
+		expect(Transforms.removeNodes).toHaveBeenCalledTimes(2)
 	})
 })

--- a/packages/obonode/obojobo-chunks-text/changes/convert-if-list.test.js
+++ b/packages/obonode/obojobo-chunks-text/changes/convert-if-list.test.js
@@ -1,0 +1,177 @@
+import { Transforms } from 'slate'
+import { ReactEditor } from 'slate-react'
+jest.mock('slate-react')
+
+import convertIfList from './convert-if-list'
+import looksLikeListItem from '../../obojobo-chunks-list/list-detector'
+jest.mock('../../obojobo-chunks-list/list-detector')
+
+const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
+const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
+const LIST_NODE = 'ObojoboDraft.Chunks.List'
+
+describe('Convert Text to List', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	test('convertIfList ignores regular text', () => {
+		jest.spyOn(Transforms, 'delete').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'insertNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'removeNodes').mockReturnValue(true)
+		ReactEditor.findPath.mockReturnValueOnce([0])
+		looksLikeListItem.mockReturnValueOnce(false)
+
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: TEXT_NODE,
+					content: {},
+					children: [
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: {},
+							children: [{ text: 'mockText' }]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0, 0], offset: 0 },
+				focus: { path: [0, 0, 0], offset: 8 }
+			},
+			isInline: () => false,
+			isVoid: () => false,
+			apply: jest.fn()
+		}
+		const event = { preventDefault: jest.fn() }
+
+		convertIfList([editor.children[0], [0]], editor, event)
+
+		expect(looksLikeListItem).toHaveBeenCalled()
+		expect(Transforms.delete).not.toHaveBeenCalled()
+		expect(Transforms.insertNodes).not.toHaveBeenCalled()
+		expect(Transforms.removeNodes).not.toHaveBeenCalled()
+	})
+
+	test('convertIfList inserts a List node with correct text', () => {
+		jest.spyOn(Transforms, 'delete').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'insertNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'removeNodes').mockReturnValue(true)
+		ReactEditor.findPath.mockReturnValueOnce([0])
+		looksLikeListItem.mockReturnValueOnce({ type: 'mockType' })
+
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: TEXT_NODE,
+					content: {},
+					children: [
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: {},
+							children: [{ text: 'mockText' }]
+						},
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: {},
+							children: [{ text: '*mockText' }]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 1, 0], offset: 1 },
+				focus: { path: [0, 1, 0], offset: 1 }
+			},
+			isInline: () => false,
+			isVoid: () => false,
+			apply: jest.fn()
+		}
+		const event = { preventDefault: jest.fn() }
+
+		convertIfList([editor.children[0], [0]], editor, event)
+
+		expect(looksLikeListItem).toHaveBeenCalled()
+		expect(Transforms.delete).toHaveBeenCalled()
+		expect(Transforms.insertNodes).toHaveBeenCalled()
+		expect(Transforms.removeNodes).toHaveBeenCalledTimes(1)
+
+		const deletedRange = Transforms.delete.mock.calls[0][1].at
+		expect(deletedRange).toEqual({
+			anchor: {
+				path: [0, 1, 0],
+				offset: 1
+			},
+			focus: {
+				path: [0, 1, 0],
+				offset: 9
+			}
+		})
+
+		const insertedNode = Transforms.insertNodes.mock.calls[0][1]
+		expect(insertedNode.type).toBe(LIST_NODE)
+		expect(insertedNode.children[0].children[0].text).toBe('mockText')
+
+		const removedRange = Transforms.removeNodes.mock.calls[0][1].at
+		expect(removedRange).toEqual({
+			anchor: {
+				path: [0, 1, 0],
+				offset: 0
+			},
+			focus: {
+				path: [0, 1, 0],
+				offset: 1
+			}
+		})
+	})
+
+	test('convertIfList removes text node if only one child', () => {
+		jest.spyOn(Transforms, 'delete').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'insertNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'removeNodes').mockReturnValue(true)
+		ReactEditor.findPath.mockReturnValueOnce([0])
+		looksLikeListItem.mockReturnValueOnce({ type: 'mockType' })
+
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: TEXT_NODE,
+					content: {},
+					children: [
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: {},
+							children: [{ text: '*mockText' }]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0, 0], offset: 2 },
+				focus: { path: [0, 0, 0], offset: 2 }
+			},
+			isInline: () => false,
+			isVoid: () => false,
+			apply: jest.fn()
+		}
+		const event = { preventDefault: jest.fn() }
+
+		convertIfList([editor.children[0], [0]], editor, event)
+
+		expect(looksLikeListItem).toHaveBeenCalled()
+		expect(Transforms.delete).toHaveBeenCalled()
+		expect(Transforms.insertNodes).toHaveBeenCalled()
+		expect(Transforms.removeNodes).toHaveBeenCalledTimes(2)
+
+		const removedNode = Transforms.removeNodes.mock.calls[1][1].at
+		expect(removedNode).toEqual([0])
+	})
+})

--- a/packages/obonode/obojobo-chunks-text/editor-registration.js
+++ b/packages/obonode/obojobo-chunks-text/editor-registration.js
@@ -14,6 +14,7 @@ import increaseIndent from './changes/increase-indent'
 import indentOrTab from './changes/indent-or-tab'
 import toggleHangingIndent from './changes/toggle-hanging-indent'
 import splitParent from './changes/split-parent'
+import convertIfList from './changes/convert-if-list'
 
 const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
 const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
@@ -77,6 +78,9 @@ const plugins = {
 
 				// TAB
 				return indentOrTab(entry, editor, event)
+
+			case ' ':
+				return convertIfList(entry, editor, event)
 
 			case 'h':
 				if (event.ctrlKey || event.metaKey) return toggleHangingIndent(entry, editor, event)

--- a/packages/obonode/obojobo-chunks-text/editor-registration.test.js
+++ b/packages/obonode/obojobo-chunks-text/editor-registration.test.js
@@ -7,6 +7,7 @@ jest.mock('./changes/indent-or-tab')
 jest.mock('./changes/decrease-indent')
 jest.mock('./changes/split-parent')
 jest.mock('./changes/toggle-hanging-indent')
+jest.mock('./changes/convert-if-list')
 
 import { Editor, Transforms, Element, Node } from 'slate'
 import KeyDownUtil from 'obojobo-document-engine/src/scripts/oboeditor/util/keydown-util'
@@ -14,6 +15,7 @@ import decreaseIndent from './changes/decrease-indent'
 import increaseIndent from './changes/increase-indent'
 import indentOrTab from './changes/indent-or-tab'
 import splitParent from './changes/split-parent'
+import convertIfList from './changes/convert-if-list'
 
 import toggleHangingIndent from './changes/toggle-hanging-indent'
 import Text from './editor-registration'
@@ -158,6 +160,39 @@ describe('Text editor', () => {
 		Text.plugins.onKeyDown([{}, [0]], editor, event)
 
 		expect(indentOrTab).toHaveBeenCalled()
+	})
+
+	test('plugins.onKeyDown deals with [Space]', () => {
+		const event = {
+			key: ' ',
+			preventDefault: jest.fn()
+		}
+
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: TEXT_NODE,
+					content: {},
+					children: [
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: { indent: 1 },
+							children: [{ text: 'mockText', b: true }]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0, 0], offset: 0 },
+				focus: { path: [0, 0, 0], offset: 8 }
+			}
+		}
+
+		Text.plugins.onKeyDown([editor.children[0], [0]], editor, event)
+
+		expect(convertIfList).toHaveBeenCalled()
 	})
 
 	test('plugins.onKeyDown ignores [h]', () => {


### PR DESCRIPTION
Resolves #1281 

Hitting space after typing `*`, `1.`, or anything else list-like will cause the current line of text to be converted to a list. Any text that is on the same line will be copied into the list as well.