### PR TITLE
Removes style bleeding effecting buttons in details menu for items in mc assessment nodes

### DIFF
--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/__snapshots__/editor-component.test.js.snap
@@ -54,6 +54,7 @@ exports[`MCAssessment Editor Node MCAssessment builds the expected component 1`]
     className="choices-container"
   >
     <div
+      className="obojobo-draft--chunks--mc-assessment--choice-button-container"
       contentEditable={false}
     >
       <div

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/editor-component.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/editor-component.js
@@ -91,7 +91,10 @@ class MCAssessment extends React.Component {
 				</div>
 				<div className="choices-container">
 					{this.props.children}
-					<div contentEditable={false}>
+					<div
+						contentEditable={false}
+						className="obojobo-draft--chunks--mc-assessment--choice-button-container"
+					>
 						<Button className={'choice-button'} onClick={this.addChoice}>
 							{'+ Add possible answer'}
 						</Button>

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/editor-component.scss
@@ -6,13 +6,10 @@
 	padding-bottom: 0;
 	margin-top: 0;
 
-	> div {
-		> .choice-button {
+	.obojobo-draft--chunks--mc-assessment--choice-button-container {
+		.choice-button {
 			background: $color-bg2;
 			width: 100%;
-		}
-
-		.obojobo-draft--components--button {
 			padding-top: 1rem;
 			padding-bottom: 1rem;
 			display: block;


### PR DESCRIPTION
Fixes #1806 