### PR TITLE
breakToText once again

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/util/keydown-util.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/util/keydown-util.test.js
@@ -1,4 +1,4 @@
-import { Transforms, Point } from 'slate'
+import { Transforms } from 'slate'
 import { ReactEditor } from 'slate-react'
 jest.mock('slate-react')
 
@@ -337,6 +337,7 @@ describe('KeyDown Util', () => {
 		ReactEditor.findPath.mockReturnValueOnce([0])
 
 		const event = {
+			isDefaultPrevented: () => false,
 			preventDefault: jest.fn()
 		}
 
@@ -352,33 +353,15 @@ describe('KeyDown Util', () => {
 		expect(insertedNode.children[0].children[0]).toEqual({ text: '' })
 	})
 
-	test('breakToText skips when multile node are selected', () => {
-		jest.spyOn(Point, 'isBefore').mockReturnValue(false)
-		jest.spyOn(Point, 'equals').mockReturnValue(false)
-
-		const editor = {
-			children: [
-				{
-					type: 'mockNode',
-					children: [{ text: 'some' }]
-				}
-			],
-			selection: {
-				anchor: { path: [0, 0], offset: 4 },
-				focus: { path: [0, 0], offset: 4 }
-			},
-			isInline: () => false,
-			isVoid: () => false
-		}
-		ReactEditor.findPath.mockReturnValueOnce([0])
-
+	test('breakToText skips when default event is prevented', () => {
 		const event = {
+			isDefaultPrevented: () => true,
 			preventDefault: jest.fn()
 		}
 
-		KeyDownUtil.breakToText(event, editor, [editor.children[0], [0]], true)
+		KeyDownUtil.breakToText(event, {})
 
-		expect(event.preventDefault).toHaveBeenCalled()
+		expect(event.preventDefault).not.toHaveBeenCalled()
 		expect(Transforms.insertNodes).not.toHaveBeenCalled()
 	})
 })

--- a/packages/obonode/obojobo-chunks-text/changes/split-parent.js
+++ b/packages/obonode/obojobo-chunks-text/changes/split-parent.js
@@ -1,10 +1,34 @@
-import { Transforms } from 'slate'
+import { Editor, Transforms, Range } from 'slate'
+
+const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
 
 const splitParent = (entry, editor, event) => {
-	if (event.isDefaultPrevented()) return
+	if (event.isDefaultPrevented()) {
+		return
+	}
+
+	if (!Range.isCollapsed(editor.selection)) {
+		return
+	}
+
+	const [leaf] = Editor.leaf(editor, editor.selection)
+
+	if (leaf.text !== '') {
+		return
+	}
+
 	event.preventDefault()
 
-	Transforms.splitNodes(editor, { at: editor.selection })
+	const [, nodePath] = entry
+	const nodeRange = Editor.range(editor, nodePath)
+	const [[, linePath]] = Array.from(
+		Editor.nodes(editor, {
+			at: Range.intersection(editor.selection, nodeRange),
+			match: child => child.subtype === TEXT_LINE_NODE
+		})
+	)
+
+	Transforms.splitNodes(editor, { at: linePath, height: 1 })
 }
 
 export default splitParent

--- a/packages/obonode/obojobo-chunks-text/changes/split-parent.js
+++ b/packages/obonode/obojobo-chunks-text/changes/split-parent.js
@@ -1,25 +1,10 @@
-import { Editor, Transforms, Range } from 'slate'
-
-const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
+import { Transforms } from 'slate'
 
 const splitParent = (entry, editor, event) => {
-	const [leaf] = Editor.leaf(editor, editor.selection)
-
-	// If the last node was not empty, continue as normal
-	if (!Range.isCollapsed(editor.selection) || leaf.text !== '') return
-
+	if (event.isDefaultPrevented()) return
 	event.preventDefault()
 
-	const [, nodePath] = entry
-	const nodeRange = Editor.range(editor, nodePath)
-	const [[, linePath]] = Array.from(
-		Editor.nodes(editor, {
-			at: Range.intersection(editor.selection, nodeRange),
-			match: child => child.subtype === TEXT_LINE_NODE
-		})
-	)
-
-	Transforms.splitNodes(editor, { at: linePath, height: 1 })
+	Transforms.splitNodes(editor, { at: editor.selection })
 }
 
 export default splitParent

--- a/packages/obonode/obojobo-chunks-text/changes/split-parent.test.js
+++ b/packages/obonode/obojobo-chunks-text/changes/split-parent.test.js
@@ -1,5 +1,6 @@
 import { Transforms } from 'slate'
-jest.mock('slate')
+import { ReactEditor } from 'slate-react'
+jest.mock('slate-react')
 
 import splitParent from './split-parent'
 
@@ -7,23 +8,42 @@ const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
 const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
 
 describe('Split Text Parent', () => {
-	test('splitParent does nothing if default event is prevented', () => {
+	test('splitParent does nothing if text is not empty', () => {
+		ReactEditor.findPath.mockReturnValueOnce([0])
+
 		const editor = {
-			children: [],
+			children: [
+				{
+					id: 'mockKey',
+					type: TEXT_NODE,
+					content: {},
+					children: [
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: { indent: 1 },
+							children: [{ text: 'mockText', b: true }]
+						}
+					]
+				}
+			],
 			selection: {
 				anchor: { path: [0, 0, 0], offset: 1 },
 				focus: { path: [0, 0, 0], offset: 1 }
 			},
 			isVoid: () => false
 		}
-		const event = { isDefaultPrevented: () => true, preventDefault: jest.fn() }
+		const event = { preventDefault: jest.fn(), isDefaultPrevented: () => false }
 
 		splitParent([editor.children[0], [0]], editor, event)
 
 		expect(event.preventDefault).not.toHaveBeenCalled()
 	})
 
-	test('splitParent calls splitNodes', () => {
+	test('splitParent does nothing if text is not empty', () => {
+		jest.spyOn(Transforms, 'splitNodes').mockReturnValueOnce(true)
+		ReactEditor.findPath.mockReturnValueOnce([0])
+
 		const editor = {
 			children: [
 				{
@@ -46,7 +66,7 @@ describe('Split Text Parent', () => {
 			},
 			isVoid: () => false
 		}
-		const event = { isDefaultPrevented: () => false, preventDefault: jest.fn() }
+		const event = { preventDefault: jest.fn(), isDefaultPrevented: () => false }
 
 		splitParent([editor.children[0], [0]], editor, event)
 

--- a/packages/obonode/obojobo-chunks-text/changes/split-parent.test.js
+++ b/packages/obonode/obojobo-chunks-text/changes/split-parent.test.js
@@ -1,4 +1,4 @@
-import { Transforms } from 'slate'
+import { Transforms, Range } from 'slate'
 import { ReactEditor } from 'slate-react'
 jest.mock('slate-react')
 
@@ -41,7 +41,7 @@ describe('Split Text Parent', () => {
 	})
 
 	test('splitParent does nothing if text is not empty', () => {
-		jest.spyOn(Transforms, 'splitNodes').mockReturnValueOnce(true)
+		const spy = jest.spyOn(Transforms, 'splitNodes').mockReturnValueOnce(true)
 		ReactEditor.findPath.mockReturnValueOnce([0])
 
 		const editor = {
@@ -72,5 +72,81 @@ describe('Split Text Parent', () => {
 
 		expect(event.preventDefault).toHaveBeenCalled()
 		expect(Transforms.splitNodes).toHaveBeenCalled()
+
+		spy.mockRestore()
+	})
+
+	test('splitParent does nothing if event is prevented', () => {
+		const spy = jest.spyOn(Transforms, 'splitNodes').mockReturnValueOnce(true)
+		ReactEditor.findPath.mockReturnValueOnce([0])
+
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: TEXT_NODE,
+					content: {},
+					children: [
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: { indent: 1 },
+							children: [{ text: '', b: true }]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0, 0], offset: 0 },
+				focus: { path: [0, 0, 0], offset: 0 }
+			},
+			isVoid: () => false
+		}
+		const event = { preventDefault: jest.fn(), isDefaultPrevented: () => true }
+
+		splitParent([editor.children[0], [0]], editor, event)
+
+		expect(event.preventDefault).not.toHaveBeenCalled()
+		expect(Transforms.splitNodes).not.toHaveBeenCalled()
+
+		spy.mockRestore()
+	})
+
+	test('splitParent does nothing if the selection is not collapsed', () => {
+		const transSpy = jest.spyOn(Transforms, 'splitNodes').mockReturnValueOnce(true)
+		const rangeSpy = jest.spyOn(Range, 'isCollapsed').mockReturnValueOnce(false)
+		ReactEditor.findPath.mockReturnValueOnce([0])
+
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: TEXT_NODE,
+					content: {},
+					children: [
+						{
+							type: TEXT_NODE,
+							subtype: TEXT_LINE_NODE,
+							content: { indent: 1 },
+							children: [{ text: '', b: true }]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0, 0], offset: 0 },
+				focus: { path: [0, 0, 0], offset: 0 }
+			},
+			isVoid: () => false
+		}
+		const event = { preventDefault: jest.fn(), isDefaultPrevented: () => false }
+
+		splitParent([editor.children[0], [0]], editor, event)
+
+		expect(event.preventDefault).not.toHaveBeenCalled()
+		expect(Transforms.splitNodes).not.toHaveBeenCalled()
+
+		transSpy.mockRestore()
+		rangeSpy.mockRestore()
 	})
 })

--- a/packages/obonode/obojobo-chunks-text/changes/split-parent.test.js
+++ b/packages/obonode/obojobo-chunks-text/changes/split-parent.test.js
@@ -1,6 +1,5 @@
 import { Transforms } from 'slate'
-import { ReactEditor } from 'slate-react'
-jest.mock('slate-react')
+jest.mock('slate')
 
 import splitParent from './split-parent'
 
@@ -8,42 +7,23 @@ const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
 const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
 
 describe('Split Text Parent', () => {
-	test('splitParent does nothing if text is not empty', () => {
-		ReactEditor.findPath.mockReturnValueOnce([0])
-
+	test('splitParent does nothing if default event is prevented', () => {
 		const editor = {
-			children: [
-				{
-					id: 'mockKey',
-					type: TEXT_NODE,
-					content: {},
-					children: [
-						{
-							type: TEXT_NODE,
-							subtype: TEXT_LINE_NODE,
-							content: { indent: 1 },
-							children: [{ text: 'mockText', b: true }]
-						}
-					]
-				}
-			],
+			children: [],
 			selection: {
 				anchor: { path: [0, 0, 0], offset: 1 },
 				focus: { path: [0, 0, 0], offset: 1 }
 			},
 			isVoid: () => false
 		}
-		const event = { preventDefault: jest.fn() }
+		const event = { isDefaultPrevented: () => true, preventDefault: jest.fn() }
 
 		splitParent([editor.children[0], [0]], editor, event)
 
 		expect(event.preventDefault).not.toHaveBeenCalled()
 	})
 
-	test('splitParent does nothing if text is not empty', () => {
-		jest.spyOn(Transforms, 'splitNodes').mockReturnValueOnce(true)
-		ReactEditor.findPath.mockReturnValueOnce([0])
-
+	test('splitParent calls splitNodes', () => {
 		const editor = {
 			children: [
 				{
@@ -66,7 +46,7 @@ describe('Split Text Parent', () => {
 			},
 			isVoid: () => false
 		}
-		const event = { preventDefault: jest.fn() }
+		const event = { isDefaultPrevented: () => false, preventDefault: jest.fn() }
 
 		splitParent([editor.children[0], [0]], editor, event)
 


### PR DESCRIPTION
Fixes #1599, #1597

1599 was due to `splitParent` cannot handle multiple nodes. I also further simplified it, not sure if it causes any issue.