### PR TITLE
Allow empty XML style tags when saving

### DIFF
--- a/packages/app/obojobo-document-xml-parser/__tests__/src/text-group-parser.test.js
+++ b/packages/app/obojobo-document-xml-parser/__tests__/src/text-group-parser.test.js
@@ -145,4 +145,17 @@ describe('TextGroup parser', () => {
 
 		expect(parsed[0].text.value).toBe('')
 	})
+
+	test('Handles missing text item', () => {
+		setTextGroupElements([
+			{
+				name: 'sup',
+				value: undefined
+			}
+		])
+
+		const parsed = textGroupParser(textGroup)
+
+		expect(parsed[0].text.value).toBe('')
+	})
 })

--- a/packages/app/obojobo-document-xml-parser/src/text-group-parser.js
+++ b/packages/app/obojobo-document-xml-parser/src/text-group-parser.js
@@ -81,6 +81,7 @@ const parseText = (node, textItem) => {
 
 	textItem.styleList.push(styleRange)
 
+	if (!node.value) node.value = ''
 	for (const value of node.value) {
 		parseText(value, textItem)
 	}


### PR DESCRIPTION
Fixes #1654

I added a check that sets `node.value = ''` if it doesn't already exist, which prevents the saving error from occurring and lets the empty tag get removed when swapping to the JSON/Visual Editor and back.