### PR TITLE
Limit iframe text length

### DIFF
--- a/packages/obonode/obojobo-chunks-iframe/editor-component.js
+++ b/packages/obonode/obojobo-chunks-iframe/editor-component.js
@@ -71,8 +71,6 @@ class IFrame extends React.Component {
 	}
 
 	getTitle(src, title) {
-		const charLimit = 50
-
 		if (src === null) {
 			return 'IFrame missing src attribute'
 		} else if (title) {
@@ -80,6 +78,7 @@ class IFrame extends React.Component {
 		}
 
 		const displayedTitle = src.replace(/^https?:\/\//, '')
+		const charLimit = 50
 
 		if (displayedTitle.length > charLimit) {
 			return displayedTitle.substring(0, charLimit) + '...'

--- a/packages/obonode/obojobo-chunks-iframe/editor-component.js
+++ b/packages/obonode/obojobo-chunks-iframe/editor-component.js
@@ -71,13 +71,21 @@ class IFrame extends React.Component {
 	}
 
 	getTitle(src, title) {
+		const charLimit = 50
+
 		if (src === null) {
 			return 'IFrame missing src attribute'
 		} else if (title) {
 			return title
 		}
 
-		return src.replace(/^https?:\/\//, '')
+		const displayedTitle = src.replace(/^https?:\/\//, '')
+
+		if (displayedTitle.length > charLimit) {
+			return displayedTitle.substring(0, charLimit) + '...'
+		}
+
+		return displayedTitle
 	}
 
 	deleteNode() {

--- a/packages/obonode/obojobo-chunks-iframe/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-iframe/editor-component.test.js
@@ -79,6 +79,35 @@ describe('IFrame Editor Node', () => {
 		expect(component.toJSON()).toMatchSnapshot()
 	})
 
+	test('IFrame renders with long src and no title correctly', () => {
+		const component = renderer.create(
+			<IFrame
+				element={{
+					content: {
+						width: 200,
+						height: 200,
+						controls: '',
+						border: false,
+						initialZoom: 1,
+						src: 'mockVeryLongSrcThatHasManyCharsAndExceedsTheMaxDisplaySize'
+					}
+				}}
+				selected
+				parent={{
+					getPath: () => ({
+						get: () => 0
+					}),
+					nodes: {
+						size: 2
+					}
+				}}
+			/>
+		)
+
+		const title = component.root.findByType('span')
+		expect(title.children[0]).toBe('mockVeryLongSrcThatHasManyCharsAndExceedsTheMaxDis...')
+	})
+
 	test('IFrame component deletes self', () => {
 		const component = mount(
 			<IFrame

--- a/packages/obonode/obojobo-chunks-iframe/render-settings.js
+++ b/packages/obonode/obojobo-chunks-iframe/render-settings.js
@@ -29,13 +29,21 @@ const getControlsOptions = modelState => {
 }
 
 const getDisplayedTitle = modelState => {
+	const charLimit = 50
+
 	if (modelState.src === null) {
 		return 'IFrame missing src attribute'
 	} else if (modelState.title) {
 		return modelState.title
 	}
 
-	return (modelState.src || '').replace(/^https?:\/\//, '')
+	const displayedTitle = (modelState.src || '').replace(/^https?:\/\//, '')
+
+	if (displayedTitle.length > charLimit) {
+		return displayedTitle.substring(0, charLimit) + '...'
+	}
+
+	return displayedTitle
 }
 
 const getAriaRegionLabel = (modelState, displayedTitle) => {

--- a/packages/obonode/obojobo-chunks-iframe/render-settings.js
+++ b/packages/obonode/obojobo-chunks-iframe/render-settings.js
@@ -29,8 +29,6 @@ const getControlsOptions = modelState => {
 }
 
 const getDisplayedTitle = modelState => {
-	const charLimit = 50
-
 	if (modelState.src === null) {
 		return 'IFrame missing src attribute'
 	} else if (modelState.title) {
@@ -38,6 +36,7 @@ const getDisplayedTitle = modelState => {
 	}
 
 	const displayedTitle = (modelState.src || '').replace(/^https?:\/\//, '')
+	const charLimit = 50
 
 	if (displayedTitle.length > charLimit) {
 		return displayedTitle.substring(0, charLimit) + '...'

--- a/packages/obonode/obojobo-chunks-iframe/render-settings.test.js
+++ b/packages/obonode/obojobo-chunks-iframe/render-settings.test.js
@@ -267,6 +267,9 @@ describe('render-settings', () => {
 		expect(t({ src: 'src', title: null })).toBe('src')
 		expect(t({ src: 'src', title: 'title' })).toBe('title')
 		expect(t({ src: false, title: null })).toBe('')
+		expect(
+			t({ src: 'mockVeryLongSrcThatHasManyCharsAndExceedsTheMaxDisplaySize', title: null })
+		).toBe('mockVeryLongSrcThatHasManyCharsAndExceedsTheMaxDis...')
 	})
 
 	test('getAriaRegionLabel', () => {


### PR DESCRIPTION
Fixes #1837 

I limited the length to 50 characters, which I chose somewhat arbitrarily, so let me know if another max length is preferred.