### PR TITLE
fix year dependent snapshots for 2020

### DIFF
--- a/packages/app/obojobo-repository/shared/components/layouts/__snapshots__/footer.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/layouts/__snapshots__/footer.test.js.snap
@@ -53,7 +53,7 @@ exports[`Footer renders 1`] = `
       <span
         id="copyright-date"
       >
-        2020
+        2016
       </span>
        
       <a

--- a/packages/app/obojobo-repository/shared/components/layouts/footer.test.js
+++ b/packages/app/obojobo-repository/shared/components/layouts/footer.test.js
@@ -1,6 +1,10 @@
 import React from 'react'
-import Footer from './footer'
 import renderer from 'react-test-renderer'
+
+mockStaticDate()
+
+// require used to make sure it's loaded after mock date
+const Footer = require('./footer')
 
 describe('Footer', () => {
 	test('renders', () => {

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-error.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-error.test.js.snap
@@ -188,7 +188,7 @@ exports[`PageError renders when given props 1`] = `
               <span
                 id="copyright-date"
               >
-                2020
+                2016
               </span>
                
               <a

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-homepage.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-homepage.test.js.snap
@@ -285,7 +285,7 @@ exports[`PageHomepage renders when given props 1`] = `
               <span
                 id="copyright-date"
               >
-                2020
+                2016
               </span>
                
               <a

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-login.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-login.test.js.snap
@@ -199,7 +199,7 @@ exports[`PageLogin renders when given props 1`] = `
               <span
                 id="copyright-date"
               >
-                2020
+                2016
               </span>
                
               <a

--- a/packages/app/obojobo-repository/shared/components/pages/page-error.test.js
+++ b/packages/app/obojobo-repository/shared/components/pages/page-error.test.js
@@ -1,6 +1,10 @@
 import React from 'react'
-import PageError from './page-error'
 import renderer from 'react-test-renderer'
+
+mockStaticDate()
+
+// require used to make sure it's loaded after mock date
+const PageError = require('./page-error')
 
 describe('PageError', () => {
 	test('renders when given props', () => {

--- a/packages/app/obojobo-repository/shared/components/pages/page-homepage.test.js
+++ b/packages/app/obojobo-repository/shared/components/pages/page-homepage.test.js
@@ -1,6 +1,10 @@
 import React from 'react'
-import PageHomepage from './page-homepage'
 import renderer from 'react-test-renderer'
+
+mockStaticDate()
+
+// require used to make sure it's loaded after mock date
+const PageHomepage = require('./page-homepage')
 
 describe('PageHomepage', () => {
 	test('renders when given props', () => {

--- a/packages/app/obojobo-repository/shared/components/pages/page-login.test.js
+++ b/packages/app/obojobo-repository/shared/components/pages/page-login.test.js
@@ -1,6 +1,10 @@
 import React from 'react'
-import PageLogin from './page-login'
 import renderer from 'react-test-renderer'
+
+mockStaticDate()
+
+// require used to make sure it's loaded after mock date
+const PageLogin = require('./page-login')
 
 describe('PageLogin', () => {
 	test('renders when given props', () => {


### PR DESCRIPTION
So the year flipped from 2020 to 2021 and there are a couple of snapshots that have the current year shown in the footer in them.

This pr mocks the date to a constant value that wont change.