### PR TITLE
Multiple page loading improvements

### DIFF
--- a/packages/app/obojobo-document-engine/setupTests.js
+++ b/packages/app/obojobo-document-engine/setupTests.js
@@ -2,7 +2,7 @@ require('obojobo-lib-utils/test-setup-chunks') // setup enzyme
 
 // Hack to get LaTeX to not warn about quirks mode:
 document.write(
-	'<!DOCTYPE html><body><div id="viewer-app"></div><div id="viewer-app-loading"></div></body>'
+	'<!DOCTYPE html><body><div id="viewer-app"></div><div id="app-loading"></div></body>'
 )
 
 // Externals:

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/editor-app.js
@@ -282,7 +282,10 @@ class EditorApp extends React.Component {
 		}
 
 		return this.reloadDraft(draftId, this.state.mode)
-			.then(() => this.startRenewEditLockInterval(draftId))
+			.then(() => {
+				this.removeLoadingNotice()
+				this.startRenewEditLockInterval(draftId)
+			})
 			.then(() => {
 				enableWindowCloseDispatcher()
 				Dispatcher.on('window:closeNow', this.onWindowClose)
@@ -293,6 +296,13 @@ class EditorApp extends React.Component {
 				Dispatcher.on('window:returnFromInactive', this.onWindowReturnFromInactive)
 			})
 			.catch(() => {})
+	}
+
+	removeLoadingNotice() {
+		const loadingEl = document.getElementById('app-loading')
+		if (loadingEl && loadingEl.parentElement) {
+			loadingEl.parentElement.removeChild(loadingEl)
+		}
 	}
 
 	onWindowClose() {

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -247,7 +247,7 @@ export default class ViewerApp extends React.Component {
 	componentDidUpdate(prevProps, prevState) {
 		// remove loading element
 		if (prevState.loading && !this.state.loading) {
-			const loadingEl = document.getElementById('viewer-app-loading')
+			const loadingEl = document.getElementById('app-loading')
 			if (loadingEl && loadingEl.parentElement) {
 				document.getElementById('viewer-app').classList.add('is-loaded')
 				loadingEl.parentElement.removeChild(loadingEl)

--- a/packages/app/obojobo-document-engine/src/scss/main.scss
+++ b/packages/app/obojobo-document-engine/src/scss/main.scss
@@ -46,7 +46,7 @@ body {
 	}
 }
 
-#viewer-app-loading {
+#app-loading {
 	background: $color-bg;
 	box-sizing: border-box;
 	width: 14em;

--- a/packages/app/obojobo-express/server/views/editor.ejs
+++ b/packages/app/obojobo-express/server/views/editor.ejs
@@ -22,28 +22,27 @@
 			let fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap']
 		%>
 		<%- include('./partials/head', {title, css, headerJs, fonts}) %>
+		<%
+		if (typeof footerJs !== 'undefined')
+		{
+			footerJs.forEach(function(href) { %>
+			<script defer src="<%= href %>"></script>
+			<% })
+		}
+	%>
 </head>
 
 <body>
 	<div id="editor-app" style="opacity: 100;"></div>
-	<%
-		if (typeof inlines !== 'undefined')
-		{
-			inlines.forEach(function(inline)
-			{ %>
-		<script><% - js %></script>
-		<% })
-		}
-		if (typeof footerJs !== 'undefined')
-		{
-			footerJs.forEach(function(href) { %>
-			<script src="<%= href %>"></script>
-			<% })
-		}
-	%>
+	<div id="app-loading">
+		<%- include('./partials/loading', {loadingMessage: 'Module Editor'}) %>
+	</div>
 	<script>
-		var settings = <%- JSON.stringify(settings) %>
-		window.__oboEditorRender(settings)
+		const settings = <%- JSON.stringify(settings) %>
+		Object.freeze(settings)
+		document.addEventListener('DOMContentLoaded', () => {
+			window.__oboEditorRender(settings)
+		})
 	</script>
 </body>
 

--- a/packages/app/obojobo-express/server/views/editor.ejs
+++ b/packages/app/obojobo-express/server/views/editor.ejs
@@ -19,7 +19,7 @@
 				'//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.13.1/katex.min.js',
 				webpackAssetPath('editor.js')
 			]
-			let fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i']
+			let fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap']
 		%>
 		<%- include('./partials/head', {title, css, headerJs, fonts}) %>
 </head>

--- a/packages/app/obojobo-express/server/views/partials/head.ejs
+++ b/packages/app/obojobo-express/server/views/partials/head.ejs
@@ -13,7 +13,7 @@
 
 	if (typeof fonts !== 'undefined'){
 		fonts.forEach(function(font){ -%>
-		<link rel="stylesheet" media="screen" href="<%= font %>" />
+		<link rel="preload" as="style" media="screen" href="<%= font %>" />
 		<% })
 	}
 

--- a/packages/app/obojobo-express/server/views/partials/loading.ejs
+++ b/packages/app/obojobo-express/server/views/partials/loading.ejs
@@ -5,7 +5,7 @@
 </div>
 <span class="loading-label">Loading</span>
 <span class="draft-title">
-	<%= draftTitle %>
+	<%= loadingMessage %>
 </span>
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
  width="253px" height="64.577px" viewBox="0 0 253 64.577" enable-background="new 0 0 253 64.577" xml:space="preserve" fill="black">

--- a/packages/app/obojobo-express/server/views/viewer.ejs
+++ b/packages/app/obojobo-express/server/views/viewer.ejs
@@ -18,30 +18,22 @@
 			const fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap']
 		%>
 		<%- include('./partials/head', {title, css, fonts, headerJs}) %>
+		<%
+		if (typeof footerJs !== 'undefined')
+		{
+			footerJs.forEach(function(href) { %>
+			<script defer src="<%= href %>"></script>
+			<% })
+		}
+	%>
 </head>
 
 <body>
 	<div id="viewer-app"></div>
-	<div id="viewer-app-loading">
-		<%- include('./partials/loading') %>
+	<div id="app-loading">
+		<%- include('./partials/loading', {loadingMessage: draftTitle}) %>
 	</div>
-	<%
-		if (typeof inlines !== 'undefined')
-		{
-			inlines.forEach(function(inline)
-			{ %>
-		<script><% - js %></script>
-		<% })
-		}
-
-		if (typeof footerJs !== 'undefined')
-		{
-			footerJs.forEach(function(href) { %>
-			<script src="<%= href %>"></script>
-			<% })
-		}
-	%>
-				<script>window.__oboViewerRender()</script>
+	<script>document.addEventListener('DOMContentLoaded', () => {window.__oboViewerRender()})</script>
 </body>
 
 </html>

--- a/packages/app/obojobo-express/server/views/viewer.ejs
+++ b/packages/app/obojobo-express/server/views/viewer.ejs
@@ -15,7 +15,7 @@
 				assetForEnv('//cdnjs.cloudflare.com/ajax/libs/backbone.js/1.3.3/backbone$[-min].js'),
 				webpackAssetPath('viewer.js')
 			]
-			const fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i']
+			const fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap']
 		%>
 		<%- include('./partials/head', {title, css, fonts, headerJs}) %>
 </head>

--- a/packages/app/obojobo-module-selector/server/views/module-selector.ejs
+++ b/packages/app/obojobo-module-selector/server/views/module-selector.ejs
@@ -15,6 +15,14 @@
 			const fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:300,400,700&display=swap']
 		%>
 		<%- include('../../../obojobo-express/server/views/partials/head', {title, css, fonts}) %>
+		<%
+			if (typeof footerJs !== 'undefined')
+			{
+				footerJs.forEach(function(href) { %>
+					<script defer src="<%= href %>"></script>
+				<% })
+			}
+		%>
 	</head>
 	<body>
 		<section id="section-options">
@@ -179,25 +187,8 @@
 			<input type="hidden" name="data" value="<%= opaqueData %>" />
 		</form>
 
-
 		<script type="text/javascript">
 			window.__isAssignment = <%= isAssignment ? 'true' : 'false' %>
 		</script>
-
-		<%
-			if (typeof inlines !== 'undefined')
-			{
-				inlines.forEach(function(inline)
-				{ %>
-			<script><% - js %></script>
-			<% })
-			}
-			if (typeof footerJs !== 'undefined')
-			{
-				footerJs.forEach(function(href) { %>
-				<script src="<%= href %>"></script>
-				<% })
-			}
-		%>
 	</body>
 </html>

--- a/packages/app/obojobo-module-selector/server/views/module-selector.ejs
+++ b/packages/app/obojobo-module-selector/server/views/module-selector.ejs
@@ -12,7 +12,7 @@
 				webpackAssetPath('module-selector.js')
 			]
 
-			const fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:300,400,700']
+			const fonts = ['//fonts.googleapis.com/css?family=Libre+Franklin:300,400,700&display=swap']
 		%>
 		<%- include('../../../obojobo-express/server/views/partials/head', {title, css, fonts}) %>
 	</head>

--- a/packages/app/obojobo-repository/shared/components/layouts/default.jsx
+++ b/packages/app/obojobo-repository/shared/components/layouts/default.jsx
@@ -19,7 +19,7 @@ const LayoutDefault = props => (
 			<link
 				rel="stylesheet"
 				media="screen"
-				href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i"
+				href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap"
 			/>
 			{props.headerJs.map((url, index) => (
 				<script key={index} src={url}></script>

--- a/packages/app/obojobo-repository/shared/components/layouts/default.jsx
+++ b/packages/app/obojobo-repository/shared/components/layouts/default.jsx
@@ -25,6 +25,27 @@ const LayoutDefault = props => (
 			{props.headerJs.map((url, index) => (
 				<script key={index} src={url}></script>
 			))}
+			{props.appScriptUrl ? (
+				<React.Fragment>
+					<script
+						referrerPolicy="no-referrer"
+						crossOrigin="anonymous"
+						defer
+						src={`//unpkg.com/react@${reactVersion}/umd/react.${
+							props.isDev ? 'development' : 'production.min'
+						}.js`}
+					></script>
+					<script
+						referrerPolicy="no-referrer"
+						crossOrigin="anonymous"
+						defer
+						src={`//unpkg.com/react-dom@${reactVersion}/umd/react-dom.${
+							props.isDev ? 'development' : 'production.min'
+						}.js`}
+					></script>
+					<script defer src={props.appScriptUrl}></script>
+				</React.Fragment>
+			) : null}
 		</head>
 		<body className={props.className}>
 			<div className="layout--wrapper">
@@ -33,25 +54,6 @@ const LayoutDefault = props => (
 					<Footer />
 				</div>
 			</div>
-			{props.appScriptUrl ? (
-				<React.Fragment>
-					<script
-						referrerPolicy="no-referrer"
-						crossOrigin="anonymous"
-						src={`//unpkg.com/react@${reactVersion}/umd/react.${
-							props.isDev ? 'development' : 'production.min'
-						}.js`}
-					></script>
-					<script
-						referrerPolicy="no-referrer"
-						crossOrigin="anonymous"
-						src={`//unpkg.com/react-dom@${reactVersion}/umd/react-dom.${
-							props.isDev ? 'development' : 'production.min'
-						}.js`}
-					></script>
-					<script src={props.appScriptUrl}></script>
-				</React.Fragment>
-			) : null}
 		</body>
 	</html>
 )

--- a/packages/app/obojobo-repository/shared/components/layouts/default.jsx
+++ b/packages/app/obojobo-repository/shared/components/layouts/default.jsx
@@ -17,7 +17,8 @@ const LayoutDefault = props => (
 			/>
 			{props.appCSSUrl ? <link rel="stylesheet" media="screen" href={props.appCSSUrl} /> : null}
 			<link
-				rel="stylesheet"
+				rel="preload"
+				as="style"
 				media="screen"
 				href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap"
 			/>

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-error.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-error.test.js.snap
@@ -19,7 +19,7 @@ exports[`PageError renders when given props 1`] = `
       name="viewport"
     />
     <link
-      href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i"
+      href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap"
       media="screen"
       rel="stylesheet"
     />

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-error.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-error.test.js.snap
@@ -19,9 +19,10 @@ exports[`PageError renders when given props 1`] = `
       name="viewport"
     />
     <link
+      as="style"
       href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap"
       media="screen"
-      rel="stylesheet"
+      rel="preload"
     />
   </head>
   <body

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-homepage.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-homepage.test.js.snap
@@ -21,7 +21,7 @@ exports[`PageHomepage renders when given props 1`] = `
       name="viewport"
     />
     <link
-      href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i"
+      href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap"
       media="screen"
       rel="stylesheet"
     />

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-homepage.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-homepage.test.js.snap
@@ -21,9 +21,10 @@ exports[`PageHomepage renders when given props 1`] = `
       name="viewport"
     />
     <link
+      as="style"
       href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap"
       media="screen"
-      rel="stylesheet"
+      rel="preload"
     />
   </head>
   <body

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-login.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-login.test.js.snap
@@ -21,9 +21,10 @@ exports[`PageLogin renders when given props 1`] = `
       name="viewport"
     />
     <link
+      as="style"
       href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap"
       media="screen"
-      rel="stylesheet"
+      rel="preload"
     />
   </head>
   <body

--- a/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-login.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/pages/__snapshots__/page-login.test.js.snap
@@ -21,7 +21,7 @@ exports[`PageLogin renders when given props 1`] = `
       name="viewport"
     />
     <link
-      href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i"
+      href="//fonts.googleapis.com/css?family=Libre+Franklin:400,400i,700,700i,900,900i|Roboto+Mono:400,400i,700,700i|Noto+Serif:400,400i,700,700i&display=swap"
       media="screen"
       rel="stylesheet"
     />


### PR DESCRIPTION
* font `display: swap` avoids the browser displaying no text while font tags are loading.
* Uses `rel=preload` option to allow browser to load fonts and can prevent font repainting.
* editor inherited the viewer's initial loading animation, partial, and css
* script tags at bottom of pages moved to top and now using defer (can speed up time to render)
* inline js options removed from templates as they were not used