### PR TITLE
Fixes convert-if-list to work in any nested structure

### DIFF
--- a/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
+++ b/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
@@ -10,7 +10,7 @@ const convertIfList = function(entry, editor, event) {
 	const nodeRange = Editor.range(editor, nodePath)
 	const cursor = editor.selection
 	const cursorOffset = cursor.anchor.offset
-	const nodeIdx = cursor.anchor.path[1]
+	const nodeIdx = cursor.anchor.path[cursor.anchor.path.length - 2]
 	const nodeStr = node.children[nodeIdx].children[0].text
 	const listPrefix = nodeStr.substring(0, cursorOffset)
 


### PR DESCRIPTION
Fixes #1819 

The automatic list creation when typing "*" or "2. " (for example) was breaking inside Questions. The `nodeIdx` variable was hardcoded to look for the second item in the path. I changed this to look at the second from last item in the path, which should make it work in any nested node structure.