### PR TITLE
Increases cache time for module icons

### DIFF
--- a/packages/app/obojobo-repository/server/routes/library.js
+++ b/packages/app/obojobo-repository/server/routes/library.js
@@ -28,6 +28,7 @@ router
 
 // Module Images
 router.route('/library/module-icon/:moduleId').get((req, res) => {
+	res.set('Cache-control', 'public, max-age=31536000')
 	// @TODO: when user's can change these images,
 	// we'll need to use a smarter etag
 


### PR DESCRIPTION
Despite previous efforts to implement eTags for cache, the browser still needed to ask the server if there was a new version every time.  The cache life time header was not set, so this does.  It'll keep the browser from even asking the server about the icon, which should drastically reduce requests