### PR TITLE
query timeouts added

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,10 @@
 			"description": "PG-Promise SSL Configuration. https://github.com/vitaly-t/pg-promise/wiki/Connection-Syntax",
 			"value": "{\"rejectUnauthorized\":false}"
 		},
+		"DB_TIMEOUT": {
+			"description": "DB Query timeout in milliseconds https://github.com/brianc/node-postgres/pull/1760",
+			"value": "29000"
+		},
 		"OBO_LTI_KEYS_JSON": {
 			"description": "Edit the secret value. JSON string for LTI key:secret values.",
 			"value": "{\"obo-production-lti-key\":\"CHANGE_THIS_VALUE_NOW\"}"

--- a/packages/app/obojobo-express/server/config/db.json
+++ b/packages/app/obojobo-express/server/config/db.json
@@ -7,7 +7,9 @@
 		"database": "",
 		"port": 5432,
 		"ssl": { "rejectUnauthorized": false },
-		"useBluebird": false
+		"useBluebird": false,
+		"query_timeout": 29000,
+		"statement_timeout": 29000
 	},
 	"test": {
 		"user": "postgres",
@@ -23,7 +25,9 @@
 		"host": "127.0.0.1",
 		"database": "postgres",
 		"ssl": false,
-		"useBluebird": true
+		"useBluebird": true,
+		"query_timeout": 29000,
+		"statement_timeout": 29000
 	},
 	"production":{
 		"user":  {"ENV": "DB_USER"},
@@ -31,6 +35,8 @@
 		"host": {"ENV": "DB_HOST"},
 		"database": {"ENV": "DB_NAME"},
 		"port": {"ENV": "DB_PORT"},
-		"ssl": {"ENV": "DB_SSL_JSON"}
+		"ssl": {"ENV": "DB_SSL_JSON"},
+		"query_timeout": {"ENV": "DB_TIMEOUT"},
+		"statement_timeout": {"ENV": "DB_TIMEOUT"}
 	}
 }

--- a/packages/app/obojobo-express/server/middleware.default.js
+++ b/packages/app/obojobo-express/server/middleware.default.js
@@ -69,7 +69,8 @@ module.exports = app => {
 		res.missing()
 	})
 
-	// unknown error handler
+	// uncaught error handler
+	// you'll want to keep an eye out for 'Query read timeout' in your logs, it may indicate the db has gone away
 	app.use((err, req, res, next) => {
 		logger.error('Unknown error', err)
 		res.unexpected(err)


### PR DESCRIPTION
We had an outage where our AWS RDS database failed over to
its backup server.  Normally one would expect the db driver to lose
connection or at least somehow be aware of the outage.  It wasn't, and just
sat waiting for every db query to resolve.  No errors logged, no automatic
recovery.  The node proccesses needed to be terminated to re-establish
connections.

This commit adds query_timeouts to the configuration for pg-promise to ensure
that they will eventually time out.  We set them just below chromes usual request timeout
to maximize the time before timeout occurs.  This should give us a lot of headroom
for unforseen long-running queries and still produce error logs we can use to indicate
something has gone wrong.

Important: adds a required env var: DB_TIMEOUT, suggested value 29000