### PR TITLE
upgrade katex from 0.11.1 to 0.12.0

### DIFF
--- a/packages/app/obojobo-document-engine/package.json
+++ b/packages/app/obojobo-document-engine/package.json
@@ -45,7 +45,7 @@
 		"codemirror": "^5.58.1",
 		"date-fns": "^2.16.1",
 		"downloadjs": "^1.4.7",
-		"katex": "^0.11.1",
+		"katex": "^0.12.0",
 		"prop-types": "15.7.2",
 		"react": "^16.13.1",
 		"react-codemirror2": "^7.2.1",

--- a/packages/app/obojobo-document-engine/src/scripts/common/util/inject-katex-if-needed.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/util/inject-katex-if-needed.js
@@ -16,12 +16,12 @@ const injectKatexIfNeeded = async ({ value: draftModel }) => {
 
 	if (stringModel.includes('latex')) {
 		const jsProps = {
-			src: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.js'
+			src: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.js'
 		}
 		const cssProps = {
 			rel: 'stylesheet',
 			type: 'text/css',
-			href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css'
+			href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.css'
 		}
 		insertDomTag(jsProps, 'script')
 		insertDomTag(cssProps, 'link')

--- a/packages/app/obojobo-express/server/views/editor.ejs
+++ b/packages/app/obojobo-express/server/views/editor.ejs
@@ -6,7 +6,7 @@
 			let title = 'Obojobo Visual Editor'
 			let css = [
 				webpackAssetPath('editor.css'),
-				'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css'
+				'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.css'
 			]
 			let headerJs = []
 			let footerJs = [
@@ -16,7 +16,7 @@
 				assetForEnv('//unpkg.com/slate-react@0.57.2/dist/slate-react$[.min].js'),
 				assetForEnv('//unpkg.com/underscore@1.11.0/underscore$[-min].js'),
 				assetForEnv('//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.3.3/backbone$[-min].js'),
-				'//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.js',
+				'//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.js',
 				webpackAssetPath('editor.js')
 			]
 			let fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i']

--- a/packages/obonode/obojobo-chunks-math-equation/package.json
+++ b/packages/obonode/obojobo-chunks-math-equation/package.json
@@ -27,7 +27,7 @@
 		"singleQuote": true
 	},
 	"dependencies": {
-		"katex": "^0.11.1"
+		"katex": "^0.12.0"
 	},
 	"peerDependencies": {
 		"obojobo-lib-utils": "^11.2.0-alpha.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9526,10 +9526,10 @@ jsx-ast-utils@^2.2.3:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
-katex@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.11.1.tgz#df30ca40c565c9df01a466a00d53e079e84ffaa2"
-  integrity sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==
+katex@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.12.0.tgz#2fb1c665dbd2b043edcf8a1f5c555f46beaa0cb9"
+  integrity sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==
   dependencies:
     commander "^2.19.0"
 
@@ -13139,11 +13139,6 @@ run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
-
-run-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
-  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
 
 run-parallel@^1.1.9:
   version "1.1.9"


### PR DESCRIPTION
Newer KaTeX support some features needed right now by project at UCF, specifically displaying this equation is not possible in 0.11.1 but works in 0.12.0

```latex
{\begin{rcases}V_{AB} = Ed \\ E = \frac{V_{AB}}{d} \end{rcases}{\textbf{(uniform} \; E \;\textbf{- field only)}}}
```
## In obonext dev 16 (using katex 0.11.1)

Obojobo katex parse error:
> KaTeX parse error: No such environment: rcases at position 8: {\begin{̲r̲c̲a̲s̲e̲s̲}̲V_{AB} = Ed \\ …

![image (6)](https://user-images.githubusercontent.com/73480/109052972-37f12300-76aa-11eb-82dd-4b3679fce196.png)

## using katex 0.12.0
![image (7)](https://user-images.githubusercontent.com/73480/109052859-1a23be00-76aa-11eb-91b5-526ee4621e80.png)

