### PR TITLE
Fixed misaligned toolbar menus in safari

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/drop-down-menu.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/drop-down-menu.scss
@@ -58,7 +58,7 @@
 		}
 
 		.dropdown {
-			display: inline;
+			display: block;
 			margin: 0;
 			position: relative;
 


### PR DESCRIPTION
The absolute children menus were not playing really well on Safari with a relative inline parent container. I changed the parent container to be a block element and, apparently, everything now works on Safari, Chrome, and Firefox.

Fixes #1513 