### PR TITLE
Fixes invalid start value crash

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/stores/editor-store.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/stores/editor-store.test.js
@@ -168,11 +168,6 @@ describe('EditorStore', () => {
 		expect(EditorUtil.gotoPath).toHaveBeenCalledWith('startingpath')
 	})
 
-	test('init builds and goes to starting id', () => {
-		EditorStore.init(null, 12, null, 'startingpath', 'visual')
-		expect(EditorUtil.goto).toHaveBeenCalledWith(12)
-	})
-
 	test('init builds and goes to first with no starting id', () => {
 		EditorUtil.getFirst.mockReturnValueOnce({ id: 'mockFirstId' })
 		EditorStore.init(null, null, null, 'startingpath', 'visual')

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/stores/editor-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/stores/editor-store.js
@@ -74,13 +74,8 @@ class EditorStore extends Store {
 		this.buildMenu(model)
 		EditorUtil.gotoPath(startingPath)
 
-		if (startingId != null) {
-			EditorUtil.goto(startingId)
-		} else {
-			const first = EditorUtil.getFirst(this.state)
-
-			if (first && first.id) EditorUtil.goto(first.id)
-		}
+		const first = EditorUtil.getFirst(this.state)
+		if (first && first.id) EditorUtil.goto(first.id)
 	}
 
 	buildMenu(model) {

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/stores/nav-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/stores/nav-store.js
@@ -112,6 +112,8 @@ class NavStore extends Store {
 								to: this.state.itemsById[payload.value.id].id
 							}
 						})
+					} else {
+						this.gotoFirst()
 					}
 				},
 				'nav:lock': () => {
@@ -194,9 +196,7 @@ class NavStore extends Store {
 		if (startingId !== null && typeof startingId !== 'undefined') {
 			NavUtil.goto(startingId)
 		} else {
-			const first = NavUtil.getFirst(this.state)
-
-			if (first && first.id) NavUtil.goto(first.id)
+			this.gotoFirst()
 		}
 	}
 
@@ -205,6 +205,11 @@ class NavStore extends Store {
 		this.state.itemsByPath = {}
 		this.state.itemsByFullPath = {}
 		this.state.items = this.generateNav(model)
+	}
+
+	gotoFirst() {
+		const first = NavUtil.getFirst(this.state)
+		if (first && first.id) NavUtil.goto(first.id)
 	}
 
 	gotoItem(navItem) {


### PR DESCRIPTION
* The editor no longer listens to the starting value, it now always defaults to the first page in the module
* If the starting ID isn't found, the viewer defaults to the first page in the module

Fixes #1577 