### PR TITLE
Page jumping when answering a question

### DIFF
--- a/packages/obonode/obojobo-chunks-question/viewer-component.js
+++ b/packages/obonode/obojobo-chunks-question/viewer-component.js
@@ -452,7 +452,7 @@ export default class Question extends React.Component {
 			case FOCUS_TARGET_RESULTS:
 				if (this.getScore() !== null) {
 					delete this.nextFocus
-					focus(this.resultsRef.current, false)
+					focus(this.resultsRef.current, true)
 				}
 				break
 


### PR DESCRIPTION
Resolves #1808

Swapped `preventScroll` to `true` when answering a question, so it should no longer jump around but still change focus properly.