### PR TITLE
materia - custom launch vars and temporary context_id update

### DIFF
--- a/packages/obonode/obojobo-chunks-materia/server/index.js
+++ b/packages/obonode/obojobo-chunks-materia/server/index.js
@@ -131,7 +131,7 @@ router
 			return
 		}
 
-		const materiaChunkId = materiaNode.node.id
+		const materiaOboNodeId = materiaNode.node.id
 		const endpoint = materiaNode.node.content.src
 
 		// verify the endpoint is the configured materia server
@@ -148,7 +148,7 @@ router
 			currentDocument,
 			req.currentVisit,
 			req.currentUser,
-			materiaChunkId,
+			materiaOboNodeId,
 			baseUrl(req)
 		)
 

--- a/packages/obonode/obojobo-chunks-materia/server/index.js
+++ b/packages/obonode/obojobo-chunks-materia/server/index.js
@@ -1,4 +1,3 @@
-
 const router = require('express').Router() //eslint-disable-line new-cap
 const logger = require('obojobo-express/server/logger')
 const uuid = require('uuid').v4
@@ -147,10 +146,9 @@ router
 
 		const launchParams = widgetLaunchParams(
 			currentDocument,
-			materiaChunkId,
+			req.currentVisit,
 			req.currentUser,
-			req.currentVisit.id,
-			req.currentVisit.is_preview,
+			materiaChunkId,
 			baseUrl(req)
 		)
 

--- a/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
+++ b/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
@@ -63,7 +63,7 @@ const widgetLaunchParams = (document, visit, user, materiaOboNodeId, baseUrl) =>
 	// * re lti launch will reset scores/attempts
 	// * browser reload of the window will resume an attempt/score window
 	// a visit id is a representation of: user_id + lti launch + draft_id + draft_content_id
-	const overrideKeys = { context_id: params.resource_link_id }
+	const overrideKeys = { context_id: params.lis_result_sourcedid }
 
 	const ltiUser = visit.is_preview ? buildLTIInstructor(user) : buildLTIStudent(user)
 	return {

--- a/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
+++ b/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
@@ -50,7 +50,7 @@ const widgetLaunchParams = (document, visit, user, materiaOboNodeId, baseUrl) =>
 		// unique placement of this widget (take into account the module's unique placement in a course + the widget's place in the module)
 		// we are intentionally not including user id (not part of the placement) or draft_content_id (to allow updates to a module)
 		resource_link_id: `${visit.resource_link_id}__${visit.draft_id}__${materiaChunkId}`,
-		custom_chunk_id: materiaChunkId,
+		custom_obo_node_id: materiaOboNodeId,
 		custom_visit_id: visit.id,
 		custom_draft_id: visit.draft_id,
 		custom_draft_content_id: visit.draft_content_id,

--- a/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
+++ b/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
@@ -46,7 +46,7 @@ const widgetLaunchParams = (document, visit, user, materiaOboNodeId, baseUrl) =>
 		// materia will send scores here
 		lis_outcome_service_url: `${baseUrl}/materia-lti-score-passback`,
 		// represents the container for the user's score this widget can set/update
-		lis_result_sourcedid: `${visit.id}__${materiaChunkId}`,
+		lis_result_sourcedid: `${visit.id}__${materiaOboNodeId}`,
 		// unique placement of this widget (take into account the module's unique placement in a course + the widget's place in the module)
 		// we are intentionally not including user id (not part of the placement) or draft_content_id (to allow updates to a module)
 		resource_link_id: `${visit.resource_link_id}__${visit.draft_id}__${materiaChunkId}`,

--- a/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
+++ b/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
@@ -49,7 +49,7 @@ const widgetLaunchParams = (document, visit, user, materiaOboNodeId, baseUrl) =>
 		lis_result_sourcedid: `${visit.id}__${materiaOboNodeId}`,
 		// unique placement of this widget (take into account the module's unique placement in a course + the widget's place in the module)
 		// we are intentionally not including user id (not part of the placement) or draft_content_id (to allow updates to a module)
-		resource_link_id: `${visit.resource_link_id}__${visit.draft_id}__${materiaChunkId}`,
+		resource_link_id: `${visit.resource_link_id}__${visit.draft_id}__${materiaOboNodeId}`,
 		custom_obo_node_id: materiaOboNodeId,
 		custom_visit_id: visit.id,
 		custom_draft_id: visit.draft_id,
@@ -75,7 +75,7 @@ const widgetLaunchParams = (document, visit, user, materiaOboNodeId, baseUrl) =>
 	}
 }
 
-const contentSelectionParams = (document, materiaChunkId, user, clientBaseUrl, serverBaseUrl) => {
+const contentSelectionParams = (document, materiaOboNodeId, user, clientBaseUrl, serverBaseUrl) => {
 	const params = {
 		lti_message_type: 'ContentItemSelectionRequest',
 		lti_version: 'LTI-1p0',
@@ -86,7 +86,7 @@ const contentSelectionParams = (document, materiaChunkId, user, clientBaseUrl, s
 		accept_copy_advice: false,
 		auto_create: false,
 		content_item_return_url: `${clientBaseUrl}/materia-lti-picker-return`,
-		data: `draftId=${document.draftId}&contentId=${document.contentId}&nodeId=${materiaChunkId}`
+		data: `draftId=${document.draftId}&contentId=${document.contentId}&nodeId=${materiaOboNodeId}`
 	}
 
 	return {

--- a/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
+++ b/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
@@ -39,7 +39,7 @@ const ltiToolConsumer = baseUrl => ({
 	tool_consumer_instance_url: baseUrl
 })
 
-const widgetLaunchParams = (document, visit, user, materiaChunkId, baseUrl) => {
+const widgetLaunchParams = (document, visit, user, materiaOboNodeId, baseUrl) => {
 	const params = {
 		lti_message_type: 'basic-lti-launch-request',
 		lti_version: 'LTI-1p0',


### PR DESCRIPTION
changes materia launch params to better encapsulate score/attempt windows
adds a bunch of documentation to the lti launch params for materia