### PR TITLE
adds fallback error page when res.unexpected isn't availible

### DIFF
--- a/packages/app/obojobo-express/server/middleware.default.js
+++ b/packages/app/obojobo-express/server/middleware.default.js
@@ -71,7 +71,12 @@ module.exports = app => {
 
 	// unknown error handler
 	app.use((err, req, res, next) => {
-		logger.error('Unknown error', err)
-		res.unexpected(err)
+		const timecode = new Date().getTime()
+		logger.error(`Uncaught error (timecode shown on user error page: ${timecode})`, err)
+		// res.unexpected is not always available here
+		if (res.unexpected) return res.unexpected(err)
+
+		res.status(500)
+		res.send(`500 - Internal Server Error: ${timecode}`)
 	})
 }


### PR DESCRIPTION
At least in development, I keep seeing several cases where express's catch all error handler is getting called and the res.unexpected function is undefined.

This patches that up a little for now - provides a fallback and makes sure the error that originally caused the problem doesn't get lost.  

Also adds a timestamp code to the error in the log and on the user's screen for the purpose of debugging them later.