### PR TITLE
Removes unnecessary comma from IFrame controls

### DIFF
--- a/packages/obonode/obojobo-chunks-iframe/iframe-properties-modal.js
+++ b/packages/obonode/obojobo-chunks-iframe/iframe-properties-modal.js
@@ -93,7 +93,7 @@ class IFrameProperties extends React.Component {
 	}
 
 	handleControlChange(property, event) {
-		const controls = new Set(this.state.controls.split(','))
+		const controls = new Set(this.state.controls.split(',').filter(control => control !== ''))
 
 		// Use checked value to determine the control string for the changed property
 		// Use controlList values to determine control strings for unchanged properties

--- a/packages/obonode/obojobo-chunks-iframe/iframe-properties-modal.test.js
+++ b/packages/obonode/obojobo-chunks-iframe/iframe-properties-modal.test.js
@@ -294,7 +294,7 @@ describe('IFrame Properties Modal', () => {
 
 		// execute that switch's onChange
 		autoloadSwitch.props.onChange({ target: { checked: true } })
-		expect(testInstance.instance.state.controls).toBe(',reload')
+		expect(testInstance.instance.state.controls).toBe('reload')
 
 		// capture the changes
 		const endState = testRenderer.toJSON()


### PR DESCRIPTION
Fixes #1710 

It only removes the comma on update, so you'll have to update the controls in the properties modal for the extra comma to disappear.