### PR TITLE
Fix duplicate nested score action pages being created

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/util/keydown-util.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/util/keydown-util.test.js
@@ -365,7 +365,11 @@ describe('KeyDown Util', () => {
 			children: [
 				{
 					type: HEADING_NODE,
-					children: [{ text: 'someText' }]
+					children: [
+						{ text: 'someText' },
+						{ children: [{ text: 'and' }] },
+						{ text: 'someMoreText' }
+					]
 				}
 			],
 			selection: {

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/util/keydown-util.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/util/keydown-util.js
@@ -3,6 +3,14 @@ import { Text, Editor, Transforms, Range, Path, Element, Point, Node } from 'sla
 const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
 const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
 
+const getOnlyTextNodes = node => {
+	if (Text.isText(node)) {
+		return node
+	}
+
+	return node.children.flatMap(getOnlyTextNodes)
+}
+
 const KeyDownUtil = {
 	deleteNodeContents: (event, editor, entry, deleteForward) => {
 		const [, nodePath] = entry
@@ -94,6 +102,7 @@ const KeyDownUtil = {
 			focus: endPoint
 		}
 		const newTexts = Node.fragment(editor, textRange)
+
 		const newNode = {
 			type: TEXT_NODE,
 			content: { triggers: [] },
@@ -102,7 +111,7 @@ const KeyDownUtil = {
 					type: TEXT_NODE,
 					subtype: TEXT_LINE_NODE,
 					content: { indent: 0, align: 'left' },
-					children: [...newTexts[0].children]
+					children: getOnlyTextNodes(newTexts[0])
 				}
 			]
 		}


### PR DESCRIPTION
Fixes #1689 

The issue: If you make a new empty module, go to the score action page and then focus in somewhere in the Retry Assessment button, then hit enter, a nested duplicate score action page is created.

The reason: Buttons use the breakToText method in KeyboardUtil. Normally hitting enter in a node causes slate to duplicate and split that node. In this case you'd get two Buttons. But this is overridden with breakToText, which turns the second sibling node into a regular Text Chunk node. The issue is that the newly created Text Chunk node is given children which, normally, is just a text node like `{ text:'abc' }`, but in the score action page is actually a whole Score Action node.

The solution: Find all of the text nodes of the split sibling child and put those as the children of the newly created Text Chunk. In the case of the score action page, that means it will find the leaf `{ text:'abc' }` type nodes and use those rather than nest a whole Score Actions node.