### PR TITLE
Ensure that the height of Iframes when sizing=max-width or text-width is respected

### DIFF
--- a/packages/obonode/obojobo-chunks-iframe/__snapshots__/render-settings.test.js.snap
+++ b/packages/obonode/obojobo-chunks-iframe/__snapshots__/render-settings.test.js.snap
@@ -3,7 +3,7 @@
 exports[`render-settings getRenderSettings 1`] = `
 Object {
   "afterStyle": Object {
-    "height": 456,
+    "height": 480,
   },
   "ariaRegionLabel": "External content from src.",
   "controlsOpts": Object {
@@ -14,18 +14,18 @@ Object {
   },
   "displayedTitle": "src",
   "iframeStyle": Object {
-    "height": "100%",
-    "transform": "scale(1)",
-    "width": "100%",
+    "height": "130.6122448979592%",
+    "transform": "scale(0.765625)",
+    "width": "130.6122448979592%",
   },
   "isAtMaxScale": false,
   "isAtMinScale": false,
   "isShowing": false,
   "scaleDimensions": Object {
     "containerStyle": Object {
-      "width": 123,
+      "width": 640,
     },
-    "scale": 1,
+    "scale": 0.765625,
   },
   "zoomValues": Object {
     "currentZoom": 1,

--- a/packages/obonode/obojobo-chunks-iframe/iframe-default-sizes.js
+++ b/packages/obonode/obojobo-chunks-iframe/iframe-default-sizes.js
@@ -1,0 +1,4 @@
+export default {
+	MAX_WIDTH: 835,
+	TEXT_WIDTH: 722
+}

--- a/packages/obonode/obojobo-chunks-iframe/render-settings.js
+++ b/packages/obonode/obojobo-chunks-iframe/render-settings.js
@@ -5,7 +5,6 @@ import Viewer from 'obojobo-document-engine/src/scripts/viewer'
 import IFrameDefaultSizes from './iframe-default-sizes'
 const MediaUtil = Viewer.util.MediaUtil
 
-// const MAX_OR_TEXT_WIDTH = '835' //722
 const DEFAULT_WIDTH = 640
 const DEFAULT_HEIGHT = 480
 

--- a/packages/obonode/obojobo-chunks-iframe/render-settings.js
+++ b/packages/obonode/obojobo-chunks-iframe/render-settings.js
@@ -46,7 +46,7 @@ const getAriaRegionLabel = (modelState, displayedTitle) => {
 	}
 }
 
-const getSetDimensions = modelState => {
+const getDesiredDimensions = modelState => {
 	switch (modelState.sizing) {
 		case IFrameSizingTypes.MAX_WIDTH:
 			return {
@@ -72,20 +72,20 @@ const getScaleAmount = (actualWidth, padding, setWidth) => {
 	return Math.min(1, (actualWidth - padding) / setWidth)
 }
 
-const getScaleDimensions = (modelState, zoom, scaleAmount, minScale, setDimensions) => {
+const getScaleDimensions = (modelState, zoom, scaleAmount, minScale, desiredDimensions) => {
 	let scale
 	let containerStyle = {}
 
 	if (modelState.fit === IFrameFitTypes.SCROLL) {
 		scale = zoom
 		containerStyle = {
-			width: setDimensions.w,
-			height: setDimensions.h
+			width: desiredDimensions.w,
+			height: desiredDimensions.h
 		}
 	} else {
 		scale = scaleAmount * zoom
 		containerStyle = {
-			width: setDimensions.w
+			width: desiredDimensions.w
 		}
 	}
 
@@ -126,8 +126,8 @@ const getZoomValues = (mediaState, model) => {
 const getRenderSettings = (model, actualWidth, padding, minScale, maxScale, mediaState) => {
 	const ms = model.modelState
 	const zoomValues = getZoomValues(mediaState, model)
-	const setDimensions = getSetDimensions(ms)
-	const scaleAmount = getScaleAmount(actualWidth, padding, setDimensions.w)
+	const desiredDimensions = getDesiredDimensions(ms)
+	const scaleAmount = getScaleAmount(actualWidth, padding, desiredDimensions.w)
 	const displayedTitle = getDisplayedTitle(ms)
 	const ariaRegionLabel = getAriaRegionLabel(ms, displayedTitle)
 	const scaleDimensions = getScaleDimensions(
@@ -135,13 +135,13 @@ const getRenderSettings = (model, actualWidth, padding, minScale, maxScale, medi
 		zoomValues.currentZoom,
 		scaleAmount,
 		minScale,
-		setDimensions
+		desiredDimensions
 	)
 	const controlsOpts = getControlsOptions(ms)
 	const isAtMinScale = scaleDimensions.scale <= minScale
 	const isAtMaxScale = scaleDimensions.scale >= maxScale
 	const iframeStyle = getIFrameStyle(scaleDimensions.scale)
-	const afterStyle = getAfterStyle(setDimensions.w, setDimensions.h, ms.fit)
+	const afterStyle = getAfterStyle(desiredDimensions.w, desiredDimensions.h, ms.fit)
 	const isShowing = getIsShowing(mediaState, model)
 
 	return {
@@ -163,7 +163,7 @@ export {
 	getControlsOptions,
 	getDisplayedTitle,
 	getAriaRegionLabel,
-	getSetDimensions,
+	getDesiredDimensions,
 	getScaleAmount,
 	getScaleDimensions,
 	getIFrameStyle,

--- a/packages/obonode/obojobo-chunks-iframe/render-settings.js
+++ b/packages/obonode/obojobo-chunks-iframe/render-settings.js
@@ -2,9 +2,12 @@ import IFrameControlTypes from './iframe-control-types'
 import IFrameFitTypes from './iframe-fit-types'
 import IFrameSizingTypes from './iframe-sizing-types'
 import Viewer from 'obojobo-document-engine/src/scripts/viewer'
+import IFrameDefaultSizes from './iframe-default-sizes'
 const MediaUtil = Viewer.util.MediaUtil
 
-const MAX_OR_TEXT_WIDTH = '835'
+// const MAX_OR_TEXT_WIDTH = '835' //722
+const DEFAULT_WIDTH = 640
+const DEFAULT_HEIGHT = 480
 
 const getIsShowing = (mediaState, model) => {
 	return (
@@ -44,15 +47,29 @@ const getAriaRegionLabel = (modelState, displayedTitle) => {
 	}
 }
 
-const getSetDimensions = (modelState, defaultWidth, defaultHeight) => ({
-	w: modelState.width || defaultWidth,
-	h: modelState.height || defaultHeight
-})
+const getSetDimensions = modelState => {
+	switch (modelState.sizing) {
+		case IFrameSizingTypes.MAX_WIDTH:
+			return {
+				w: IFrameDefaultSizes.MAX_WIDTH,
+				h: modelState.height || DEFAULT_HEIGHT
+			}
 
-const getScaleAmount = (actualWidth, padding, setWidth, sizing) => {
-	if (sizing === IFrameSizingTypes.MAX_WIDTH || sizing === IFrameSizingTypes.TEXT_WIDTH) {
-		setWidth = MAX_OR_TEXT_WIDTH
+		case IFrameSizingTypes.TEXT_WIDTH:
+			return {
+				w: IFrameDefaultSizes.TEXT_WIDTH,
+				h: modelState.height || DEFAULT_HEIGHT
+			}
+
+		default:
+			return {
+				w: modelState.width || DEFAULT_WIDTH,
+				h: modelState.height || DEFAULT_HEIGHT
+			}
 	}
+}
+
+const getScaleAmount = (actualWidth, padding, setWidth) => {
 	return Math.min(1, (actualWidth - padding) / setWidth)
 }
 
@@ -107,20 +124,11 @@ const getZoomValues = (mediaState, model) => {
 	}
 }
 
-const getRenderSettings = (
-	model,
-	actualWidth,
-	padding,
-	defaultWidth,
-	defaultHeight,
-	minScale,
-	maxScale,
-	mediaState
-) => {
+const getRenderSettings = (model, actualWidth, padding, minScale, maxScale, mediaState) => {
 	const ms = model.modelState
 	const zoomValues = getZoomValues(mediaState, model)
-	const setDimensions = getSetDimensions(ms, defaultWidth, defaultHeight)
-	const scaleAmount = getScaleAmount(actualWidth, padding, setDimensions.w, ms.sizing)
+	const setDimensions = getSetDimensions(ms)
+	const scaleAmount = getScaleAmount(actualWidth, padding, setDimensions.w)
 	const displayedTitle = getDisplayedTitle(ms)
 	const ariaRegionLabel = getAriaRegionLabel(ms, displayedTitle)
 	const scaleDimensions = getScaleDimensions(

--- a/packages/obonode/obojobo-chunks-iframe/render-settings.test.js
+++ b/packages/obonode/obojobo-chunks-iframe/render-settings.test.js
@@ -3,7 +3,7 @@ import {
 	getControlsOptions,
 	getDisplayedTitle,
 	getAriaRegionLabel,
-	getSetDimensions,
+	getDesiredDimensions,
 	getScaleAmount,
 	getScaleDimensions,
 	getIFrameStyle,
@@ -278,8 +278,8 @@ describe('render-settings', () => {
 		expect(t({ src: 'mock-src' }, 'displayed-title')).toBe('External content from mock-src.')
 	})
 
-	test('getSetDimensions', () => {
-		const d = getSetDimensions
+	test('getDesiredDimensions', () => {
+		const d = getDesiredDimensions
 
 		expect(d({ width: 'w', height: 'h' })).toEqual({ w: 'w', h: 'h' })
 		expect(d({ height: 'h' })).toEqual({ w: 640, h: 'h' })

--- a/packages/obonode/obojobo-chunks-iframe/render-settings.test.js
+++ b/packages/obonode/obojobo-chunks-iframe/render-settings.test.js
@@ -13,7 +13,6 @@ import {
 } from './render-settings'
 
 import MediaUtil from 'obojobo-document-engine/src/scripts/viewer/util/media-util'
-import IFrameSizingTypes from './iframe-sizing-types'
 
 describe('render-settings', () => {
 	test('getIsShowing', () => {
@@ -282,27 +281,29 @@ describe('render-settings', () => {
 	test('getSetDimensions', () => {
 		const d = getSetDimensions
 
-		expect(d({ width: 'w', height: 'h' }, 'dw', 'dh')).toEqual({ w: 'w', h: 'h' })
-		expect(d({ height: 'h' }, 'dw', 'dh')).toEqual({ w: 'dw', h: 'h' })
-		expect(d({ width: 'w' }, 'dw', 'dh')).toEqual({ w: 'w', h: 'dh' })
-		expect(d({}, 'dw', 'dh')).toEqual({ w: 'dw', h: 'dh' })
+		expect(d({ width: 'w', height: 'h' })).toEqual({ w: 'w', h: 'h' })
+		expect(d({ height: 'h' })).toEqual({ w: 640, h: 'h' })
+		expect(d({ width: 'w' })).toEqual({ w: 'w', h: 480 })
+		expect(d({})).toEqual({ w: 640, h: 480 })
+
+		expect(d({ width: 'w', height: 'h', sizing: 'text-width' })).toEqual({ w: 722, h: 'h' })
+		expect(d({ height: 'h', sizing: 'text-width' })).toEqual({ w: 722, h: 'h' })
+		expect(d({ width: 'w', sizing: 'text-width' })).toEqual({ w: 722, h: 480 })
+		expect(d({ sizing: 'text-width' })).toEqual({ w: 722, h: 480 })
+
+		expect(d({ width: 'w', height: 'h', sizing: 'max-width' })).toEqual({ w: 835, h: 'h' })
+		expect(d({ height: 'h', sizing: 'max-width' })).toEqual({ w: 835, h: 'h' })
+		expect(d({ width: 'w', sizing: 'max-width' })).toEqual({ w: 835, h: 480 })
+		expect(d({ sizing: 'max-width' })).toEqual({ w: 835, h: 480 })
 	})
 
 	test('getScaleAmount', () => {
 		const s = getScaleAmount
 
-		expect(s(1, 2, 3, IFrameSizingTypes.FIXED)).toBe(-1 / 3)
-		expect(s(3, 2, 1, IFrameSizingTypes.FIXED)).toBe(1)
-		expect(s(100, 0, 1, IFrameSizingTypes.FIXED)).toBe(1)
-		expect(s(200, 20, 400, IFrameSizingTypes.FIXED)).toBe(180 / 400)
-
-		expect(s(835, 0, 640, IFrameSizingTypes.MAX_WIDTH)).toBe(1)
-		expect(s(700, 20, 1, IFrameSizingTypes.MAX_WIDTH)).toBe(136 / 167)
-		expect(s(835, 20, 1000, IFrameSizingTypes.MAX_WIDTH)).toBe(163 / 167)
-
-		expect(s(835, 0, 640, IFrameSizingTypes.TEXT_WIDTH)).toBe(1)
-		expect(s(700, 20, 1, IFrameSizingTypes.TEXT_WIDTH)).toBe(136 / 167)
-		expect(s(835, 20, 1000, IFrameSizingTypes.TEXT_WIDTH)).toBe(163 / 167)
+		expect(s(1, 2, 3)).toBe(-1 / 3)
+		expect(s(3, 2, 1)).toBe(1)
+		expect(s(100, 0, 1)).toBe(1)
+		expect(s(200, 20, 400)).toBe(180 / 400)
 	})
 
 	test('getScaleDimensions (fit="scale")', () => {
@@ -405,6 +406,6 @@ describe('render-settings', () => {
 				controls: ''
 			}
 		}
-		expect(getRenderSettings(model, 500, 10, 123, 456, 0.1, 20, mediaState)).toMatchSnapshot()
+		expect(getRenderSettings(model, 500, 10, 0.1, 20, mediaState)).toMatchSnapshot()
 	})
 })

--- a/packages/obonode/obojobo-chunks-iframe/viewer-component.js
+++ b/packages/obonode/obojobo-chunks-iframe/viewer-component.js
@@ -13,8 +13,6 @@ import ReactDOM from 'react-dom'
 import Viewer from 'obojobo-document-engine/src/scripts/viewer'
 import { getRenderSettings } from './render-settings'
 
-const DEFAULT_WIDTH = 1000
-const DEFAULT_HEIGHT = 500
 const MIN_SCALE = 0.1
 const MAX_SCALE = 10
 const DECREASE_ZOOM_STEP = -0.1
@@ -147,8 +145,6 @@ export default class IFrame extends React.Component {
 			model,
 			this.state.actualWidth,
 			this.state.padding,
-			DEFAULT_WIDTH,
-			DEFAULT_HEIGHT,
 			MIN_SCALE,
 			MAX_SCALE,
 			this.props.moduleData.mediaState

--- a/packages/obonode/obojobo-chunks-question-bank/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question-bank/editor-component.js
@@ -102,15 +102,17 @@ class QuestionBank extends React.Component {
 	}
 
 	freezeEditor() {
-		clearTimeout(window.restoreEditorFocusId)
-		this.props.editor.toggleEditable(false)
+		const el = document.activeElement
+		setTimeout(() => {
+			el.focus()
+		})
 	}
 
 	unfreezeEditor() {
-		window.restoreEditorFocusId = setTimeout(() => {
-			this.updateNodeFromState()
-			this.props.editor.toggleEditable(true)
-		})
+		// window.restoreEditorFocusId = setTimeout(() => {
+		// 	this.updateNodeFromState()
+		// 	this.props.editor.toggleEditable(true)
+		// })
 	}
 
 	displaySettings(editor, element) {

--- a/packages/obonode/obojobo-chunks-question-bank/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question-bank/editor-component.js
@@ -102,17 +102,15 @@ class QuestionBank extends React.Component {
 	}
 
 	freezeEditor() {
-		const el = document.activeElement
-		setTimeout(() => {
-			el.focus()
-		})
+		clearTimeout(window.restoreEditorFocusId)
+		this.props.editor.toggleEditable(false)
 	}
 
 	unfreezeEditor() {
-		// window.restoreEditorFocusId = setTimeout(() => {
-		// 	this.updateNodeFromState()
-		// 	this.props.editor.toggleEditable(true)
-		// })
+		window.restoreEditorFocusId = setTimeout(() => {
+			this.updateNodeFromState()
+			this.props.editor.toggleEditable(true)
+		})
 	}
 
 	displaySettings(editor, element) {


### PR DESCRIPTION
Fixes #1735 

The problem: When you change "sizing" for an IFrame to be set to "text-width" or "max-width" you no longer can define the width AND height of the iframe - instead you can only set the height. However, the resulting IFrame wasn't actually at that height. For example, if you put in a height of 480px with sizing set to "text-width" then the resulting IFrame would be < 480px.

The solution: Just need to tweak the default width and height values being given to renderSettings to the actual widths of iframes at text-width and max-width. This means if you create a "text-width" iframe and set the height to 480px, as long as the page isn't narrowed it should display at a height of 480px.