### PR TITLE
includes config files in obojobo-lib-utils npm package

### DIFF
--- a/packages/util/obojobo-lib-utils/.npmignore
+++ b/packages/util/obojobo-lib-utils/.npmignore
@@ -6,13 +6,6 @@ yarn-error.log
 __mocks__
 __tests__
 .vscode
-.eslintignore
-.eslintrc
-.prettierignore
-.stylelintignore
-.stylelintrc
-.scss-lint.yml
-prettier.config.js
 Dockerfile
 __snapshots__
 *.test.js


### PR DESCRIPTION
Makes sure some of the config files centralized in obojobo-lib-utils package are published to the npm package so they can be reused easily elsewhere.