### PR TITLE
adds menu dropdown hide on mouseout when selected

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/drop-down-menu.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/drop-down-menu.js
@@ -117,6 +117,7 @@ class DropDownMenu extends React.PureComponent {
 				onBlur={this.onBlurHandler}
 				onFocus={this.onFocusHandler}
 				onKeyDown={this.onKeyDown}
+				onMouseLeave={this.onBlurHandler}
 				ref={this.props.onRef}
 				tabIndex={-1}
 			>


### PR DESCRIPTION
fixes #1291 that kept editor toolbar items open when selected.

Solution: listen for mouse out and use existing blur handler to
to change state to closed