### PR TITLE
Added a fixed height to dashboard icons

### DIFF
--- a/packages/app/obojobo-repository/shared/components/module-image.scss
+++ b/packages/app/obojobo-repository/shared/components/module-image.scss
@@ -2,4 +2,5 @@
 
 .repository--module-icon--image {
 	filter: saturate(2);
+	height: 10em;
 }


### PR DESCRIPTION
Now it looks like this:

![obo](https://user-images.githubusercontent.com/39862359/115416383-bdcead80-a1c5-11eb-816f-c8b977f5f14c.gif)

Fixes #1771 