### PR TITLE
Clearer message for assessment ID error

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/Viewer/stores/assessment-store.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/stores/assessment-store.test.js
@@ -309,6 +309,24 @@ describe('AssessmentStore', () => {
 		)
 	})
 
+	test('startAttemptWithAPICall shows an error if the assessment ID is invalid', () => {
+		OboModel.create(getExampleAssessment())
+
+		AssessmentAPI.startAttempt.mockResolvedValueOnce({
+			status: 'error',
+			value: {
+				message: 'Invalid ID'
+			}
+		})
+
+		return AssessmentStore.startAttemptWithAPICall('draftId', 'visitId', 'assessmentId').then(
+			() => {
+				expect(ErrorUtil.show).toHaveBeenCalledTimes(1)
+				expect(AssessmentStore.triggerChange).toHaveBeenCalledTimes(1)
+			}
+		)
+	})
+
 	test('startAttemptWithAPICall shows a generic error if an unrecognized error is thrown and triggers a change', () => {
 		OboModel.create(getExampleAssessment())
 

--- a/packages/app/obojobo-document-engine/__tests__/Viewer/stores/assessment-store.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/stores/assessment-store.test.js
@@ -315,7 +315,7 @@ describe('AssessmentStore', () => {
 		AssessmentAPI.startAttempt.mockResolvedValueOnce({
 			status: 'error',
 			value: {
-				message: 'Invalid ID'
+				message: 'ID not found'
 			}
 		})
 

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store.js
@@ -265,7 +265,7 @@ class AssessmentStore extends Store {
 							'You have attempted this assessment the maximum number of times available.'
 						)
 						break
-					case 'invalid id':
+					case 'id not found':
 						ErrorUtil.show(
 							'Assessment ID not found',
 							`Couldn't find an assessment with ID "${assessmentId}".`

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store.js
@@ -265,7 +265,12 @@ class AssessmentStore extends Store {
 							'You have attempted this assessment the maximum number of times available.'
 						)
 						break
-
+					case 'invalid id':
+						ErrorUtil.show(
+							'Assessment ID not found',
+							`Couldn't find an assessment with ID "${assessmentId}".`
+						)
+						break
 					default:
 						ErrorUtil.errorResponse(res)
 				}

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-start.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-start.js
@@ -10,7 +10,7 @@ const ACTION_ASSESSMENT_SEND_TO_ASSESSMENT = 'ObojoboDraft.Sections.Assessment:s
 const ERROR_ATTEMPT_LIMIT_REACHED = 'Attempt limit reached'
 const ERROR_UNEXPECTED_DB_ERROR = 'Unexpected DB error'
 const ERROR_IMPORT_USED = 'Import score has already been used'
-const ERROR_ASSESSMENT_INVALID_ID = 'Invalid ID'
+const ERROR_ASSESSMENT_ID_NOT_FOUND = 'ID not found'
 
 const startAttempt = (req, res) => {
 	let attemptState
@@ -38,7 +38,7 @@ const startAttempt = (req, res) => {
 			assessmentNode = req.currentDocument.getChildNodeById(req.body.assessmentId)
 
 			if (!assessmentNode) {
-				throw new Error(ERROR_ASSESSMENT_INVALID_ID)
+				throw new Error(ERROR_ASSESSMENT_ID_NOT_FOUND)
 			}
 
 			assessmentProperties.oboNode = assessmentNode
@@ -116,7 +116,7 @@ const startAttempt = (req, res) => {
 			switch (error.message) {
 				case ERROR_ATTEMPT_LIMIT_REACHED:
 				case ERROR_IMPORT_USED:
-				case ERROR_ASSESSMENT_INVALID_ID:
+				case ERROR_ASSESSMENT_ID_NOT_FOUND:
 					return res.reject(error.message)
 
 				default:

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-start.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-start.js
@@ -10,6 +10,7 @@ const ACTION_ASSESSMENT_SEND_TO_ASSESSMENT = 'ObojoboDraft.Sections.Assessment:s
 const ERROR_ATTEMPT_LIMIT_REACHED = 'Attempt limit reached'
 const ERROR_UNEXPECTED_DB_ERROR = 'Unexpected DB error'
 const ERROR_IMPORT_USED = 'Import score has already been used'
+const ERROR_ASSESSMENT_INVALID_ID = 'Invalid ID'
 
 const startAttempt = (req, res) => {
 	let attemptState
@@ -35,6 +36,11 @@ const startAttempt = (req, res) => {
 
 			// @TODO: make sure assessmentID is found
 			assessmentNode = req.currentDocument.getChildNodeById(req.body.assessmentId)
+
+			if (!assessmentNode) {
+				throw new Error(ERROR_ASSESSMENT_INVALID_ID)
+			}
+
 			assessmentProperties.oboNode = assessmentNode
 			assessmentProperties.nodeChildrenIds = assessmentNode.children[1].childrenSet
 			assessmentProperties.questionBank = assessmentNode.children[1]
@@ -110,6 +116,7 @@ const startAttempt = (req, res) => {
 			switch (error.message) {
 				case ERROR_ATTEMPT_LIMIT_REACHED:
 				case ERROR_IMPORT_USED:
+				case ERROR_ASSESSMENT_INVALID_ID:
 					return res.reject(error.message)
 
 				default:

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-start.test.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-start.test.js
@@ -54,7 +54,7 @@ const QUESTION_BANK_NODE_TYPE = 'ObojoboDraft.Chunks.QuestionBank'
 const ERROR_ATTEMPT_LIMIT_REACHED = 'Attempt limit reached'
 const ERROR_UNEXPECTED_DB_ERROR = 'Unexpected DB error'
 const ERROR_IMPORT_USED = 'Import score has already been used'
-const ERROR_ASSESSMENT_INVALID_ID = 'Invalid ID'
+const ERROR_ASSESSMENT_ID_NOT_FOUND = 'ID not found'
 
 describe('start attempt route', () => {
 	let mockDraft
@@ -265,7 +265,7 @@ describe('start attempt route', () => {
 
 		expect.hasAssertions()
 		return startAttempt(mockReq, mockRes).then(() => {
-			expect(mockRes.reject).toHaveBeenCalledWith(ERROR_ASSESSMENT_INVALID_ID)
+			expect(mockRes.reject).toHaveBeenCalledWith(ERROR_ASSESSMENT_ID_NOT_FOUND)
 		})
 	})
 

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-start.test.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-start.test.js
@@ -54,6 +54,7 @@ const QUESTION_BANK_NODE_TYPE = 'ObojoboDraft.Chunks.QuestionBank'
 const ERROR_ATTEMPT_LIMIT_REACHED = 'Attempt limit reached'
 const ERROR_UNEXPECTED_DB_ERROR = 'Unexpected DB error'
 const ERROR_IMPORT_USED = 'Import score has already been used'
+const ERROR_ASSESSMENT_INVALID_ID = 'Invalid ID'
 
 describe('start attempt route', () => {
 	let mockDraft
@@ -245,6 +246,26 @@ describe('start attempt route', () => {
 		expect.hasAssertions()
 		return startAttempt(mockReq, mockRes).then(() => {
 			expect(mockRes.reject).toHaveBeenCalledWith(ERROR_IMPORT_USED)
+		})
+	})
+
+	test('startAttempt rejects with an invalid assessment ID', () => {
+		mockReq = {
+			body: {
+				assessmentId: 'badMockId'
+			},
+			currentVisit: { is_preview: false },
+			currentDocument: {
+				getChildNodeById: jest.fn(() => null)
+			},
+			currentUser: { id: 4 }
+		}
+
+		mockRes = { reject: jest.fn() }
+
+		expect.hasAssertions()
+		return startAttempt(mockReq, mockRes).then(() => {
+			expect(mockRes.reject).toHaveBeenCalledWith(ERROR_ASSESSMENT_INVALID_ID)
 		})
 	})
 


### PR DESCRIPTION
Attempting to start an assessment with a trigger using an assessment ID that couldn't be found now shows an error modal:

<img width="608" alt="Screen Shot 2020-10-26 at 5 15 00 PM" src="https://user-images.githubusercontent.com/7400747/97229722-2ad12f80-17af-11eb-955e-211e2c780709.png">

Fixes #1573 