### PR TITLE
Backspace at start of list converts it to text

### DIFF
--- a/packages/obonode/obojobo-chunks-list/changes/on-backspace.js
+++ b/packages/obonode/obojobo-chunks-list/changes/on-backspace.js
@@ -2,6 +2,8 @@ import { Editor, Transforms, Range, Node } from 'slate'
 
 const LIST_LEVEL_NODE = 'ObojoboDraft.Chunks.List.Level'
 const LIST_LINE_NODE = 'ObojoboDraft.Chunks.List.Line'
+const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
+const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
 
 const onBackspace = (entry, editor, event) => {
 	const [, nodePath] = entry
@@ -13,26 +15,64 @@ const onBackspace = (entry, editor, event) => {
 		})
 	)
 	const [lineNode, linePath] = startLine
+	const cursor = editor.selection
+	const cursorOffset = cursor.anchor.offset
+	const nodeStr = Node.string(lineNode)
 
-	// If we are deleting multiple things or the line is not empty, stop here
+	// If we are deleting multiple things or we are not at the start of the line, stop here
 	// Returning before the preventDefault allows Slate to handle the delete
-	if (!Range.isCollapsed(editor.selection) || Node.string(lineNode) !== '') {
+	if (!Range.isCollapsed(editor.selection) || cursorOffset !== 0) {
 		return
 	}
 
 	// Get the deepest level that contains this line
 	const [listLevel, levelPath] = Editor.parent(editor, linePath)
-	if (listLevel.children.length > 1) return
-
-	event.preventDefault()
-
 	// Get the deepest level that holds the listLevel
 	const [oneLevelUp, oneLevelUpPath] = Editor.parent(editor, levelPath)
 	if (oneLevelUp.subtype === LIST_LEVEL_NODE) {
+		// If we are not at the highest level, lift the current node
 		Transforms.liftNodes(editor, { at: linePath })
+	} else if (linePath[nodePath.length + 1] === 0) {
+		// Else if we are at the first item in the list, remove it
+		// If it has children remove the line, otherwise remove the whole node
+		const deletePath = listLevel.children.length > 1 ? linePath : oneLevelUpPath
+		Transforms.removeNodes(editor, { at: deletePath })
+
+		const isFirstNode = !Editor.before(editor, editor.selection.anchor)
+		const isLastNode = !Editor.after(editor, editor.selection.anchor)
+
+		Transforms.insertNodes(
+			editor,
+			{
+				type: TEXT_NODE,
+				children: [
+					{
+						type: TEXT_NODE,
+						subtype: TEXT_LINE_NODE,
+						content: { align: 0, indent: 0, hangingIndent: false },
+						children: [{ text: nodeStr }]
+					}
+				]
+			},
+			{ at: deletePath }
+		)
+
+		// If the list was the only node on the page, an empty text node is created after removing it
+		// Merge them to remove the extra blank node
+		if (isFirstNode && isLastNode) {
+			Transforms.mergeNodes(editor, editor.selection.anchor)
+		}
+
+		const selectPath = isFirstNode
+			? Editor.before(editor, editor.selection.anchor)
+			: Editor.after(editor, editor.selection.anchor)
+		Transforms.select(editor, { ...selectPath, offset: 0 })
 	} else {
-		Transforms.removeNodes(editor, { at: oneLevelUpPath })
+		// If not at first item in the list, do not preventDefault and let Slate handle the delete
+		return
 	}
+
+	event.preventDefault()
 }
 
 export default onBackspace

--- a/packages/obonode/obojobo-chunks-list/changes/on-backspace.test.js
+++ b/packages/obonode/obojobo-chunks-list/changes/on-backspace.test.js
@@ -1,4 +1,4 @@
-import { Transforms } from 'slate'
+import { Transforms, Editor } from 'slate'
 import { ReactEditor } from 'slate-react'
 jest.mock('slate-react')
 
@@ -7,9 +7,11 @@ import onBackspace from './on-backspace'
 const LIST_NODE = 'ObojoboDraft.Chunks.List'
 const LIST_LEVEL_NODE = 'ObojoboDraft.Chunks.List.Level'
 const LIST_LINE_NODE = 'ObojoboDraft.Chunks.List.Line'
+const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
+const TEXT_LINE_NODE = 'ObojoboDraft.Chunks.Text.TextLine'
 
 describe('On Backspace List', () => {
-	test('onBackspace does nothing if not empty', () => {
+	test('onBackspace does nothing if not at start of node', () => {
 		ReactEditor.findPath.mockReturnValueOnce([0])
 		const editor = {
 			children: [
@@ -35,10 +37,12 @@ describe('On Backspace List', () => {
 				}
 			],
 			selection: {
-				anchor: { path: [0, 0, 0, 0], offset: 0 },
-				focus: { path: [0, 0, 0, 0], offset: 0 }
+				anchor: { path: [0, 0, 0, 0], offset: 3 },
+				focus: { path: [0, 0, 0, 0], offset: 3 }
 			},
-			isVoid: () => false
+			apply: jest.fn(),
+			isVoid: () => false,
+			isInline: () => false
 		}
 		const event = { preventDefault: jest.fn() }
 
@@ -47,7 +51,56 @@ describe('On Backspace List', () => {
 		expect(event.preventDefault).not.toHaveBeenCalled()
 	})
 
-	test('onBackspace does nothing if the containing Level has more than 1 child', () => {
+	test('onBackspace does nothing if not at first list item', () => {
+		ReactEditor.findPath.mockReturnValueOnce([0])
+		const editor = {
+			children: [
+				{
+					id: 'mockKey',
+					type: LIST_NODE,
+					content: {},
+					children: [
+						{
+							type: LIST_NODE,
+							subtype: LIST_LEVEL_NODE,
+							content: {},
+							children: [
+								{
+									type: LIST_NODE,
+									subtype: LIST_LINE_NODE,
+									content: {},
+									children: [{ text: '', b: true }]
+								},
+								{
+									type: LIST_NODE,
+									subtype: LIST_LINE_NODE,
+									content: {},
+									children: [{ text: 'mockList', b: true }]
+								}
+							]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0, 1, 0], offset: 0 },
+				focus: { path: [0, 0, 1, 0], offset: 0 }
+			},
+			apply: jest.fn(),
+			isVoid: () => false,
+			isInline: () => false
+		}
+		const event = { preventDefault: jest.fn() }
+
+		onBackspace([editor.children[0], [0]], editor, event)
+
+		expect(event.preventDefault).not.toHaveBeenCalled()
+	})
+
+	test('onBackspace splits at correct location when the containing Level has more than 1 child', () => {
+		jest.spyOn(Transforms, 'removeNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'insertNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'select').mockReturnValueOnce(true)
 		ReactEditor.findPath.mockReturnValueOnce([0])
 		const editor = {
 			children: [
@@ -82,17 +135,37 @@ describe('On Backspace List', () => {
 				anchor: { path: [0, 0, 0, 0], offset: 0 },
 				focus: { path: [0, 0, 0, 0], offset: 0 }
 			},
-			isVoid: () => false
+			apply: jest.fn(),
+			isVoid: () => false,
+			isInline: () => false
 		}
 		const event = { preventDefault: jest.fn() }
 
 		onBackspace([editor.children[0], [0]], editor, event)
 
-		expect(event.preventDefault).not.toHaveBeenCalled()
+		expect(Transforms.removeNodes).toHaveBeenCalled()
+		expect(Transforms.removeNodes.mock.calls[0][1]).toEqual({ at: [0, 0, 0] })
+
+		expect(Transforms.insertNodes).toHaveBeenCalled()
+		expect(Transforms.insertNodes.mock.calls[0][1]).toEqual({
+			type: TEXT_NODE,
+			children: [
+				{
+					type: TEXT_NODE,
+					subtype: TEXT_LINE_NODE,
+					content: { align: 0, indent: 0, hangingIndent: false },
+					children: [{ text: '' }]
+				}
+			]
+		})
+		expect(Transforms.insertNodes.mock.calls[0][2]).toEqual({ at: [0, 0, 0] })
+
+		expect(Transforms.select).toHaveBeenCalled()
 	})
 
 	test('onBackspace removes nodes at top level', () => {
 		jest.spyOn(Transforms, 'removeNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'select').mockReturnValueOnce(true)
 		ReactEditor.findPath.mockReturnValueOnce([0])
 		const editor = {
 			children: [
@@ -121,7 +194,9 @@ describe('On Backspace List', () => {
 				anchor: { path: [0, 0, 0, 0], offset: 0 },
 				focus: { path: [0, 0, 0, 0], offset: 0 }
 			},
-			isVoid: () => false
+			apply: jest.fn(),
+			isVoid: () => false,
+			isInline: () => false
 		}
 		const event = { preventDefault: jest.fn() }
 
@@ -129,6 +204,53 @@ describe('On Backspace List', () => {
 
 		expect(event.preventDefault).toHaveBeenCalled()
 		expect(Transforms.removeNodes).toHaveBeenCalled()
+	})
+
+	test('onBackspace properly moves selection when not on first node', () => {
+		jest.spyOn(Transforms, 'removeNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'insertNodes').mockReturnValueOnce(true)
+		jest.spyOn(Transforms, 'select').mockReturnValueOnce(true)
+		// Mocks behavior as if it were not the first node
+		jest.spyOn(Editor, 'before').mockReturnValueOnce(true)
+		jest.spyOn(Editor, 'after').mockReturnValueOnce(false)
+		ReactEditor.findPath.mockReturnValueOnce([0])
+		const editor = {
+			children: [
+				{
+					id: 'mockKey2',
+					type: LIST_NODE,
+					content: {},
+					children: [
+						{
+							type: LIST_NODE,
+							subtype: LIST_LEVEL_NODE,
+							content: {},
+							children: [
+								{
+									type: LIST_NODE,
+									subtype: LIST_LINE_NODE,
+									content: {},
+									children: [{ text: '', b: true }]
+								}
+							]
+						}
+					]
+				}
+			],
+			selection: {
+				anchor: { path: [0, 0, 0, 0], offset: 0 },
+				focus: { path: [0, 0, 0, 0], offset: 0 }
+			},
+			apply: jest.fn(),
+			isVoid: () => false,
+			isInline: () => false
+		}
+		const event = { preventDefault: jest.fn() }
+
+		onBackspace([editor.children[0], [0]], editor, event)
+
+		expect(Editor.before).toHaveBeenCalledTimes(1)
+		expect(Editor.after).toHaveBeenCalledTimes(2)
 	})
 
 	test('onBackspace reduces indent', () => {

--- a/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
+++ b/packages/obonode/obojobo-chunks-text/changes/convert-if-list.js
@@ -72,6 +72,9 @@ const convertIfList = function(entry, editor, event) {
 		if (node.children.length === 1) {
 			Transforms.removeNodes(editor, { at: nodePath })
 		}
+
+		// Move cursor to the start of the line
+		Transforms.select(editor, { ...editor.selection.anchor, offset: 0 })
 	}
 }
 


### PR DESCRIPTION
Fixes #1786 

Hitting backspace at the start of the first list item should now convert it to a text node when at the highest level. It'll also make Slate keep the cursor at the start of the node after the conversion instead of at the end. I made a slight modification to `convert-if-list` as well to do the same as I noticed it would put the cursor at the end of the line, which seemed unexpected.