### PR TITLE
Dangling line in nav menu

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/nav.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/nav.scss
@@ -244,6 +244,8 @@
 		}
 
 		&.is-last-in-list {
+			border: none;
+
 			&::before {
 				content: '';
 				position: absolute;


### PR DESCRIPTION
Resolves #270 

Removes the border from the last item in the menu list, getting rid of the dangling line when there's no assessment.