### PR TITLE
Feature Flags

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/common/util/__snapshots__/feature-flags.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/common/util/__snapshots__/feature-flags.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FeatureFlags Constructs as expected 1`] = `
+FeatureFlags {
+  "ENABLED": "enabled",
+}
+`;

--- a/packages/app/obojobo-document-engine/__tests__/common/util/feature-flags.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/common/util/feature-flags.test.js
@@ -1,0 +1,115 @@
+import FeatureFlags from '../../../src/scripts/common/util/feature-flags'
+import mockConsole from 'jest-mock-console'
+
+describe('FeatureFlags', () => {
+	let restoreConsole
+
+	beforeEach(() => {
+		restoreConsole = mockConsole('error')
+	})
+
+	afterEach(() => {
+		FeatureFlags.clearAll()
+		restoreConsole()
+	})
+
+	test('Constructs as expected', () => {
+		expect(FeatureFlags).toMatchSnapshot()
+	})
+
+	test('set sets the string value into localStorage', () => {
+		expect(window.localStorage['obojobo:flags']).toBeUndefined()
+		expect(FeatureFlags.set('mockName', 123)).toBe(true)
+		expect(JSON.parse(window.localStorage['obojobo:flags'])).toEqual({ mockName: '123' })
+	})
+
+	test('get gets the value from localStorage', () => {
+		FeatureFlags.set('mockName', 'mockValue')
+		expect(FeatureFlags.get('mockName')).toBe('mockValue')
+	})
+
+	test('is returns true if the feature flag at flagName is equal to the given value', () => {
+		FeatureFlags.set('mockName', 123)
+		expect(FeatureFlags.is('someOtherKey', '123')).toBe(false)
+		expect(FeatureFlags.is('mockName', 123)).toBe(true)
+		expect(FeatureFlags.is('mockName', '123')).toBe(true)
+	})
+
+	test('list returns the contents of all feature flags', () => {
+		expect(FeatureFlags.list()).toEqual({})
+		FeatureFlags.set('mockName', 'mockValue')
+		expect(FeatureFlags.list()).toEqual({ mockName: 'mockValue' })
+	})
+
+	test('clear will clear out a feature flag', () => {
+		FeatureFlags.set('alpha', '42')
+		FeatureFlags.set('beta', '0')
+		expect(JSON.parse(window.localStorage['obojobo:flags'])).toEqual({ alpha: '42', beta: '0' })
+
+		FeatureFlags.clear('alpha')
+		expect(JSON.parse(window.localStorage['obojobo:flags'])).toEqual({ beta: '0' })
+		expect(FeatureFlags.list()).toEqual({ beta: '0' })
+	})
+
+	test('clearAll will remove all feature flags', () => {
+		FeatureFlags.set('alpha', '42')
+		FeatureFlags.set('beta', '0')
+		expect(JSON.parse(window.localStorage['obojobo:flags'])).toEqual({ alpha: '42', beta: '0' })
+
+		FeatureFlags.clearAll()
+		expect(window.localStorage['obojobo:flags']).toBeUndefined()
+		expect(FeatureFlags.list()).toEqual({})
+	})
+
+	test('Writing a bad feature flag fails as expected, deletes all flags', () => {
+		FeatureFlags.set('alpha', '42')
+		FeatureFlags.set('beta', '0')
+		expect(JSON.parse(window.localStorage['obojobo:flags'])).toEqual({ alpha: '42', beta: '0' })
+
+		const originalJSON = JSON
+		window.JSON = {
+			stringify: () => {
+				throw 'mockError'
+			}
+		}
+
+		expect(FeatureFlags.set('gamma', '0')).toBe(false)
+
+		expect(console.error).toHaveBeenCalledWith('Unable to save feature flags: mockError')
+		expect(FeatureFlags.list()).toEqual({})
+		expect(window.localStorage['obojobo:flags']).toBeUndefined()
+
+		window.JSON = originalJSON
+	})
+
+	test('Clearing a flag deletes all flags if there is an error', () => {
+		FeatureFlags.set('alpha', '42')
+		FeatureFlags.set('beta', '0')
+
+		const originalJSON = JSON
+		window.JSON = {
+			stringify: () => {
+				throw 'mockError'
+			}
+		}
+
+		expect(FeatureFlags.clear('gamma')).toBe(false)
+
+		expect(console.error).toHaveBeenCalledWith('Unable to save feature flags: mockError')
+		expect(FeatureFlags.list()).toEqual({})
+		expect(window.localStorage['obojobo:flags']).toBeUndefined()
+
+		window.JSON = originalJSON
+	})
+
+	test('When getting a feature flag fails all flags are deleted', () => {
+		window.localStorage['obojobo:flags'] = '{This will cause a JSON.parse error!'
+
+		FeatureFlags.constructor()
+
+		expect(console.error).toHaveBeenCalledWith(
+			'Unable to parse feature flags: SyntaxError: Unexpected token T in JSON at position 1'
+		)
+		expect(window.localStorage['obojobo:flags']).toBeUndefined()
+	})
+})

--- a/packages/app/obojobo-document-engine/src/scripts/common/util/feature-flags.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/util/feature-flags.js
@@ -1,3 +1,36 @@
+/*
+Defines an API for users and the codebase to get, set and clear feature flags.
+It is intentionally kept very basic - Flags are key value pairs where both key and value are strings
+only.
+Feature flags are kept in localStorage as encoded JSON. If at any time the JSON can't be parsed and
+there's an error then all set flags are deleted to return to a clean slate, so that there are no
+issues with bad feature flag settings stopping Obojobo from running.
+It is expected that this API will be exposed to the user via window.
+
+Usage examples:
+
+Expose this singleton to the user:
+	window.obojobo.flags = FeatureFlags
+
+How a user would interact with this in a javascript console (examples):
+	obojobo.flags.set('experimental.darkMode', obojobo.flags.ENABLED)
+	> true
+
+	obojobo.flags.list()
+	> { "experimental.darkMode": "enabled" }
+
+	obojobo.flags.clear('experimental.darkMode')
+	> true
+
+	obojobo.flags.list()
+	> {}
+
+How to incorporate into your code:
+	const FEATURE_FLAG_DARK_MODE = 'experimental.darkMode'
+	// ...
+	if(FeatureFlags.is(FEATURE_FLAG_DARK_MODE, FeatureFlags.ENABLED)) { ... }
+*/
+
 const LOCAL_STORAGE_FLAGS_KEY = 'obojobo:flags'
 
 const writeFlagsToLocalStorage = flags => {
@@ -7,6 +40,7 @@ const writeFlagsToLocalStorage = flags => {
 
 		return true
 	} catch (e) {
+		//eslint-disable-next-line no-console
 		console.error('Unable to save feature flags: ' + e)
 		delete window.localStorage[LOCAL_STORAGE_FLAGS_KEY]
 
@@ -22,6 +56,7 @@ const getFlagsFromLocalStorage = () => {
 			return JSON.parse(localStorageFlags)
 		}
 	} catch (e) {
+		//eslint-disable-next-line no-console
 		console.error('Unable to parse feature flags: ' + e)
 		delete window.localStorage[LOCAL_STORAGE_FLAGS_KEY]
 	}
@@ -36,6 +71,9 @@ class FeatureFlags {
 		flags = getFlagsFromLocalStorage()
 	}
 
+	// Sets the flag flagName to the value flagValue.
+	// flagValue must be a string, if not it will be converted to a string
+	// Returns true if the value was written, false otherwise
 	set(flagName, flagValue) {
 		const newFlags = { ...flags, [flagName]: '' + flagValue }
 
@@ -48,6 +86,7 @@ class FeatureFlags {
 		return false
 	}
 
+	// Returns the value of flagName, or null if it doesn't exist
 	get(flagName) {
 		const value = flags[flagName]
 
@@ -58,14 +97,17 @@ class FeatureFlags {
 		return value
 	}
 
+	// Returns true if the value of flagName is value
 	is(flagName, value) {
 		return this.get(flagName) === '' + value
 	}
 
+	// Returns a copy of the value of all flags in memory
 	list() {
 		return { ...flags }
 	}
 
+	// Clears the value of flagName, returning true if successful
 	clear(flagName) {
 		const newFlags = { ...flags }
 		delete newFlags[flagName]
@@ -79,6 +121,7 @@ class FeatureFlags {
 		return false
 	}
 
+	// Clears all flags, returning true if successful
 	clearAll() {
 		flags = {}
 		delete window.localStorage[LOCAL_STORAGE_FLAGS_KEY]

--- a/packages/app/obojobo-document-engine/src/scripts/common/util/feature-flags.js
+++ b/packages/app/obojobo-document-engine/src/scripts/common/util/feature-flags.js
@@ -1,0 +1,94 @@
+const LOCAL_STORAGE_FLAGS_KEY = 'obojobo:flags'
+
+const writeFlagsToLocalStorage = flags => {
+	try {
+		const string = JSON.stringify(flags)
+		window.localStorage[LOCAL_STORAGE_FLAGS_KEY] = string
+
+		return true
+	} catch (e) {
+		console.error('Unable to save feature flags: ' + e)
+		delete window.localStorage[LOCAL_STORAGE_FLAGS_KEY]
+
+		return false
+	}
+}
+
+const getFlagsFromLocalStorage = () => {
+	try {
+		const localStorageFlags = window.localStorage[LOCAL_STORAGE_FLAGS_KEY]
+
+		if (typeof localStorageFlags !== 'undefined') {
+			return JSON.parse(localStorageFlags)
+		}
+	} catch (e) {
+		console.error('Unable to parse feature flags: ' + e)
+		delete window.localStorage[LOCAL_STORAGE_FLAGS_KEY]
+	}
+
+	return {}
+}
+
+let flags = {}
+
+class FeatureFlags {
+	constructor() {
+		flags = getFlagsFromLocalStorage()
+	}
+
+	set(flagName, flagValue) {
+		const newFlags = { ...flags, [flagName]: '' + flagValue }
+
+		if (writeFlagsToLocalStorage(newFlags)) {
+			flags = newFlags
+			return true
+		}
+
+		flags = {}
+		return false
+	}
+
+	get(flagName) {
+		const value = flags[flagName]
+
+		if (typeof value === 'undefined') {
+			return null
+		}
+
+		return value
+	}
+
+	is(flagName, value) {
+		return this.get(flagName) === '' + value
+	}
+
+	list() {
+		return { ...flags }
+	}
+
+	clear(flagName) {
+		const newFlags = { ...flags }
+		delete newFlags[flagName]
+
+		if (writeFlagsToLocalStorage(newFlags)) {
+			flags = newFlags
+			return true
+		}
+
+		flags = {}
+		return false
+	}
+
+	clearAll() {
+		flags = {}
+		delete window.localStorage[LOCAL_STORAGE_FLAGS_KEY]
+
+		return true
+	}
+}
+
+const featureFlags = new FeatureFlags()
+
+featureFlags.ENABLED = 'enabled'
+
+export default featureFlags

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/app.js
@@ -1,6 +1,6 @@
 import Common from 'obojobo-document-engine/src/scripts/common'
 import Editor from './index'
-
+import FeatureFlags from 'obojobo-document-engine/src/scripts/common/util/feature-flags'
 import React from 'react'
 import ReactDOM from 'react-dom'
 
@@ -26,6 +26,11 @@ if (ie) {
 } else {
 	window.onfocus = onFocus
 	window.onblur = onBlur
+}
+
+// Expose an obojobo object:
+window.obojobo = {
+	flags: FeatureFlags
 }
 
 window.__oboEditorRender = (settings = {}) => {

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/app.js
@@ -1,5 +1,6 @@
 import Common from 'obojobo-document-engine/src/scripts/common'
 import Viewer from 'obojobo-document-engine/src/scripts/viewer'
+import FeatureFlags from 'obojobo-document-engine/src/scripts/common/util/feature-flags'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import './polyfills'
@@ -23,6 +24,11 @@ const onBlur = function() {
 
 window.onfocus = onFocus
 window.onblur = onBlur
+
+// Expose an obojobo object:
+window.obojobo = {
+	flags: FeatureFlags
+}
 
 window.__oboViewerRender = () => {
 	ReactDOM.render(


### PR DESCRIPTION
Implements #1814 

Users would turn on a flag by using a javascript console and do something like
```js
obojobo.flags.set('experimental.darkMode', obojobo.flags.ENABLED)
```

`obojobo.flags.ENABLED` === `FeatureFlags.ENABLED` === `"enabled"`. All values for the flags are always strings, just to keep things simple and easy to wrap your head around.

We would use it in the codebase like this
```js
const FEATURE_FLAG_DARK_MODE = 'experimental.darkMode'
// ...
if(FeatureFlags.is(FEATURE_FLAG_DARK_MODE, FeatureFlags.ENABLED)) { ... }
```

These flags are kept in localStorage - in the above example localStorage would look like this:

```js
{
  "obojobo:flags": "{\"experimental.darkMode\":\"enabled\"}"
}
```

If the localStorage "database" was ever corrupted it would be reset to a clean slate so as not to pose any issues with the app loading or running.