### PR TITLE
WIP - Adds floating images

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.js
@@ -230,7 +230,7 @@ class Node extends React.Component {
 			.className || ''}`
 
 		return (
-			<div className={className} data-obo-component="true">
+			<div className={className} data-obo-component="true" data-type={this.props.element.type}>
 				{this.props.selected ? (
 					<div className={'component-toolbar'}>
 						<InsertMenu

--- a/packages/app/obojobo-document-engine/src/scss/main.scss
+++ b/packages/app/obojobo-document-engine/src/scss/main.scss
@@ -136,7 +136,6 @@ body {
 	overflow-wrap: break-word;
 	position: relative;
 	white-space: pre-wrap;
-	width: 100%;
 	word-wrap: break-word;
 	margin: 0 auto;
 	padding-top: 1em;

--- a/packages/obonode/obojobo-chunks-figure/adapter.js
+++ b/packages/obonode/obojobo-chunks-figure/adapter.js
@@ -22,6 +22,12 @@ const Adapter = {
 		])
 		model.setStateProp('width', null, p => parseInt(p, 10))
 		model.setStateProp('height', null, p => parseInt(p, 10))
+		model.setStateProp('align', 'center', p => p.toLowerCase(), [
+			'left-wrap',
+			'center',
+			'right-wrap'
+		])
+		// model.setStateProp('wrap', 'no-wrap', p => p.toLowerCase(), ['no-wrap', 'wrap'])
 		model.setStateProp('alt', null)
 		model.setStateProp('captionWidth', ImageCaptionWidthTypes.IMAGE_WIDTH, p => p.toLowerCase(), [
 			ImageCaptionWidthTypes.IMAGE_WIDTH,
@@ -30,6 +36,7 @@ const Adapter = {
 
 		if (model.modelState.size === 'large' || model.modelState.size === 'medium') {
 			model.modelState.captionWidth = ImageCaptionWidthTypes.IMAGE_WIDTH
+			model.modelState.align = 'center'
 		}
 	},
 

--- a/packages/obonode/obojobo-chunks-figure/converter.js
+++ b/packages/obonode/obojobo-chunks-figure/converter.js
@@ -28,7 +28,8 @@ const slateToObo = node => {
 			size: node.content.size,
 			width: node.content.width,
 			height: node.content.height,
-			captionWidth: node.content.captionWidth
+			captionWidth: node.content.captionWidth,
+			align: node.content.align
 		})
 	}
 }
@@ -46,6 +47,11 @@ const oboToSlate = node => {
 		slateNode.children = [{ text: '' }]
 	} else {
 		slateNode.children = node.content.textGroup.flatMap(line => TextUtil.parseMarkings(line))
+	}
+
+	if (node.content.size === 'large' || node.content.size === 'medium') {
+		node.content.captionWidth = null
+		node.content.align = null
 	}
 
 	return slateNode

--- a/packages/obonode/obojobo-chunks-figure/editor-component.scss
+++ b/packages/obonode/obojobo-chunks-figure/editor-component.scss
@@ -1,5 +1,13 @@
 @import '~styles/includes';
 
+.component[data-type='ObojoboDraft.Chunks.Figure'].is-selected {
+	&.is-align-left-wrap,
+	&.is-align-right-wrap {
+		overflow: visible;
+		float: inherit;
+	}
+}
+
 .obojobo-draft--chunks--figure {
 	.accessibility-warning {
 		font-family: $font-default;

--- a/packages/obonode/obojobo-chunks-figure/image-properties-modal.js
+++ b/packages/obonode/obojobo-chunks-figure/image-properties-modal.js
@@ -34,6 +34,7 @@ class ImageProperties extends React.Component {
 		this.focusOnFirstElement = this.focusOnFirstElement.bind(this)
 		this.handleAltTextChange = this.handleAltTextChange.bind(this)
 		this.handleCaptionWidthChange = this.handleCaptionWidthChange.bind(this)
+		this.handleAlignChange = this.handleAlignChange.bind(this)
 		this.onOpenChoosingImageModal = this.onOpenChoosingImageModal.bind(this)
 	}
 
@@ -47,6 +48,12 @@ class ImageProperties extends React.Component {
 		const captionWidth = event.target.value
 
 		this.setState({ captionWidth })
+	}
+
+	handleAlignChange(event) {
+		const align = event.target.value
+
+		this.setState({ align })
 	}
 
 	handleWidthTextChange(event) {
@@ -68,7 +75,8 @@ class ImageProperties extends React.Component {
 			size,
 			width: null,
 			height: null,
-			captionWidth: size === 'small' || size === 'custom' ? this.state.captionWidth : null
+			captionWidth: size === 'small' || size === 'custom' ? this.state.captionWidth : null,
+			align: size === 'small' || size === 'custom' ? this.state.align : null
 		})
 	}
 
@@ -110,6 +118,7 @@ class ImageProperties extends React.Component {
 		const size = this.state.size
 		const isCaptionWidthOptionAvailable =
 			this.state.size === 'small' || this.state.size === 'custom'
+		const isAlignAvailable = this.state.size === 'small' || this.state.size === 'custom'
 
 		return (
 			<SimpleDialog
@@ -172,6 +181,26 @@ class ImageProperties extends React.Component {
 									<option value={ImageCaptionWidthTypes.TEXT_WIDTH}>
 										Allow caption to extend past the image width
 									</option>
+								</React.Fragment>
+							) : (
+								<option>--</option>
+							)}
+						</select>
+
+						<label className="align-label" htmlFor="obojobo-draft--chunks--figure--align">
+							Align:
+						</label>
+						<select
+							id="obojobo-draft--chunks--figure--align"
+							value={this.state.align || 'center'}
+							onChange={this.handleAlignChange}
+							disabled={!isAlignAvailable}
+						>
+							{isAlignAvailable ? (
+								<React.Fragment>
+									<option value={'left-wrap'}>Left (Wrap)</option>
+									<option value={'center'}>Center</option>
+									<option value={'right-wrap'}>Right (Wrap)</option>
 								</React.Fragment>
 							) : (
 								<option>--</option>

--- a/packages/obonode/obojobo-chunks-figure/viewer-component.js
+++ b/packages/obonode/obojobo-chunks-figure/viewer-component.js
@@ -31,7 +31,11 @@ const Figure = props => {
 	}
 
 	return (
-		<OboComponent model={props.model} moduleData={props.moduleData}>
+		<OboComponent
+			model={props.model}
+			moduleData={props.moduleData}
+			className={`is-align-${props.model.modelState.align}`}
+		>
 			<NonEditableChunk
 				className={`obojobo-draft--chunks--figure viewer ${props.model.modelState.size}`}
 			>

--- a/packages/obonode/obojobo-chunks-figure/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-figure/viewer-component.scss
@@ -1,5 +1,57 @@
 @import '~styles/includes';
 
+@include mq($from: tablet) {
+	.component[data-type='ObojoboDraft.Chunks.Figure'] {
+		&.is-align-left-wrap,
+		&.is-align-right-wrap {
+			clear: both;
+			z-index: $z-index-above-all;
+			overflow: auto;
+			padding-bottom: 0.5em;
+		}
+
+		&.is-align-left-wrap {
+			float: left;
+
+			.obojobo-draft--chunks--figure {
+				padding-right: 1.5em;
+
+				&.custom {
+					padding-left: 3em;
+
+					@include mq($until: desktop) {
+						padding-left: 3em * 0.75;
+					}
+
+					@include mq($until: tablet) {
+						padding-left: 3em * 0.3;
+					}
+				}
+			}
+		}
+
+		&.is-align-right-wrap {
+			float: right;
+
+			.obojobo-draft--chunks--figure {
+				padding-left: 1.5em;
+
+				&.custom {
+					padding-right: 3em;
+
+					@include mq($until: desktop) {
+						padding-right: 3em * 0.75;
+					}
+
+					@include mq($until: tablet) {
+						padding-right: 3em * 0.3;
+					}
+				}
+			}
+		}
+	}
+}
+
 .obojobo-draft--chunks--figure {
 	text-align: center;
 

--- a/packages/obonode/obojobo-chunks-iframe/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-iframe/viewer-component.scss
@@ -1,6 +1,9 @@
 @import '~styles/includes';
 
 .obojobo-draft--chunks--iframe {
+	// Cancel any floating elements:
+	clear: both;
+
 	display: block;
 	font-size: 1em;
 	margin: 0 auto;

--- a/packages/obonode/obojobo-chunks-materia/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-materia/viewer-component.scss
@@ -1,6 +1,9 @@
 @import '~styles/includes';
 
 .obojobo-draft--chunks--materia {
+	// Cancel any floating elements:
+	clear: both;
+
 	display: block;
 	font-size: 1em;
 	margin: 0 auto;

--- a/packages/obonode/obojobo-chunks-question-bank/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-question-bank/viewer-component.scss
@@ -1,6 +1,9 @@
 @import '~styles/includes';
 
 .obojobo-draft--chunks--question-bank {
+	// Cancel any floating elements:
+	clear: both;
+
 	position: relative;
 	width: auto;
 	margin: 0.3em;

--- a/packages/obonode/obojobo-chunks-question/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-question/viewer-component.scss
@@ -1,6 +1,9 @@
 @import '~styles/includes';
 
 .obojobo-draft--chunks--question {
+	// Cancel any floating elements:
+	clear: both;
+
 	perspective: 1000px;
 	margin: 0 auto;
 

--- a/packages/obonode/obojobo-chunks-table/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-table/viewer-component.scss
@@ -1,5 +1,10 @@
 @import '~styles/includes';
 
+.obojobo-draft--chunks--table {
+	// Cancel any floating elements:
+	clear: both;
+}
+
 .obojobo-draft--chunks--table.viewer {
 	> .container {
 		// This allows auto-width tables with really long strings of text to still fit within the viewer

--- a/packages/obonode/obojobo-chunks-youtube/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-youtube/viewer-component.scss
@@ -1,6 +1,9 @@
 @import '~styles/includes';
 
 .obojobo-draft--chunks--you-tube {
+	// Cancel any floating elements:
+	clear: both;
+
 	display: block;
 	margin: 1em auto;
 	position: relative;


### PR DESCRIPTION
Allows you to set align to Figures to get text to wrap around. The values for align are "center" (default), then "left-wrap" and "right-wrap". This was done because "left" and "right" when used for Math Equation do not wrap text around, and I'd like for left and right align to be consistent across chunks. In the future we could add "left-wrap" and "right-wrap" to Math Equation. I thought about adding a wrap property instead, but I don't think we'll ever want to support center wrap (align="center", wrap="true"), so that didn't make sense to me.

I tried very hard to get the editor to render floating images, but it has all sorts of unsolvable z-index issues. The solution I think will be to change the insert menu to a single menu that is absolutely positioned, but that is an issue for another time (or, we may never want to do this).

Work still to be done:
* Add some sort of indicator in the editor that text will wrap around the image when rendered
* Make the left/center/right align toolbar button work with this
* Chunks that shouldn't wrap around have a new `clear: both` rule added, but maybe this should be changed so by default each chunk has `clear:both` and chunks can opt-in to wrapping somehow.