### PR TITLE
Invalid assessment attempt modal refreshes the page

### DIFF
--- a/packages/obonode/obojobo-sections-assessment/components/__snapshots__/assessment-dialog.test.js.snap
+++ b/packages/obonode/obojobo-sections-assessment/components/__snapshots__/assessment-dialog.test.js.snap
@@ -50,7 +50,7 @@ exports[`AssessmentDialog renders as expected AssessmentDialog(assessmentMachine
           Click close dialog to review and catalog your answers.
         </p>
         <p>
-          When you're ready, click restart to start a new attempt with the updated module
+          When you're ready, click reload to view the updated module before starting a new attempt.
         </p>
       </div>
       <div

--- a/packages/obonode/obojobo-sections-assessment/components/assessment-dialog.js
+++ b/packages/obonode/obojobo-sections-assessment/components/assessment-dialog.js
@@ -48,9 +48,9 @@ const onCloseResultsDialog = assessmentModel => {
 	AssessmentUtil.acknowledgeEndAttemptSuccessful(assessmentModel)
 }
 
-const startAttempt = assessmentModel => {
-	AssessmentUtil.startAttempt(assessmentModel)
-}
+// const startAttempt = assessmentModel => {
+// 	AssessmentUtil.startAttempt(assessmentModel)
+// }
 
 const continueAttempt = assessmentModel => {
 	AssessmentUtil.continueAttempt(assessmentModel)
@@ -234,7 +234,7 @@ const getDialog = (
 					return (
 						<UpdatedModuleDialog
 							onClose={() => acknowledgeEndAttemptFailed(assessmentModel)}
-							onRestart={() => startAttempt(assessmentModel)}
+							onRestart={() => window.location.reload()}
 						/>
 					)
 

--- a/packages/obonode/obojobo-sections-assessment/components/assessment-dialog.test.js
+++ b/packages/obonode/obojobo-sections-assessment/components/assessment-dialog.test.js
@@ -300,17 +300,19 @@ describe('AssessmentDialog renders as expected', () => {
 				}
 			}
 		}
-		const spy = jest.spyOn(AssessmentUtil, 'startAttempt').mockReturnValue({})
+		Object.defineProperty(window, 'location', {
+			value: { reload: jest.fn() }
+		})
 
-		expect(AssessmentUtil.startAttempt).not.toHaveBeenCalled()
+		expect(window.location.reload).not.toHaveBeenCalled()
 
 		const component = renderer.create(<AssessmentDialog {...props} />)
 		const button = component.root.findAllByType('button')[1]
 		button.props.onClick()
 
-		expect(AssessmentUtil.startAttempt).toHaveBeenCalledWith(props.assessmentModel)
+		expect(window.location.reload).toHaveBeenCalled()
 
-		spy.mockRestore()
+		// spy.mockRestore()
 	})
 
 	test('END_ATTEMPT_SUCCESSFUL, clicking ok closes the dialog', () => {

--- a/packages/obonode/obojobo-sections-assessment/components/dialogs/__snapshots__/updated-module-dialog.test.js.snap
+++ b/packages/obonode/obojobo-sections-assessment/components/dialogs/__snapshots__/updated-module-dialog.test.js.snap
@@ -50,7 +50,7 @@ exports[`UpdatedModuleDialog UpdatedModuleDialog component 1`] = `
           Click close dialog to review and catalog your answers.
         </p>
         <p>
-          When you're ready, click restart to start a new attempt with the updated module
+          When you're ready, click reload to view the updated module before starting a new attempt.
         </p>
       </div>
       <div

--- a/packages/obonode/obojobo-sections-assessment/components/dialogs/updated-module-dialog.js
+++ b/packages/obonode/obojobo-sections-assessment/components/dialogs/updated-module-dialog.js
@@ -23,7 +23,9 @@ const UpdatedModuleDialog = ({ onClose, onRestart }) => (
 	>
 		<p>A portion of this module was just updated and unfortunately has to be restarted.</p>
 		<p>Click close dialog to review and catalog your answers.</p>
-		<p>When you&apos;re ready, click restart to start a new attempt with the updated module</p>
+		<p>
+			When you&apos;re ready, click reload to view the updated module before starting a new attempt.
+		</p>
 	</Dialog>
 )
 


### PR DESCRIPTION
Resolves #1657 

Modifies the invalid attempt modal to refresh the page instead of starting an attempt, in case the content in the module has changed in any significant way. In the issue Zach said that he's open to discuss it, so if anyone has any ideas about any other/better solutions I'm open to any and all suggestions.