### PR TITLE
Fix non-failing test warnings

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/Viewer/stores/assessment-store.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/stores/assessment-store.test.js
@@ -1504,7 +1504,7 @@ describe('AssessmentStore', () => {
 		AssessmentAPI.resumeAttempt.mockResolvedValueOnce(mockResumeAttemptResponse)
 
 		jest.spyOn(AssessmentStore, 'updateStateAfterStartAttempt')
-		jest.spyOn(AssessmentStore, 'startAttemptWithImportScoreOption')
+		jest.spyOn(AssessmentStore, 'startAttemptWithImportScoreOption').mockImplementation(jest.fn())
 		jest.spyOn(AssessmentStore, 'findUnfinishedAttemptInAssessmentSummary')
 
 		AssessmentStore.updateStateAfterStartAttempt.mockReturnValueOnce()
@@ -1571,7 +1571,7 @@ describe('AssessmentStore', () => {
 	})
 
 	test('onCloseUpdatedModuleDialog restarts attempt with same id', () => {
-		jest.spyOn(AssessmentStore, 'startAttemptWithImportScoreOption')
+		jest.spyOn(AssessmentStore, 'startAttemptWithImportScoreOption').mockImplementation(jest.fn())
 
 		AssessmentStore.onCloseUpdatedModuleDialog('mock-id')
 


### PR DESCRIPTION
Resolves #1667 

Ian got most of the ones listed on the main issue, this fixes the last assessment store one. I ended up just doing the `.mockImplementation(jest.fn())` fix instead of something with `.mockResolvedValue()` since the resolved value isn't used in the tests producing the warnings at all.