### PR TITLE
Fixes viewer crash when loading assessment with katex

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/common/util/inject-katex-if-needed.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/util/inject-katex-if-needed.test.js
@@ -24,6 +24,12 @@ describe('Inject Katex if Needed Util', () => {
 		expect(global.window).not.toHaveProperty('katex')
 	})
 
+	test('skips loading if katex is already defined', async () => {
+		global.window.katex = 'mockObjectWithKatexLoaded'
+		await injectKatexIfNeeded({ value: { text: 'latex' } })
+		expect(global.window.katex).toEqual('mockObjectWithKatexLoaded')
+	})
+
 	test('handles error when katex loading times out', async () => {
 		expect.assertions(2)
 

--- a/packages/app/obojobo-document-engine/src/scripts/common/util/inject-katex-if-needed.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/util/inject-katex-if-needed.js
@@ -7,6 +7,11 @@ const injectKatexIfNeeded = async ({ value: draftModel }) => {
 	// AND in text nodes with a styleList item of type _latex
 	// The second can be matched against `"type":"_latex"` without many false positives
 	// However, the html node's classname will generate more false positives
+
+	if (window.katex) {
+		return draftModel
+	}
+
 	const stringModel = JSON.stringify(draftModel)
 
 	if (stringModel.includes('latex')) {

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store.js
@@ -14,6 +14,7 @@ import findItemsWithMaxPropValue from '../../common/util/find-items-with-max-pro
 import UnfinishedAttemptDialog from 'obojobo-sections-assessment/components/dialogs/unfinished-attempt-dialog'
 import ResultsDialog from 'obojobo-sections-assessment/components/dialogs/results-dialog'
 import PreAttemptImportScoreDialog from 'obojobo-sections-assessment/components/dialogs/pre-attempt-import-score-dialog'
+import injectKatexIfNeeded from 'obojobo-document-engine/src/scripts/common/util/inject-katex-if-needed'
 
 const QUESTION_NODE_TYPE = 'ObojoboDraft.Chunks.Question'
 const ASSESSMENT_NODE_TYPE = 'ObojoboDraft.Sections.Assessment'
@@ -301,7 +302,12 @@ class AssessmentStore extends Store {
 		return await apiCall.call(this, draftId, visitId, assessmentId)
 	}
 
-	updateStateAfterStartAttempt(startAttemptResp) {
+	async updateStateAfterStartAttempt(startAttemptResp) {
+		// Need to make sure katex gets injected when the only
+		// place latex is used is in the assessment, since it
+		// won't be detected when first loading a module.
+		await injectKatexIfNeeded({ value: startAttemptResp })
+
 		const id = startAttemptResp.assessmentId
 		const model = OboModel.models[id]
 

--- a/packages/obonode/obojobo-sections-assessment/components/post-test/index.js
+++ b/packages/obonode/obojobo-sections-assessment/components/post-test/index.js
@@ -5,6 +5,7 @@ import LTIStatus from './lti-status'
 import React from 'react'
 import Viewer from 'Viewer'
 import AssessmentApi from 'obojobo-document-engine/src/scripts/viewer/util/assessment-api'
+import injectKatexIfNeeded from 'obojobo-document-engine/src/scripts/common/util/inject-katex-if-needed'
 
 const { OboModel } = Common.models
 const { focus } = Common.page
@@ -58,9 +59,14 @@ class AssessmentPostTest extends React.Component {
 				attempt.state.questionModels = result[attempt.id]
 			})
 
-			this.setState({
-				attempts,
-				isFetching: false
+			// Some of the questions may contain latex. Need to
+			// make sure window.katex is defined before trying
+			// to render those questions
+			injectKatexIfNeeded({ value: attempts }).then(() => {
+				this.setState({
+					attempts,
+					isFetching: false
+				})
 			})
 		})
 	}

--- a/packages/obonode/obojobo-sections-assessment/components/post-test/index.js
+++ b/packages/obonode/obojobo-sections-assessment/components/post-test/index.js
@@ -62,7 +62,7 @@ class AssessmentPostTest extends React.Component {
 			// Some of the questions may contain latex. Need to
 			// make sure window.katex is defined before trying
 			// to render those questions
-			injectKatexIfNeeded({ value: attempts }).then(() => {
+			injectKatexIfNeeded({ value: attempts }).finally(() => {
 				this.setState({
 					attempts,
 					isFetching: false


### PR DESCRIPTION
Katex is injected when starting/resuming an assessment since it might not be loaded when the document is first rendered.

Fixes #1604 