### PR TITLE
enables all optional nodes when running dev server

### DIFF
--- a/packages/app/obojobo-express/package.json
+++ b/packages/app/obojobo-express/package.json
@@ -15,7 +15,7 @@
 		"db:createmigration": "obojobo-migrate create",
 		"db:remove": "(docker kill db_postgres || true) && (docker rm db_postgres || true)",
 		"db:rebuild": "yarn db:remove && yarn db:initdocker && sleep 4 && yarn db:migrateup && yarn sampleDraft:seed",
-		"dev": "DEBUG=obojobo_server:error,obojobo_server:warn,obojobo_server:info IS_WEBPACK=true nodemon ./node_modules/.bin/webpack serve",
+		"dev": "OBO_OPTIONAL_NODES=* DEBUG=obojobo_server:error,obojobo_server:warn,obojobo_server:info IS_WEBPACK=true nodemon ./node_modules/.bin/webpack serve",
 		"sampleDraft:seed": "node ./bin/sample_draft.js seed",
 		"sampleDraft:watch": "node ./bin/sample_draft.js watch",
 		"test": "TZ='America/New_York' jest",


### PR DESCRIPTION
Dev/18 added last minute code to disable optional nodes by default.  This turns them on when running the dev server `yarn dev` 

Materia is the only optional node right now, so you should be able to test by running dev/19 and running this branch

With this change you'll see obojobo-chunks-materia/server/index.js get loaded and you'll see the Materia button in the editor

```
OboNode client scripts to build 7
  obojobo_server:info  Registering express middleware: /Obojobo/packages/obonode/obojobo-chunks-materia/server/index.js +0ms
  obojobo_server:info  Registering express middleware: /Obojobo/packages/app/obojobo-module-selector/server/index.js +5ms
  obojobo_server:info  Registering express middleware: /Obojobo/packages/app/obojobo-repository/server/index.js +1ms
  obojobo_server:info  Registering express middleware: /Obojobo/packages/obonode/obojobo-sections-assessment/server/express.js +21ms
  obojobo_server:info  Registering OboNode: ObojoboDraft.Chunks.MCAssessment +6ms
  obojobo_server:info  Registering OboNode: ObojoboDraft.Chunks.MCAssessment.MCChoice +0ms
  obojobo_server:info  Registering OboNode: ObojoboDraft.Chunks.QuestionBank +1ms
  obojobo_server:info  Registering OboNode: ObojoboDraft.Chunks.Question +1ms
  obojobo_server:info  Registering OboNode: ObojoboDraft.Sections.Assessment +0ms
```