### PR TITLE
adds onClick to submit custom color input

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/assets/color-picker.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/assets/color-picker.js
@@ -157,7 +157,11 @@ const ColorPicker = props => {
 						onChange={onChangeColorValue}
 						placeholder="#000000"
 					/>
-					<Button className="ok-button" disabled={userColorString !== '' && safeColorString === ''}>
+					<Button
+						className="ok-button"
+						disabled={userColorString !== '' && safeColorString === ''}
+						onClick={onSubmit}
+					>
 						OK
 					</Button>
 				</form>


### PR DESCRIPTION
Fixes #1825 

Seems like the issue was just that the OK button didn't have an `onClick` even though it was within the form, should properly update the text color now.