### PR TITLE
Added the option for authors to create lists from different starting indexes

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/visual-editor.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/visual-editor.test.js.snap
@@ -70,7 +70,6 @@ Array [
             "deleteBackward": [Function],
             "deleteForward": [Function],
             "deleteFragment": [Function],
-            "getFragment": [Function],
             "history": Object {
               "redos": Array [],
               "undos": Array [
@@ -147,7 +146,6 @@ Array [
               },
             },
             "setAlign": [Function],
-            "setFragmentData": [Function],
             "toggleEditable": [Function],
             "toggleMark": [Function],
             "toggleScript": [Function],
@@ -169,7 +167,6 @@ Array [
             "deleteBackward": [Function],
             "deleteForward": [Function],
             "deleteFragment": [Function],
-            "getFragment": [Function],
             "history": Object {
               "redos": Array [],
               "undos": Array [
@@ -246,7 +243,6 @@ Array [
               },
             },
             "setAlign": [Function],
-            "setFragmentData": [Function],
             "toggleEditable": [Function],
             "toggleMark": [Function],
             "toggleScript": [Function],
@@ -272,7 +268,6 @@ Array [
             "deleteBackward": [Function],
             "deleteForward": [Function],
             "deleteFragment": [Function],
-            "getFragment": [Function],
             "history": Object {
               "redos": Array [],
               "undos": Array [
@@ -349,7 +344,6 @@ Array [
               },
             },
             "setAlign": [Function],
-            "setFragmentData": [Function],
             "toggleEditable": [Function],
             "toggleMark": [Function],
             "toggleScript": [Function],
@@ -394,7 +388,6 @@ Array [
             "deleteBackward": [Function],
             "deleteForward": [Function],
             "deleteFragment": [Function],
-            "getFragment": [Function],
             "history": Object {
               "redos": Array [],
               "undos": Array [
@@ -471,7 +464,6 @@ Array [
               },
             },
             "setAlign": [Function],
-            "setFragmentData": [Function],
             "toggleEditable": [Function],
             "toggleMark": [Function],
             "toggleScript": [Function],

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/visual-editor.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/visual-editor.test.js.snap
@@ -70,6 +70,7 @@ Array [
             "deleteBackward": [Function],
             "deleteForward": [Function],
             "deleteFragment": [Function],
+            "getFragment": [Function],
             "history": Object {
               "redos": Array [],
               "undos": Array [
@@ -146,6 +147,7 @@ Array [
               },
             },
             "setAlign": [Function],
+            "setFragmentData": [Function],
             "toggleEditable": [Function],
             "toggleMark": [Function],
             "toggleScript": [Function],
@@ -167,6 +169,7 @@ Array [
             "deleteBackward": [Function],
             "deleteForward": [Function],
             "deleteFragment": [Function],
+            "getFragment": [Function],
             "history": Object {
               "redos": Array [],
               "undos": Array [
@@ -243,6 +246,7 @@ Array [
               },
             },
             "setAlign": [Function],
+            "setFragmentData": [Function],
             "toggleEditable": [Function],
             "toggleMark": [Function],
             "toggleScript": [Function],
@@ -268,6 +272,7 @@ Array [
             "deleteBackward": [Function],
             "deleteForward": [Function],
             "deleteFragment": [Function],
+            "getFragment": [Function],
             "history": Object {
               "redos": Array [],
               "undos": Array [
@@ -344,6 +349,7 @@ Array [
               },
             },
             "setAlign": [Function],
+            "setFragmentData": [Function],
             "toggleEditable": [Function],
             "toggleMark": [Function],
             "toggleScript": [Function],
@@ -388,6 +394,7 @@ Array [
             "deleteBackward": [Function],
             "deleteForward": [Function],
             "deleteFragment": [Function],
+            "getFragment": [Function],
             "history": Object {
               "redos": Array [],
               "undos": Array [
@@ -464,6 +471,7 @@ Array [
               },
             },
             "setAlign": [Function],
+            "setFragmentData": [Function],
             "toggleEditable": [Function],
             "toggleMark": [Function],
             "toggleScript": [Function],

--- a/packages/obonode/obojobo-chunks-list/changes/normalize-node.js
+++ b/packages/obonode/obojobo-chunks-list/changes/normalize-node.js
@@ -165,13 +165,18 @@ const normalizeNode = (entry, editor, next) => {
 
 		// create styles for this LIST_LEVEL_NODE
 		const stylesToSet = {}
-		if (node.content.type !== desired.type) stylesToSet.type = desired.type
+		if (node.content.type !== desired.type) {
+			stylesToSet.type = desired.type
+		}
 		if (node.content.bulletStyle !== desired.bulletStyle) {
 			stylesToSet.bulletStyle = desired.bulletStyle
 		}
+		if (desired.start > 1 && node.content.start !== desired.start) {
+			stylesToSet.start = desired.start
+		}
 
 		// only update if needed
-		if (stylesToSet.type || stylesToSet.bulletStyle) {
+		if (stylesToSet.type || stylesToSet.bulletStyle || stylesToSet.start) {
 			Transforms.setNodes(editor, { content: { ...node.content, ...stylesToSet } }, { at: path })
 			return
 		}

--- a/packages/obonode/obojobo-chunks-list/changes/normalize-node.test.js
+++ b/packages/obonode/obojobo-chunks-list/changes/normalize-node.test.js
@@ -584,4 +584,54 @@ describe('Normalize List', () => {
 
 		expect(NormalizeUtil.wrapOrphanedSiblings).toHaveBeenCalled()
 	})
+
+	test('normalizeNode on ListLevel calls Transforms.setNodes with the correct listStyle values', () => {
+		const spy = jest.spyOn(Transforms, 'setNodes').mockReturnValue(jest.fn())
+		const next = jest.fn()
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: LIST_NODE,
+					content: {
+						listStyles: {
+							type: 'ordered',
+							indents: [{ type: 'ordered', start: 9, bulletStyle: 'upper-alpha' }]
+						}
+					},
+					children: [
+						{
+							type: LIST_NODE,
+							subtype: LIST_LEVEL_NODE,
+							content: { type: 'unordered', bulletStyle: 'disc', start: 8 },
+							children: [
+								{
+									type: LIST_NODE,
+									subtype: LIST_LINE_NODE,
+									content: {},
+									children: [{ text: 'mockList', b: true }]
+								}
+							]
+						}
+					]
+				}
+			],
+			isInline: () => false,
+			isVoid: () => false
+		}
+		normalizeNode([editor.children[0].children[0], [0, 0]], editor, next)
+		expect(spy).toHaveBeenCalledWith(
+			editor,
+			{
+				content: {
+					bulletStyle: 'upper-alpha',
+					start: 9,
+					type: 'ordered'
+				}
+			},
+			{ at: [0, 0] }
+		)
+
+		spy.mockRestore()
+	})
 })

--- a/packages/obonode/obojobo-chunks-list/components/level/editor-component.js
+++ b/packages/obonode/obojobo-chunks-list/components/level/editor-component.js
@@ -17,7 +17,11 @@ class Level extends React.Component {
 		if (this.props.element.content.type === 'unordered') {
 			return <ul style={this.getListStyle()}>{this.props.children}</ul>
 		} else {
-			return <ol style={this.getListStyle()}>{this.props.children}</ol>
+			return (
+				<ol style={this.getListStyle()} start={this.props.element.content.start}>
+					{this.props.children}
+				</ol>
+			)
 		}
 	}
 

--- a/packages/obonode/obojobo-chunks-list/editor-registration.js
+++ b/packages/obonode/obojobo-chunks-list/editor-registration.js
@@ -22,7 +22,7 @@ const LIST_LINE_NODE = 'ObojoboDraft.Chunks.List.Line'
 const LIST_LEVEL_NODE = 'ObojoboDraft.Chunks.List.Level'
 
 const plugins = {
-	// Editor Plugins - These get attached to the editor object and override it's default functions
+	// Editor Plugins - These get attached to the editor object and override its default functions
 	// They may affect multiple nodes simultaneously
 	insertData(data, editor, next) {
 		// Insert Slate fragments normally

--- a/packages/obonode/obojobo-chunks-list/empty-node.json
+++ b/packages/obonode/obojobo-chunks-list/empty-node.json
@@ -1,12 +1,17 @@
 {
 	"object": "block",
 	"type": "ObojoboDraft.Chunks.List",
-	"content": { "listStyles": { "type": "unordered" } },
+	"content": {
+		"listStyles": {
+			"type": "unordered",
+			"indents": [{ "type": "unordered", "bulletStyle": "disc" }]
+		}
+	},
 	"children": [
 		{
 			"type": "ObojoboDraft.Chunks.List",
 			"subtype": "ObojoboDraft.Chunks.List.Level",
-			"content": { "type": "unordered", "bulletStyle": "disc" },
+			"content": {},
 			"children": [
 				{
 					"type": "ObojoboDraft.Chunks.List",

--- a/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
+++ b/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
@@ -38,12 +38,23 @@ const convertIfList = function(entry, editor, event) {
 			editor,
 			{
 				type: LIST_NODE,
-				content: { listStyles: { type: isList.type } },
+				content: {
+					listStyles: {
+						type: isList.type,
+						indents: [
+							{
+								start: isList.symbolIndex,
+								type: isList.type,
+								bulletStyle: isList.symbolStyle
+							}
+						]
+					}
+				},
 				children: [
 					{
 						type: LIST_NODE,
 						subtype: LIST_LEVEL_NODE,
-						content: { start: isList.symbolIndex },
+						content: {},
 						children: [{ text: nodeStr.substring(cursorOffset) }]
 					}
 				]

--- a/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
+++ b/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
@@ -3,7 +3,7 @@ import { Editor, Range, Transforms } from 'slate'
 import looksLikeListItem from '../../obojobo-chunks-list/list-detector'
 
 const LIST_NODE = 'ObojoboDraft.Chunks.List'
-const LIST_LINE_NODE = 'ObojoboDraft.Chunks.List.Line'
+const LIST_LEVEL_NODE = 'ObojoboDraft.Chunks.List.Level'
 
 const convertIfList = function(entry, editor, event) {
 	const [node, nodePath] = entry
@@ -42,8 +42,8 @@ const convertIfList = function(entry, editor, event) {
 				children: [
 					{
 						type: LIST_NODE,
-						subtype: LIST_LINE_NODE,
-						content: {},
+						subtype: LIST_LEVEL_NODE,
+						content: { start: isList.symbolIndex },
 						children: [{ text: nodeStr.substring(cursorOffset) }]
 					}
 				]


### PR DESCRIPTION
I added the option for authors to create lists from different starting indexes. So, if you type, for example, 3., 65., or 749., and hit space, the list should be created with the desired index. 

Note that roman numerals will also be translated to an ordered list with the proper number. So, if you type II. and hit enter, the list will be created with a starting index of 2.
Fixes #1596 