### PR TITLE
Fixed invalid assessment id error

### DIFF
--- a/packages/obonode/obojobo-sections-assessment/server/attempt-start.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-start.js
@@ -10,6 +10,7 @@ const ACTION_ASSESSMENT_SEND_TO_ASSESSMENT = 'ObojoboDraft.Sections.Assessment:s
 const ERROR_ATTEMPT_LIMIT_REACHED = 'Attempt limit reached'
 const ERROR_UNEXPECTED_DB_ERROR = 'Unexpected DB error'
 const ERROR_IMPORT_USED = 'Import score has already been used'
+const ERROR_INVALID_ASSESSMENT_ID = 'This Assessment ID does not exist'
 
 const startAttempt = (req, res) => {
 	let attemptState
@@ -33,8 +34,13 @@ const startAttempt = (req, res) => {
 				resourceLinkId: req.currentVisit.resource_link_id
 			}
 
-			// @TODO: make sure assessmentID is found
 			assessmentNode = req.currentDocument.getChildNodeById(req.body.assessmentId)
+
+			// Making sure an assessmentID is found.
+			if (typeof assessmentNode === 'undefined') {
+				throw new Error(ERROR_INVALID_ASSESSMENT_ID)
+			}
+
 			assessmentProperties.oboNode = assessmentNode
 			assessmentProperties.nodeChildrenIds = assessmentNode.children[1].childrenSet
 			assessmentProperties.questionBank = assessmentNode.children[1]
@@ -110,8 +116,8 @@ const startAttempt = (req, res) => {
 			switch (error.message) {
 				case ERROR_ATTEMPT_LIMIT_REACHED:
 				case ERROR_IMPORT_USED:
+				case ERROR_INVALID_ASSESSMENT_ID:
 					return res.reject(error.message)
-
 				default:
 					logAndRespondToUnexpected(ERROR_UNEXPECTED_DB_ERROR, res, req, error)
 			}

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-start.test.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-start.test.js
@@ -54,6 +54,7 @@ const QUESTION_BANK_NODE_TYPE = 'ObojoboDraft.Chunks.QuestionBank'
 const ERROR_ATTEMPT_LIMIT_REACHED = 'Attempt limit reached'
 const ERROR_UNEXPECTED_DB_ERROR = 'Unexpected DB error'
 const ERROR_IMPORT_USED = 'Import score has already been used'
+const ERROR_INVALID_ASSESSMENT_ID = 'This Assessment ID does not exist'
 
 describe('start attempt route', () => {
 	let mockDraft
@@ -203,6 +204,29 @@ describe('start attempt route', () => {
 		expect.hasAssertions()
 		return startAttempt(mockReq, mockRes).then(() => {
 			expect(mockRes.reject).toHaveBeenCalledWith(ERROR_ATTEMPT_LIMIT_REACHED)
+		})
+	})
+
+	test('startAttempt rejects with an expected error when a given assessment id does not exist', () => {
+		const mockAssessmentNode = {
+			getChildNodeById: jest.fn(() => {})
+		}
+
+		mockReq = {
+			body: {
+				draftId: 'mockDraftId',
+				assessmentId: 'mockInvalidAssessmentId'
+			},
+			currentVisit: { is_preview: false },
+			currentDocument: mockAssessmentNode,
+			currentUser: { id: 4 }
+		}
+
+		mockRes = { reject: jest.fn() }
+
+		expect.hasAssertions()
+		return startAttempt(mockReq, mockRes).then(() => {
+			expect(mockRes.reject).toHaveBeenCalledWith(ERROR_INVALID_ASSESSMENT_ID)
 		})
 	})
 


### PR DESCRIPTION
I thought of a couple different new error messages and I went with: "This assessment id does not exist".

A couple of other message ideas I had:
- _"This assessment id is invalid"_ (I think this is not really helpful since it may confuse authors on what "invalid" really means).
- _"Obojobo could not find this assessment."_

I think it would also be helpful for authors to troubleshoot this kind of error if we could add a small subtext under that message saying something like: _"Did you input a correct assessment id for this button?"_

Also: I will be adding that idea about warning authors about invalid assessment ids on another new issue since it requires a few different changes and implement that there.

Let me know if anything should be changed.
Fixes #1621 