### PR TITLE
[WIP] security headers

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/common/util/inject-katex-if-needed.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/util/inject-katex-if-needed.js
@@ -16,12 +16,12 @@ const injectKatexIfNeeded = async ({ value: draftModel }) => {
 
 	if (stringModel.includes('latex')) {
 		const jsProps = {
-			src: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.js'
+			src: 'https://unpkg.com/katex@0.12.0/dist/katex.min.js'
 		}
 		const cssProps = {
 			rel: 'stylesheet',
 			type: 'text/css',
-			href: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.css'
+			href: 'https://unpkg.com/katex@0.12.0/dist/katex.min.css'
 		}
 		insertDomTag(jsProps, 'script')
 		insertDomTag(cssProps, 'link')

--- a/packages/app/obojobo-express/server/middleware.default.js
+++ b/packages/app/obojobo-express/server/middleware.default.js
@@ -69,6 +69,25 @@ module.exports = app => {
 		res.missing()
 	})
 
+	// set security headers
+	app.use((req, res, next) => {
+		// Disable referrers for browsers that don't support strict-origin-when-cross-origin
+		// Otherwise Only send the shortened referrer to a foreign origin, full referrer to a local host
+		res.setHeader('Referrer-Policy', 'no-referrer, strict-origin-when-cross-origin')
+
+		// Only connect to this site and subdomains via HTTPS for the next two years and also include in the preload list
+		res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload')
+
+		// Disable unsafe inline/eval and plugins, only load scripts and stylesheets from same origin, fonts from google,
+		// and images from same origin and imgur. Sites should aim for policies like this.
+		res.setHeader('Content-Security-Policy', "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://unpkg.com https://www.youtube.com; connect-src 'self'; style-src-elem 'self' https://unpkg.com https://fonts.googleapis.com; font-src https://fonts.gstatic.com https://unpkg.com; img-src 'self' data: https://secure.gravatar.com https://i.ytimg.com; object-src 'none'; style-src 'self' 'unsafe-inline'; frame-src 'self' https://www.youtube-nocookie.com; frame-ancestors 'self'; form-action 'self'")
+
+		res.setHeader('Access-Control-Allow-Origin', '*')
+		res.setHeader('Access-Control-Allow-Methods', 'GET, POST')
+		res.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type, Authorization')
+		next()
+	})
+
 	// uncaught error handler
 	// you'll want to keep an eye out for 'Query read timeout' in your logs, it may indicate the db has gone away
 	app.use((err, req, res, next) => {

--- a/packages/app/obojobo-express/server/views/editor.ejs
+++ b/packages/app/obojobo-express/server/views/editor.ejs
@@ -6,17 +6,17 @@
 			let title = 'Obojobo Visual Editor'
 			let css = [
 				webpackAssetPath('editor.css'),
-				'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.css'
+				assetForEnv('https://unpkg.com/katex@0.12.0/dist/katex$[.min].css')
 			]
 			let headerJs = []
 			let footerJs = [
-				assetForEnv('//unpkg.com/react@16.13.1/umd/react.$[development|production.min].js'),
-				assetForEnv('//unpkg.com/react-dom@16.13.1/umd/react-dom.$[development|production.min].js'),
-				assetForEnv('//unpkg.com/slate@0.57.2/dist/slate$[.min].js'),
-				assetForEnv('//unpkg.com/slate-react@0.57.2/dist/slate-react$[.min].js'),
-				assetForEnv('//unpkg.com/underscore@1.11.0/underscore$[-min].js'),
-				assetForEnv('//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.3.3/backbone$[-min].js'),
-				'//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.12.0/katex.min.js',
+				assetForEnv('https://unpkg.com/react@16.13.1/umd/react.$[development|production.min].js'),
+				assetForEnv('https://unpkg.com/react-dom@16.13.1/umd/react-dom.$[development|production.min].js'),
+				assetForEnv('https://unpkg.com/slate@0.57.2/dist/slate$[.min].js'),
+				assetForEnv('https://unpkg.com/slate-react@0.57.2/dist/slate-react$[.min].js'),
+				assetForEnv('https://unpkg.com/underscore@1.11.0/underscore$[-min].js'),
+				assetForEnv('https://unpkg.com/backbone@1.3.3/backbone$[-min].js'),
+				assetForEnv('https://unpkg.com/katex@0.12.0/dist/katex$[.min].js'),
 				webpackAssetPath('editor.js')
 			]
 			let fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i']

--- a/packages/app/obojobo-express/server/views/viewer.ejs
+++ b/packages/app/obojobo-express/server/views/viewer.ejs
@@ -12,7 +12,7 @@
 				assetForEnv('//unpkg.com/react@16.13.1/umd/react.$[development|production.min].js'),
 				assetForEnv('//unpkg.com/react-dom@16.13.1/umd/react-dom.$[development|production.min].js'),
 				assetForEnv('//unpkg.com/underscore@1.11.0/underscore$[-min].js'),
-				assetForEnv('//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.3.3/backbone$[-min].js'),
+				assetForEnv('https://unpkg.com/backbone@1.3.3/backbone$[-min].js'),
 				webpackAssetPath('viewer.js')
 			]
 			const fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i']

--- a/packages/app/obojobo-express/webpack.config.js
+++ b/packages/app/obojobo-express/webpack.config.js
@@ -20,6 +20,7 @@ module.exports =
 			performance: { hints: false },
 			mode: is_production ? 'production' : 'development',
 			target: 'web',
+			devtool: 'inline-source-map',
 			devServer: {
 				https: true,
 				host: '127.0.0.1',


### PR DESCRIPTION
adds more stringent security headers.  Needs additional work to work properly.  The rules are so tight that they won't allow lti launches to materia, loading images from 3rd party sites, or iframes to other domains.

One idea would be to search for urls in the document and add them to an allowlist.

Also, it'd be best to disable `script-src 'unsafe-eval'`, but it's needed by the current version of Slate.js