### PR TITLE
Dashboard group selecting behavior fixes

### DIFF
--- a/packages/app/obojobo-repository/shared/components/dashboard.jsx
+++ b/packages/app/obojobo-repository/shared/components/dashboard.jsx
@@ -157,9 +157,10 @@ function Dashboard(props) {
 	}
 
 	const deleteModules = draftIds => {
+		// eslint-disable-next-line no-alert, no-undef
 		const response = prompt(
 			`Are you sure you want to DELETE these ${draftIds.length} selected modules? Type 'DELETE' to confirm.`
-		) //eslint-disable-line no-alert, no-undef
+		)
 		if (response !== 'DELETE') return
 		props.bulkDeleteModules(draftIds)
 	}
@@ -172,8 +173,14 @@ function Dashboard(props) {
 			const expires = new Date()
 			expires.setFullYear(expires.getFullYear() + 1)
 			document.cookie = `sortOrder=${sortOrder}; expires=${expires.toUTCString()}; path=/dashboard`
+			setLastSelectedIndex(0)
 		}, [sortOrder])
 	}
+
+	useEffect(() => {
+		// Reset last selected index when leaving multi-select mode
+		if (!props.multiSelectMode) setLastSelectedIndex(0)
+	}, [props.multiSelectMode])
 
 	useEffect(() => {
 		document.addEventListener('keyup', onKeyUp)


### PR DESCRIPTION
Based on #1824

The last selected index is now reset when the sort order changes and when leaving multi-select mode, which should resolve the weird group selecting behavior that we found.