### PR TITLE
Fixed undefined error for table cells

### DIFF
--- a/packages/obonode/obojobo-chunks-table/editor-registration.js
+++ b/packages/obonode/obojobo-chunks-table/editor-registration.js
@@ -49,11 +49,15 @@ const plugins = {
 			case 'Enter':
 				event.preventDefault()
 				if (Range.isCollapsed(editor.selection)) {
-					// Get current Cell
-					const [[, cellPath]] = Editor.nodes(editor, {
+					// Getting the table object.
+					const [tablePath] = Editor.nodes(editor, {
 						mode: 'lowest',
-						match: nodeMatch => Element.isElement(nodeMatch) && !editor.isInline()
+						match: nodeMatch => Element.isElement(nodeMatch)
 					})
+
+					// Getting the cell in which we last clicked on.
+					const cellPath = tablePath[1]
+
 					// Check if there is a row below this one
 					const siblingPath = Path.next(cellPath.slice(0, -1))
 					if (Node.has(editor, siblingPath)) {


### PR DESCRIPTION
The error was mainly with the `isInline` custom Slate behavior and, I believe, how cell paths were gotten. Because of the nested exceptions, when authors pressed `enter`, their cursors were not even being transferred to the next cell below (if any). Everything seems to be working fine now on Safari, Chrome, and Firefox. Let me know if any changes should be made.

Fixes #1507 