### PR TITLE
Adds editorconfig, vscode config, and uses prettier inside eslint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = tab
+max_line_length = 100
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["dbaeumer.vscode-eslint", "EditorConfig.EditorConfig", "streetsidesoftware.code-spell-checker"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "eslint.validate": ["javascript"]
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"projects": [
 			"<rootDir>/packages/*/*",
 			{
-				"runner": "jest-runner-eslint/watch-fix",
+				"runner": "jest-runner-eslint",
 				"displayName": "lint",
 				"testMatch": [
 					"<rootDir>/packages/*/*/**/*.js"
@@ -53,6 +53,7 @@
 				]
 			}
 		],
+		"watchPlugins": ["jest-runner-eslint/watch-fix"],
 		"transformIgnorePatterns": [
 			"<rootDir>.*(node_modules)(?!.*obojobo-.*).*$"
 		],
@@ -63,6 +64,11 @@
 				"lines": 100,
 				"statements": 100
 			}
+		}
+	},
+	"jest-runner-eslint": {
+		"cliOptions": {
+			"fix": true
 		}
 	},
 	"workspaces": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"projects": [
 			"<rootDir>/packages/*/*",
 			{
-				"runner": "jest-runner-eslint",
+				"runner": "jest-runner-eslint/watch-fix",
 				"displayName": "lint",
 				"testMatch": [
 					"<rootDir>/packages/*/*/**/*.js"

--- a/packages/util/eslint-config-obojobo/.eslintrc
+++ b/packages/util/eslint-config-obojobo/.eslintrc
@@ -1,5 +1,5 @@
 {
-	"extends": ["eslint:recommended", "plugin:react/recommended"],
+	"extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
 	"settings": {
 		"react": {
 			"version": "16.13.1"
@@ -52,10 +52,14 @@
 		"no-var": "error",
 		"no-with": "error",
 		"prefer-const": "error",
+		"prettier/prettier": "error",
 		"radix": "error",
 		"react/prop-types": 0,
 		"yoda": "error"
 	},
+	"plugins": [
+        "prettier"
+    ],
 	"overrides": [
 		{
 		  "files": ["*.test.js"],

--- a/packages/util/eslint-config-obojobo/package.json
+++ b/packages/util/eslint-config-obojobo/package.json
@@ -12,6 +12,8 @@
 		"precommit": "echo 'not implemented'"
 	},
 	"dependencies": {
-		"eslint-plugin-react": "^7.23.1"
+		"eslint-plugin-react": "^7.23.1",
+		"eslint-config-prettier": "^8.3.0",
+		"eslint-plugin-prettier": "^3.4.0"
 	}
 }

--- a/packages/util/obojobo-lib-utils/prettier.config.js
+++ b/packages/util/obojobo-lib-utils/prettier.config.js
@@ -1,6 +1,5 @@
+// keep in mind that prettier is relying on editorconfig for some settings
 module.exports = {
-	printWidth: 100,
 	semi: false,
-	useTabs: true,
 	singleQuote: true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6124,6 +6124,18 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
+eslint-plugin-prettier@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
+  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react@^7.23.1:
   version "7.23.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.23.1.tgz#f1a2e844c0d1967c822388204a8bc4dee8415b11"
@@ -6529,6 +6541,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -11213,6 +11230,13 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
 prettier@1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
@@ -14281,6 +14305,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-debounce@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-7.0.0.tgz#00a67d23d4fe09905e11145a99278da06c01c880"
+  integrity sha512-4fvxEEs7ztdNMh+c497HAgysdq2+Ascem6EaDANGlCIap1JzqfL03Xw8xkYc2lShfXm4uO6PA6V5zcXN7gJdFA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This standardizes vscode settings, vscode plugins, and better incorporate eslint and prettier together (they can fight w/ each other).  

* Adds editorconfig https://editorconfig.org
* Moves redundant prettier configuration into editorconfig
* adds vscode recommended plugins
* changes config for eslint to incorporate prettier rules and run prettier in --fix mode
* adds vscode eslint  --fix on save settings (which runs prettier now)
* adds jest plugin to run `eslint --fix` by default  when running jest in watch mode
