### PR TITLE
Add support for Materia widgets in assessments.

### DIFF
--- a/packages/app/obojobo-document-engine/src/scss/_includes.scss
+++ b/packages/app/obojobo-document-engine/src/scss/_includes.scss
@@ -15,6 +15,7 @@ $color-bg2: #f4f4f4;
 $color-bg3: #131313;
 $color-action-bg: #f9f4ff;
 $color-correct: #38ae24;
+$color-partially-correct: #ffc802;
 $color-incorrect: #c21f00;
 $color-survey: #48b8b9;
 $color-alt-correct: #ffc802;

--- a/packages/obonode/obojobo-chunks-abstract-assessment/constants.js
+++ b/packages/obonode/obojobo-chunks-abstract-assessment/constants.js
@@ -1,5 +1,6 @@
 const CHOICE_NODE = 'ObojoboDraft.Chunks.AbstractAssessment.Choice'
 const FEEDBACK_NODE = 'ObojoboDraft.Chunks.AbstractAssessment.Feedback'
+const MATERIA_NODE = 'ObojoboDraft.Chunks.Materia'
 
 // Whenever an inheriting component is created
 // Add its Assessment type to the valid assessments, its answer type to valid answers
@@ -16,22 +17,27 @@ import {
 } from 'obojobo-chunks-multiple-choice-assessment/constants'
 import mcAssessment from 'obojobo-chunks-multiple-choice-assessment/empty-node.json'
 
+import materiaAssessment from 'obojobo-chunks-materia/empty-node.json'
+
 const assessmentToAnswer = {
 	[NUMERIC_ASSESSMENT_NODE]: numericAssessment.children[0].children[0],
-	[MC_ASSESSMENT_NODE]: mcAssessment.children[0].children[0]
+	[MC_ASSESSMENT_NODE]: mcAssessment.children[0].children[0],
+	[MATERIA_NODE]: materiaAssessment.children[0]
 }
 
 const answerTypeToJson = {
 	[NUMERIC_ANSWER_NODE]: numericAssessment.children[0].children[0],
-	[MC_ANSWER_NODE]: mcAssessment.children[0].children[0]
+	[MC_ANSWER_NODE]: mcAssessment.children[0].children[0],
+	[MATERIA_NODE]: materiaAssessment.children[0]
 }
 
 const answerToAssessment = {
 	[NUMERIC_ANSWER_NODE]: numericAssessment,
-	[MC_ANSWER_NODE]: mcAssessment
+	[MC_ANSWER_NODE]: mcAssessment,
+	[MATERIA_NODE]: materiaAssessment
 }
 
-const validAssessments = [NUMERIC_ASSESSMENT_NODE, MC_ASSESSMENT_NODE]
+const validAssessments = [NUMERIC_ASSESSMENT_NODE, MC_ASSESSMENT_NODE, MATERIA_NODE]
 const validAnswers = [NUMERIC_ANSWER_NODE, MC_ANSWER_NODE]
 
 export {

--- a/packages/obonode/obojobo-chunks-materia/index.js
+++ b/packages/obonode/obojobo-chunks-materia/index.js
@@ -7,6 +7,7 @@ module.exports = {
 		clientScripts: {
 			viewer: 'viewer.js',
 			editor: 'editor.js'
-		}
+		},
+		serverScripts: ['server/materiaassessment']
 	}
 }

--- a/packages/obonode/obojobo-chunks-materia/server/index.js
+++ b/packages/obonode/obojobo-chunks-materia/server/index.js
@@ -2,6 +2,7 @@ const router = require('express').Router() //eslint-disable-line new-cap
 const logger = require('obojobo-express/server/logger')
 const uuid = require('uuid').v4
 const bodyParser = require('body-parser')
+const db = require('obojobo-express/server/db')
 const oboEvents = require('obojobo-express/server/obo_events')
 const Visit = require('obojobo-express/server/models/visit')
 const Draft = require('obojobo-express/server/models/draft')
@@ -208,6 +209,29 @@ router
 		})
 
 		renderLtiLaunch(launchParams, method, endpoint, res)
+	})
+
+router
+	.route('/materia-lti-score-verify')
+	.get([requireCurrentUser, requireCurrentVisit])
+	.get(async (req, res) => {
+		await db.one(
+		`SELECT payload
+		FROM events
+		WHERE action = 'materia:ltiScorePassback'
+		AND visit_id = $[visitId]
+		AND payload->>'lisResultSourcedId' = $[resourceId]
+		ORDER BY created_at DESC
+		LIMIT 1`,
+		{
+			visitId: req.currentVisit.id,
+			resourceId: `${req.currentVisit.id}__${req.query.nodeId}`
+		}).then(result => {
+			res.send({
+				score: result.payload.score,
+				success: result.payload.success
+			})
+		})
 	})
 
 module.exports = router

--- a/packages/obonode/obojobo-chunks-materia/server/materiaassessment.js
+++ b/packages/obonode/obojobo-chunks-materia/server/materiaassessment.js
@@ -1,0 +1,22 @@
+const DraftNode = require('obojobo-express/server/models/draft_node')
+
+class NumericAssessment extends DraftNode {
+	static get nodeName() {
+		return 'ObojoboDraft.Chunks.Materia'
+	}
+
+	constructor(draftTree, node, initFn) {
+		super(draftTree, node, initFn)
+		this.registerEvents({
+			'ObojoboDraft.Chunks.Question:calculateScore': this.onCalculateScore
+		})
+	}
+
+	onCalculateScore(app, question, responseRecord, setScore) {
+		if (!question.contains(this.node)) return
+
+		setScore(responseRecord.response.score)
+	}
+}
+
+module.exports = NumericAssessment

--- a/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
+++ b/packages/obonode/obojobo-chunks-materia/server/route-helpers.js
@@ -58,7 +58,7 @@ const widgetLaunchParams = (document, visit, user, materiaOboNodeId, baseUrl) =>
 	}
 
 	// materia currently uses context_id to group scores and attempts
-	// obojobo doesn't support materia as scoreable questions yet, so the key in use here is intended to:
+	// the key in use here is intended to:
 	// * support materia in content pages
 	// * re lti launch will reset scores/attempts
 	// * browser reload of the window will resume an attempt/score window

--- a/packages/obonode/obojobo-chunks-materia/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-materia/viewer-component.scss
@@ -9,12 +9,15 @@
 	.materia-score {
 		display: block;
 		text-align: center;
-		margin: 0 auto;
-		margin-bottom: 2em;
+		margin: -5em auto 0;
 		font-size: 0.7em;
-		opacity: 0.5;
-		margin-top: -3.5em;
+		opacity: 1;
 		z-index: 2;
+		transition: opacity 0.4s;
+
+		&.is-not-verified {
+			opacity: 0;
+		}
 	}
 
 	.label {

--- a/packages/obonode/obojobo-chunks-materia/viewer-component.test.js
+++ b/packages/obonode/obojobo-chunks-materia/viewer-component.test.js
@@ -1,3 +1,20 @@
+jest.mock('obojobo-document-engine/src/scripts/viewer/util/api', () => ({
+	get: jest.fn(),
+	processJsonResults: jest.fn()
+}))
+
+jest.mock('obojobo-document-engine/src/scripts/viewer/util/question-util', () => ({
+	setResponse: jest.fn()
+}))
+
+jest.mock('obojobo-document-engine/src/scripts/viewer', () => ({
+	util: {
+		NavUtil: {
+			getContext: jest.fn().mockReturnValue('mock:module:context')
+		}
+	}
+}))
+
 jest.mock('react-dom')
 jest.mock(
 	'obojobo-chunks-iframe/viewer-component',
@@ -18,6 +35,19 @@ require('./viewer') // used to register this oboModel
 describe('Materia viewer component', () => {
 	let model
 	let moduleData
+	let questionModel
+
+	const flushPromises = global.flushPromises
+	const API = require('obojobo-document-engine/src/scripts/viewer/util/api')
+	const Questionutil = require('obojobo-document-engine/src/scripts/viewer/util/question-util')
+
+	const Viewer = require('obojobo-document-engine/src/scripts/viewer')
+	const { NavUtil } = Viewer.util
+
+	const mockModuleTitle = 'mocked-module-title'
+	const mockVisitId = 'mock-visit-id'
+	const mockNodeId = 'mock-obo-id'
+	const mockQuestionId = 'mock-question-id'
 
 	beforeEach(() => {
 		jest.resetAllMocks()
@@ -26,7 +56,7 @@ describe('Materia viewer component', () => {
 
 		OboModel.__setNextGeneratedLocalId('mock-uuid')
 		model = OboModel.create({
-			id: 'mock-obo-id',
+			id: mockNodeId,
 			type: 'ObojoboDraft.Chunks.Materia',
 			content: {
 				src: 'http://www.example.com'
@@ -35,11 +65,15 @@ describe('Materia viewer component', () => {
 
 		moduleData = {
 			model: {
-				title: 'mocked-module-title'
+				title: mockModuleTitle
 			},
 			navState: {
-				visitId: 'mock-visit-id'
+				visitId: mockVisitId
 			}
+		}
+
+		questionModel = {
+			get: jest.fn().mockReturnValue(mockQuestionId)
 		}
 	})
 
@@ -53,6 +87,11 @@ describe('Materia viewer component', () => {
 		}
 		const component = renderer.create(<Materia {...props} />)
 		expect(component.toJSON()).toMatchSnapshot()
+
+		const inst = component.getInstance()
+		expect(inst.state.model.modelState.src).toBe(
+			`http://localhost/materia-lti-launch?visitId=${mockVisitId}&nodeId=${mockNodeId}`
+		)
 	})
 
 	test('adds and removes listener for postmessage when mounting and unmounting', () => {
@@ -86,7 +125,7 @@ describe('Materia viewer component', () => {
 		)
 	})
 
-	test('onPostMessageFromMateria without an iframe ref doesnt update state', () => {
+	test('onPostMessageFromMateria with an empty iframe ref doesnt update state', () => {
 		expect.hasAssertions()
 		const props = {
 			model,
@@ -102,6 +141,22 @@ describe('Materia viewer component', () => {
 		expect(inst.state).toHaveProperty('score', null)
 	})
 
+	test('onPostMessageFromMateria without an iframe ref object doesnt update state', () => {
+		expect.hasAssertions()
+		const props = {
+			model,
+			moduleData
+		}
+
+		const component = renderer.create(<Materia {...props} />)
+
+		const inst = component.getInstance()
+		inst.iframeRef = null
+		const event = { source: '', data: JSON.stringify({ score: 100 }) }
+		inst.onPostMessageFromMateria(event)
+		expect(inst.state).toHaveProperty('score', null)
+	})
+
 	test('onPostMessageFromMateria without a matching iframe and event source doesnt update state', () => {
 		expect.hasAssertions()
 		const props = {
@@ -112,7 +167,7 @@ describe('Materia viewer component', () => {
 		const component = renderer.create(<Materia {...props} />)
 
 		const inst = component.getInstance()
-		inst.iframeRef = { current: { contentWindow: 'different-mock-window' } }
+		inst.iframeRef = { current: { refs: { iframe: { contentWindow: 'different-mock-window' } } } }
 		const event = { source: 'mock-window', data: JSON.stringify({ score: 100 }) }
 		inst.onPostMessageFromMateria(event)
 		expect(inst.state).toHaveProperty('score', null)
@@ -128,7 +183,9 @@ describe('Materia viewer component', () => {
 		const component = renderer.create(<Materia {...props} />)
 
 		const inst = component.getInstance()
-		inst.iframeRef = { current: { contentWindow: 'http://not-localhost/' } }
+		inst.iframeRef = {
+			current: { refs: { iframe: { contentWindow: 'http://not-localhost/whatever' } } }
+		}
 		const event = { source: 'http://localhost/whatever', data: JSON.stringify({ score: 100 }) }
 		inst.onPostMessageFromMateria(event)
 		expect(inst.state).toHaveProperty('score', null)
@@ -144,7 +201,9 @@ describe('Materia viewer component', () => {
 		const component = renderer.create(<Materia {...props} />)
 
 		const inst = component.getInstance()
-		inst.iframeRef = { current: { contentWindow: 'http://localhost/whatever' } }
+		inst.iframeRef = {
+			current: { refs: { iframe: { contentWindow: 'http://localhost/whatever' } } }
+		}
 		const event = {
 			origin: 'http://not-localhost',
 			source: 'http://localhost/whatever',
@@ -164,7 +223,9 @@ describe('Materia viewer component', () => {
 		const component = renderer.create(<Materia {...props} />)
 
 		const inst = component.getInstance()
-		inst.iframeRef = { current: { contentWindow: 'http://localhost/whatever' } }
+		inst.iframeRef = {
+			current: { refs: { iframe: { contentWindow: 'http://localhost/whatever' } } }
+		}
 		const event = {
 			origin: 'http://localhost',
 			source: 'http://localhost/whatever',
@@ -184,7 +245,9 @@ describe('Materia viewer component', () => {
 		const component = renderer.create(<Materia {...props} />)
 
 		const inst = component.getInstance()
-		inst.iframeRef = { current: { contentWindow: 'http://localhost/whatever' } }
+		inst.iframeRef = {
+			current: { refs: { iframe: { contentWindow: 'http://localhost/whatever' } } }
+		}
 		const event = {
 			origin: 'http://localhost',
 			source: 'http://localhost/whatever',
@@ -194,24 +257,67 @@ describe('Materia viewer component', () => {
 		expect(inst.state).toHaveProperty('score', null)
 	})
 
-	test('onPostMessageFromMateria updates the score', () => {
+	test('onPostMessageFromMateria makes an API call to verify the score', () => {
+		API.get = jest.fn().mockResolvedValue(true)
+		API.processJsonResults = jest.fn().mockResolvedValue({ score: 100, success: true })
+
+		NavUtil.getContext = jest.fn().mockReturnValue('mock:module:context')
+
 		expect.hasAssertions()
 		const props = {
 			model,
-			moduleData
+			moduleData,
+			questionModel
 		}
 
 		const component = renderer.create(<Materia {...props} />)
 
+		// While we're here, make sure the score dialog appears correctly.
+		// It shouldn't exist by default
+		expect(component.root.findAllByProps({ className: 'materia-score verified' }).length).toBe(0)
+
 		const inst = component.getInstance()
-		inst.iframeRef = { current: { contentWindow: 'http://localhost/whatever' } }
+		inst.iframeRef = {
+			current: { refs: { iframe: { contentWindow: 'http://localhost/whatever' } } }
+		}
 		const event = {
 			origin: 'http://localhost',
 			source: 'http://localhost/whatever',
-			data: JSON.stringify({ type: 'materiaScoreRecorded', score: 100 })
+			data: JSON.stringify({
+				type: 'materiaScoreRecorded',
+				score: 100,
+				score_url: 'http://localhost/score'
+			})
 		}
 		inst.onPostMessageFromMateria(event)
-		expect(inst.state).toHaveProperty('score', 100)
+
+		return flushPromises().then(() => {
+			expect(API.get).toHaveBeenCalledTimes(1)
+			expect(API.get).toHaveBeenCalledWith(
+				`/materia-lti-score-verify?visitId=${mockVisitId}&nodeId=${mockNodeId}`,
+				'json'
+			)
+
+			expect(inst.state).toHaveProperty('score', 100)
+
+			expect(Questionutil.setResponse).toHaveBeenCalledTimes(1)
+			expect(Questionutil.setResponse).toHaveBeenCalledWith(
+				mockQuestionId,
+				{
+					score: 100,
+					scoreUrl: 'http://localhost/score',
+					verifiedScore: true
+				},
+				null,
+				'mock:module:context',
+				'module',
+				'context',
+				false
+			)
+
+			const scoreRender = component.root.findByProps({ className: 'materia-score verified' })
+			expect(scoreRender.children.join('')).toBe('Your highest score: 100%')
+		})
 	})
 
 	test('onPostMessageFromMateria handles json parsing errors', () => {
@@ -224,7 +330,9 @@ describe('Materia viewer component', () => {
 		const component = renderer.create(<Materia {...props} />)
 
 		const inst = component.getInstance()
-		inst.iframeRef = { current: { contentWindow: 'http://localhost/whatever' } }
+		inst.iframeRef = {
+			current: { refs: { iframe: { contentWindow: 'http://localhost/whatever' } } }
+		}
 		const event = {
 			origin: 'http://localhost',
 			source: 'http://localhost/whatever',
@@ -320,5 +428,77 @@ describe('Materia viewer component', () => {
 		// find the textGroupEL by a unique prop
 		// it shouldn't render one
 		expect(component.root.findAllByProps({ groupIndex: '0' })).toHaveLength(0)
+	})
+
+	test('rendering in review mode changes the iframe src', () => {
+		const mockScoreUrl = 'http://localhost/url/to/score/screen'
+		const props = {
+			model,
+			moduleData,
+			mode: 'review',
+			response: {
+				scoreUrl: mockScoreUrl
+			}
+		}
+		const component = renderer.create(<Materia {...props} />)
+
+		const inst = component.getInstance()
+
+		expect(inst.state.model.modelState.src).toBe(mockScoreUrl)
+	})
+
+	test('isResponseEmpty returns true if the response score is not verified - does not exist', () => {
+		expect(Materia.isResponseEmpty({})).toBe(true)
+		expect(Materia.isResponseEmpty({ score: 100, verifiedScore: false })).toBe(true)
+	})
+	test('isResponseEmpty returns true if the response score is not verified - false value', () => {
+		expect(Materia.isResponseEmpty({ score: 100, verifiedScore: false })).toBe(true)
+	})
+	test('isResponseEmpty returns false if the response score is verified', () => {
+		expect(Materia.isResponseEmpty({ score: 100, verifiedScore: true })).toBe(false)
+	})
+
+	test('calculateScore returns null when no score is recorded', () => {
+		const props = {
+			model,
+			moduleData
+		}
+		const component = renderer.create(<Materia {...props} />)
+
+		const inst = component.getInstance()
+		expect(inst.calculateScore()).toBe(null)
+	})
+
+	test('calculateScore returns properly when a score is recorded', () => {
+		const mockScore = 90
+
+		const props = {
+			model,
+			moduleData,
+			score: mockScore
+		}
+		const component = renderer.create(<Materia {...props} />)
+
+		const inst = component.getInstance()
+		expect(inst.calculateScore()).toEqual({ score: mockScore, details: null })
+	})
+
+	test('getInstructions returns properly', () => {
+		const props = {
+			model,
+			moduleData
+		}
+		const component = renderer.create(<Materia {...props} />)
+
+		const inst = component.getInstance()
+		const instructionsFragment = renderer.create(inst.getInstructions())
+
+		const fragmentRender = instructionsFragment.root.findByProps({
+			className: 'for-screen-reader-only'
+		})
+		expect(fragmentRender.children[0]).toBe('Embedded Materia widget.')
+		expect(fragmentRender.parent.children[1]).toBe(
+			'Play the embedded Materia widget to receive a score. Your highest score will be saved.'
+		)
 	})
 })

--- a/packages/obonode/obojobo-chunks-question/__snapshots__/adapter.test.js.snap
+++ b/packages/obonode/obojobo-chunks-question/__snapshots__/adapter.test.js.snap
@@ -15,6 +15,11 @@ Object {
     "z",
   ],
   "needsUpdate": false,
+  "partialLabels": Array [
+    "l",
+    "m",
+    "n",
+  ],
   "revealAnswer": "when-incorrect",
   "solution": Object {
     "children": Array [
@@ -58,6 +63,7 @@ Object {
   "editing": false,
   "incorrectLabels": null,
   "needsUpdate": false,
+  "partialLabels": null,
   "revealAnswer": "default",
   "solution": null,
   "type": "default",
@@ -71,6 +77,7 @@ Object {
   "editing": false,
   "incorrectLabels": null,
   "needsUpdate": false,
+  "partialLabels": null,
   "revealAnswer": "default",
   "solution": null,
   "type": "default",
@@ -82,6 +89,7 @@ Object {
   "content": Object {
     "correctLabels": "a|b|c",
     "incorrectLabels": "d|e|f",
+    "partialLabels": null,
     "revealAnswer": "default",
     "solution": Object {
       "children": Array [
@@ -124,6 +132,7 @@ Object {
   "content": Object {
     "correctLabels": null,
     "incorrectLabels": null,
+    "partialLabels": null,
     "revealAnswer": "default",
     "solution": null,
     "type": "default",

--- a/packages/obonode/obojobo-chunks-question/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-question/__snapshots__/editor-component.test.js.snap
@@ -32,6 +32,11 @@ exports[`Question Editor Node Question builds the expected component (not in ass
             >
               Input a number
             </option>
+            <option
+              value="ObojoboDraft.Chunks.Materia"
+            >
+              Materia widget
+            </option>
           </select>
           <label
             className="question-type"
@@ -90,6 +95,11 @@ exports[`Question Editor Node Question builds the expected component 1`] = `
             >
               Input a number
             </option>
+            <option
+              value="ObojoboDraft.Chunks.Materia"
+            >
+              Materia widget
+            </option>
           </select>
           <label
             className="question-type"
@@ -116,7 +126,7 @@ exports[`Question Editor Node Question builds the expected component 1`] = `
 </div>
 `;
 
-exports[`Question Editor Node Question component adds Solution 1`] = `"<div><div class=\\"component obojobo-draft--chunks--question is-viewed pad is-type-default\\"><div class=\\"flipper question-editor\\"><div class=\\"content-back\\"><div class=\\"question-settings\\" contenteditable=\\"false\\"><label>Question Type</label><select contenteditable=\\"false\\"><option value=\\"ObojoboDraft.Chunks.MCAssessment\\">Multiple choice</option><option value=\\"ObojoboDraft.Chunks.NumericAssessment\\">Input a number</option></select><label class=\\"question-type\\" contenteditable=\\"false\\"><input type=\\"checkbox\\">Survey Only</label></div><div class=\\"add-solution-container\\" contenteditable=\\"false\\"><button class=\\"add-solution\\">Add Explanation</button></div></div></div><button class=\\"delete-button\\" contenteditable=\\"false\\">×</button></div></div>"`;
+exports[`Question Editor Node Question component adds Solution 1`] = `"<div><div class=\\"component obojobo-draft--chunks--question is-viewed pad is-type-default\\"><div class=\\"flipper question-editor\\"><div class=\\"content-back\\"><div class=\\"question-settings\\" contenteditable=\\"false\\"><label>Question Type</label><select contenteditable=\\"false\\"><option value=\\"ObojoboDraft.Chunks.MCAssessment\\">Multiple choice</option><option value=\\"ObojoboDraft.Chunks.NumericAssessment\\">Input a number</option><option value=\\"ObojoboDraft.Chunks.Materia\\">Materia widget</option></select><label class=\\"question-type\\" contenteditable=\\"false\\"><input type=\\"checkbox\\">Survey Only</label></div><div class=\\"add-solution-container\\" contenteditable=\\"false\\"><button class=\\"add-solution\\">Add Explanation</button></div></div></div><button class=\\"delete-button\\" contenteditable=\\"false\\">×</button></div></div>"`;
 
 exports[`Question Editor Node Survey Question builds the expected component 1`] = `
 <div>
@@ -149,6 +159,11 @@ exports[`Question Editor Node Survey Question builds the expected component 1`] 
               value="ObojoboDraft.Chunks.NumericAssessment"
             >
               Input a number
+            </option>
+            <option
+              value="ObojoboDraft.Chunks.Materia"
+            >
+              Materia widget
             </option>
           </select>
           <label

--- a/packages/obonode/obojobo-chunks-question/adapter.js
+++ b/packages/obonode/obojobo-chunks-question/adapter.js
@@ -33,6 +33,7 @@ const Adapter = {
 		}
 
 		model.setStateProp('correctLabels', null, p => p.split('|'))
+		model.setStateProp('partialLabels', null, p => p.split('|'))
 		model.setStateProp('incorrectLabels', null, p => p.split('|'))
 	},
 
@@ -40,6 +41,9 @@ const Adapter = {
 		clone.modelState.type = model.modelState.type
 		clone.modelState.correctLabels = model.modelState.correctLabels
 			? model.modelState.correctLabels.slice(0)
+			: null
+		clone.modelState.partialLabels = model.modelState.partialLabels
+			? model.modelState.partialLabels.slice(0)
 			: null
 		clone.modelState.incorrectLabels = model.modelState.incorrectLabels
 			? model.modelState.incorrectLabels.slice(0)
@@ -56,6 +60,9 @@ const Adapter = {
 		json.content.type = model.modelState.type
 		json.content.correctLabels = model.modelState.correctLabels
 			? model.modelState.correctLabels.join('|')
+			: null
+		json.content.partialLabels = model.modelState.partialLabels
+			? model.modelState.partialLabels.join('|')
 			: null
 		json.content.incorrectLabels = model.modelState.incorrectLabels
 			? model.modelState.incorrectLabels.join('|')

--- a/packages/obonode/obojobo-chunks-question/adapter.test.js
+++ b/packages/obonode/obojobo-chunks-question/adapter.test.js
@@ -32,6 +32,7 @@ describe('Question adapter', () => {
 			content: {
 				type: 'default',
 				correctLabels: 'a|b|c',
+				partialLabels: 'l|m|n',
 				incorrectLabels: 'x|y|z',
 				revealAnswer: 'when-incorrect',
 				solution: {
@@ -72,6 +73,7 @@ describe('Question adapter', () => {
 		const attrs = {
 			content: {
 				correctLabels: 'a|b|c',
+				partialLabels: 'l|m|n',
 				incorrectLabels: 'd|e|f'
 			}
 		}
@@ -180,6 +182,19 @@ describe('Question adapter', () => {
 		expect(json).toMatchSnapshot()
 	})
 
+	test('toJSON builds a JSON representation with partial labels', () => {
+		const json = { content: {} }
+		const attrs = {
+			content: {
+				partialLabels: 'l|m|n'
+			}
+		}
+		const model = new OboModel(attrs)
+
+		QuestionAdapter.construct(model, attrs)
+		QuestionAdapter.toJSON(model, json)
+	})
+
 	test('Adapter grabs correctLabels and incorrectLabels from child components', () => {
 		const attrs = {
 			id: 'question',
@@ -192,6 +207,7 @@ describe('Question adapter', () => {
 					type: 'ObojoboDraft.Chunks.MCAssessment',
 					content: {
 						correctLabels: 'd|e|f',
+						partialLabels: 'l|m|n',
 						incorrectLabels: 'x|y|z'
 					},
 					children: []
@@ -211,5 +227,48 @@ describe('Question adapter', () => {
 		expect(model.modelState.incorrectLabels).toEqual(['x', 'y', 'z'])
 
 		spy.mockRestore()
+	})
+
+	test('modelState uses correctLabels from content if MCAssessment child does not have any set', () => {
+		const attrs = {
+			id: 'question',
+			content: {
+				correctLabels: 'a|b|c'
+			},
+			children: [
+				{
+					id: 'mcassessment',
+					type: 'ObojoboDraft.Chunks.MCAssessment',
+					children: []
+				}
+			]
+		}
+
+		const model = new OboModel(attrs)
+		QuestionAdapter.construct(model, attrs)
+
+		expect(model.modelState.correctLabels).toEqual(['a', 'b', 'c'])
+	})
+
+	test('modelState uses correctLabels from MCAssessment child if content does not have any set', () => {
+		const attrs = {
+			id: 'question',
+			content: {},
+			children: [
+				{
+					id: 'mcassessment',
+					type: 'ObojoboDraft.Chunks.MCAssessment',
+					content: {
+						correctLabels: 'd|e|f'
+					},
+					children: []
+				}
+			]
+		}
+
+		const model = new OboModel(attrs)
+		QuestionAdapter.construct(model, attrs)
+
+		expect(model.modelState.correctLabels).toEqual(['d', 'e', 'f'])
 	})
 })

--- a/packages/obonode/obojobo-chunks-question/converter.js
+++ b/packages/obonode/obojobo-chunks-question/converter.js
@@ -6,6 +6,7 @@ const QUESTION_NODE = 'ObojoboDraft.Chunks.Question'
 const SOLUTION_NODE = 'ObojoboDraft.Chunks.Question.Solution'
 const MCASSESSMENT_NODE = 'ObojoboDraft.Chunks.MCAssessment'
 const NUMERIC_ASSESSMENT_NODE = 'ObojoboDraft.Chunks.NumericAssessment'
+const MATERIA_NODE = 'ObojoboDraft.Chunks.Materia'
 const PAGE_NODE = 'ObojoboDraft.Pages.Page'
 
 /**
@@ -32,10 +33,8 @@ const slateToObo = node => {
 				break
 
 			case MCASSESSMENT_NODE:
-				children.push(Common.Registry.getItemForType(child.type).slateToObo(child))
-				break
-
 			case NUMERIC_ASSESSMENT_NODE:
+			case MATERIA_NODE:
 				children.push(Common.Registry.getItemForType(child.type).slateToObo(child))
 				break
 
@@ -64,7 +63,11 @@ const oboToSlate = node => {
 	const clonedNode = JSON.parse(JSON.stringify(node))
 
 	clonedNode.children = clonedNode.children.map(child => {
-		if (child.type === MCASSESSMENT_NODE || child.type === NUMERIC_ASSESSMENT_NODE) {
+		if (
+			child.type === MCASSESSMENT_NODE ||
+			child.type === NUMERIC_ASSESSMENT_NODE ||
+			child.type === MATERIA_NODE
+		) {
 			return Common.Registry.getItemForType(child.type).oboToSlate(child)
 		} else {
 			return Component.helpers.oboToSlate(child)

--- a/packages/obonode/obojobo-chunks-question/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question/editor-component.js
@@ -13,6 +13,7 @@ const QUESTION_NODE = 'ObojoboDraft.Chunks.Question'
 const SOLUTION_NODE = 'ObojoboDraft.Chunks.Question.Solution'
 const MCASSESSMENT_NODE = 'ObojoboDraft.Chunks.MCAssessment'
 const NUMERIC_ASSESSMENT_NODE = 'ObojoboDraft.Chunks.NumericAssessment'
+const MATERIA_NODE = 'ObojoboDraft.Chunks.Materia'
 const ASSESSMENT_NODE = 'ObojoboDraft.Sections.Assessment'
 const PAGE_NODE = 'ObojoboDraft.Pages.Page'
 const TEXT_NODE = 'ObojoboDraft.Chunks.Text'
@@ -195,6 +196,7 @@ class Question extends React.Component {
 								>
 									<option value={MCASSESSMENT_NODE}>Multiple choice</option>
 									<option value={NUMERIC_ASSESSMENT_NODE}>Input a number</option>
+									<option value={MATERIA_NODE}>Materia widget</option>
 								</select>
 								<label className="question-type" contentEditable={false}>
 									<input type="checkbox" checked={isTypeSurvey} onChange={this.onSetType} />

--- a/packages/obonode/obojobo-chunks-question/feedback-labels.js
+++ b/packages/obonode/obojobo-chunks-question/feedback-labels.js
@@ -1,5 +1,7 @@
 const DEFAULT_CORRECT_PRACTICE_LABELS = ['Correct!', 'You got it!', 'Great job!', "That's right!"]
 const DEFAULT_CORRECT_REVIEW_LABELS = ['Correct']
+const DEFAULT_PARTIAL_LABELS = ['Partial Credit']
+const DEFAULT_PARTIAL_REVIEW_LABELS = ['Partial Credit']
 const DEFAULT_INCORRECT_LABELS = ['Incorrect']
 const DEFAULT_INCORRECT_REVIEW_LABELS = ['Incorrect']
 const DEFAULT_SURVEY_LABELS = ['Response recorded']
@@ -46,12 +48,42 @@ const getIncorrectLabels = (incorrectLabels, isReview) => {
 	return DEFAULT_INCORRECT_LABELS
 }
 
-const getLabel = (correctLabels, incorrectLabels, score, isReview, isSurvey, hasResponse) => {
-	return getRandomItem(
-		score === 100 || score === 'no-score'
-			? getCorrectLabels(correctLabels, isReview, isSurvey, hasResponse)
-			: getIncorrectLabels(incorrectLabels, isReview)
-	)
+const getPartialLabels = (partialLabels, isReview) => {
+	if (isReview) {
+		return DEFAULT_PARTIAL_REVIEW_LABELS
+	}
+
+	if (partialLabels) {
+		return partialLabels
+	}
+
+	return DEFAULT_PARTIAL_LABELS
+}
+
+const getLabel = (
+	correctLabels,
+	partialLabels,
+	incorrectLabels,
+	score,
+	isReview,
+	isSurvey,
+	hasResponse
+) => {
+	let labelOptions
+	switch (true) {
+		case score >= 100:
+		case score === 'no-score':
+			labelOptions = getCorrectLabels(correctLabels, isReview, isSurvey, hasResponse)
+			break
+		case score > 0 && score < 100:
+			labelOptions = getPartialLabels(partialLabels, isReview)
+			break
+		case score === 0:
+		default:
+			labelOptions = getIncorrectLabels(incorrectLabels, isReview)
+			break
+	}
+	return getRandomItem(labelOptions)
 }
 
 export { getLabel, getCorrectLabels, getIncorrectLabels }

--- a/packages/obonode/obojobo-chunks-question/feedback-labels.test.js
+++ b/packages/obonode/obojobo-chunks-question/feedback-labels.test.js
@@ -2,143 +2,192 @@ import { getLabel } from './feedback-labels'
 
 describe('feedbackLabels', () => {
 	test.each`
-		correctLabels           | incorrectLabels           | score         | isReview | isSurvey | hasResponse | expectedValue
-		${null}                 | ${null}                   | ${null}       | ${false} | ${false} | ${false}    | ${'Incorrect'}
-		${null}                 | ${null}                   | ${null}       | ${false} | ${false} | ${true}     | ${'Incorrect'}
-		${null}                 | ${null}                   | ${null}       | ${false} | ${true}  | ${false}    | ${'Incorrect'}
-		${null}                 | ${null}                   | ${null}       | ${false} | ${true}  | ${true}     | ${'Incorrect'}
-		${null}                 | ${null}                   | ${null}       | ${true}  | ${false} | ${false}    | ${'Incorrect'}
-		${null}                 | ${null}                   | ${null}       | ${true}  | ${false} | ${true}     | ${'Incorrect'}
-		${null}                 | ${null}                   | ${null}       | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
-		${null}                 | ${null}                   | ${null}       | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
-		${null}                 | ${null}                   | ${0}          | ${false} | ${false} | ${false}    | ${'Incorrect'}
-		${null}                 | ${null}                   | ${0}          | ${false} | ${false} | ${true}     | ${'Incorrect'}
-		${null}                 | ${null}                   | ${0}          | ${false} | ${true}  | ${false}    | ${'Incorrect'}
-		${null}                 | ${null}                   | ${0}          | ${false} | ${true}  | ${true}     | ${'Incorrect'}
-		${null}                 | ${null}                   | ${0}          | ${true}  | ${false} | ${false}    | ${'Incorrect'}
-		${null}                 | ${null}                   | ${0}          | ${true}  | ${false} | ${true}     | ${'Incorrect'}
-		${null}                 | ${null}                   | ${0}          | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
-		${null}                 | ${null}                   | ${0}          | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
-		${null}                 | ${null}                   | ${100}        | ${false} | ${false} | ${false}    | ${'Correct!'}
-		${null}                 | ${null}                   | ${100}        | ${false} | ${false} | ${true}     | ${'Correct!'}
-		${null}                 | ${null}                   | ${100}        | ${false} | ${true}  | ${false}    | ${'Response recorded'}
-		${null}                 | ${null}                   | ${100}        | ${false} | ${true}  | ${true}     | ${'Response recorded'}
-		${null}                 | ${null}                   | ${100}        | ${true}  | ${false} | ${false}    | ${'Correct'}
-		${null}                 | ${null}                   | ${100}        | ${true}  | ${false} | ${true}     | ${'Correct'}
-		${null}                 | ${null}                   | ${100}        | ${true}  | ${true}  | ${false}    | ${'No response given'}
-		${null}                 | ${null}                   | ${100}        | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
-		${null}                 | ${null}                   | ${'no-score'} | ${false} | ${false} | ${false}    | ${'Correct!'}
-		${null}                 | ${null}                   | ${'no-score'} | ${false} | ${false} | ${true}     | ${'Correct!'}
-		${null}                 | ${null}                   | ${'no-score'} | ${false} | ${true}  | ${false}    | ${'Response recorded'}
-		${null}                 | ${null}                   | ${'no-score'} | ${false} | ${true}  | ${true}     | ${'Response recorded'}
-		${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${false} | ${false}    | ${'Correct'}
-		${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${false} | ${true}     | ${'Correct'}
-		${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${true}  | ${false}    | ${'No response given'}
-		${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
-		${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${false} | ${false}    | ${'MockIncorrectLabel'}
-		${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${false} | ${true}     | ${'MockIncorrectLabel'}
-		${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${true}  | ${false}    | ${'MockIncorrectLabel'}
-		${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${true}  | ${true}     | ${'MockIncorrectLabel'}
-		${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${false} | ${false}    | ${'Incorrect'}
-		${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${false} | ${true}     | ${'Incorrect'}
-		${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
-		${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
-		${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${false} | ${false}    | ${'MockIncorrectLabel'}
-		${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${false} | ${true}     | ${'MockIncorrectLabel'}
-		${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${true}  | ${false}    | ${'MockIncorrectLabel'}
-		${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${true}  | ${true}     | ${'MockIncorrectLabel'}
-		${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${false} | ${false}    | ${'Incorrect'}
-		${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${false} | ${true}     | ${'Incorrect'}
-		${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
-		${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
-		${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${false} | ${false}    | ${'Correct!'}
-		${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${false} | ${true}     | ${'Correct!'}
-		${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${true}  | ${false}    | ${'Response recorded'}
-		${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${true}  | ${true}     | ${'Response recorded'}
-		${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${false} | ${false}    | ${'Correct'}
-		${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${false} | ${true}     | ${'Correct'}
-		${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${true}  | ${false}    | ${'No response given'}
-		${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
-		${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${false} | ${false}    | ${'Correct!'}
-		${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${false} | ${true}     | ${'Correct!'}
-		${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${true}  | ${false}    | ${'Response recorded'}
-		${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${true}  | ${true}     | ${'Response recorded'}
-		${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${false} | ${false}    | ${'Correct'}
-		${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${false} | ${true}     | ${'Correct'}
-		${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${true}  | ${false}    | ${'No response given'}
-		${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
-		${['MockCorrectLabel']} | ${null}                   | ${null}       | ${false} | ${false} | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${null}       | ${false} | ${false} | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${null}       | ${false} | ${true}  | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${null}       | ${false} | ${true}  | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${null}       | ${true}  | ${false} | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${null}       | ${true}  | ${false} | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${null}       | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${null}       | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${0}          | ${false} | ${false} | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${0}          | ${false} | ${false} | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${0}          | ${false} | ${true}  | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${0}          | ${false} | ${true}  | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${0}          | ${true}  | ${false} | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${0}          | ${true}  | ${false} | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${0}          | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${0}          | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${null}                   | ${100}        | ${false} | ${false} | ${false}    | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${null}                   | ${100}        | ${false} | ${false} | ${true}     | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${null}                   | ${100}        | ${false} | ${true}  | ${false}    | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${null}                   | ${100}        | ${false} | ${true}  | ${true}     | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${null}                   | ${100}        | ${true}  | ${false} | ${false}    | ${'Correct'}
-		${['MockCorrectLabel']} | ${null}                   | ${100}        | ${true}  | ${false} | ${true}     | ${'Correct'}
-		${['MockCorrectLabel']} | ${null}                   | ${100}        | ${true}  | ${true}  | ${false}    | ${'No response given'}
-		${['MockCorrectLabel']} | ${null}                   | ${100}        | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
-		${['MockCorrectLabel']} | ${null}                   | ${'no-score'} | ${false} | ${false} | ${false}    | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${null}                   | ${'no-score'} | ${false} | ${false} | ${true}     | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${null}                   | ${'no-score'} | ${false} | ${true}  | ${false}    | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${null}                   | ${'no-score'} | ${false} | ${true}  | ${true}     | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${null}                   | ${'no-score'} | ${true}  | ${false} | ${false}    | ${'Correct'}
-		${['MockCorrectLabel']} | ${null}                   | ${'no-score'} | ${true}  | ${false} | ${true}     | ${'Correct'}
-		${['MockCorrectLabel']} | ${null}                   | ${'no-score'} | ${true}  | ${true}  | ${false}    | ${'No response given'}
-		${['MockCorrectLabel']} | ${null}                   | ${'no-score'} | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${false} | ${false}    | ${'MockIncorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${false} | ${true}     | ${'MockIncorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${true}  | ${false}    | ${'MockIncorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${true}  | ${true}     | ${'MockIncorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${false} | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${false} | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${false} | ${false}    | ${'MockIncorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${false} | ${true}     | ${'MockIncorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${true}  | ${false}    | ${'MockIncorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${true}  | ${true}     | ${'MockIncorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${false} | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${false} | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${false} | ${false}    | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${false} | ${true}     | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${true}  | ${false}    | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${true}  | ${true}     | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${false} | ${false}    | ${'Correct'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${false} | ${true}     | ${'Correct'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${true}  | ${false}    | ${'No response given'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${false} | ${false}    | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${false} | ${true}     | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${true}  | ${false}    | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${true}  | ${true}     | ${'MockCorrectLabel'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${false} | ${false}    | ${'Correct'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${false} | ${true}     | ${'Correct'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${true}  | ${false}    | ${'No response given'}
-		${['MockCorrectLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
+		correctLabels           | partialLabels           | incorrectLabels           | score         | isReview | isSurvey | hasResponse | expectedValue
+		${null}                 | ${null}                 | ${null}                   | ${null}       | ${false} | ${false} | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${null}       | ${false} | ${false} | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${null}       | ${false} | ${true}  | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${null}       | ${false} | ${true}  | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${null}       | ${true}  | ${false} | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${null}       | ${true}  | ${false} | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${null}       | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${null}       | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${0}          | ${false} | ${false} | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${0}          | ${false} | ${false} | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${0}          | ${false} | ${true}  | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${0}          | ${false} | ${true}  | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${0}          | ${true}  | ${false} | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${0}          | ${true}  | ${false} | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${0}          | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${0}          | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${null}                   | ${50}         | ${false} | ${false} | ${false}    | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${null}                   | ${50}         | ${false} | ${false} | ${true}     | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${null}                   | ${50}         | ${false} | ${true}  | ${false}    | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${null}                   | ${50}         | ${false} | ${true}  | ${true}     | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${null}                   | ${50}         | ${true}  | ${false} | ${false}    | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${null}                   | ${50}         | ${true}  | ${false} | ${true}     | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${null}                   | ${50}         | ${true}  | ${true}  | ${false}    | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${null}                   | ${50}         | ${true}  | ${true}  | ${true}     | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${null}                   | ${100}        | ${false} | ${false} | ${false}    | ${'Correct!'}
+		${null}                 | ${null}                 | ${null}                   | ${100}        | ${false} | ${false} | ${true}     | ${'Correct!'}
+		${null}                 | ${null}                 | ${null}                   | ${100}        | ${false} | ${true}  | ${false}    | ${'Response recorded'}
+		${null}                 | ${null}                 | ${null}                   | ${100}        | ${false} | ${true}  | ${true}     | ${'Response recorded'}
+		${null}                 | ${null}                 | ${null}                   | ${100}        | ${true}  | ${false} | ${false}    | ${'Correct'}
+		${null}                 | ${null}                 | ${null}                   | ${100}        | ${true}  | ${false} | ${true}     | ${'Correct'}
+		${null}                 | ${null}                 | ${null}                   | ${100}        | ${true}  | ${true}  | ${false}    | ${'No response given'}
+		${null}                 | ${null}                 | ${null}                   | ${100}        | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
+		${null}                 | ${null}                 | ${null}                   | ${'no-score'} | ${false} | ${false} | ${false}    | ${'Correct!'}
+		${null}                 | ${null}                 | ${null}                   | ${'no-score'} | ${false} | ${false} | ${true}     | ${'Correct!'}
+		${null}                 | ${null}                 | ${null}                   | ${'no-score'} | ${false} | ${true}  | ${false}    | ${'Response recorded'}
+		${null}                 | ${null}                 | ${null}                   | ${'no-score'} | ${false} | ${true}  | ${true}     | ${'Response recorded'}
+		${null}                 | ${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${false} | ${false}    | ${'Correct'}
+		${null}                 | ${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${false} | ${true}     | ${'Correct'}
+		${null}                 | ${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${true}  | ${false}    | ${'No response given'}
+		${null}                 | ${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${false} | ${false}    | ${'MockIncorrectLabel'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${false} | ${true}     | ${'MockIncorrectLabel'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${true}  | ${false}    | ${'MockIncorrectLabel'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${true}  | ${true}     | ${'MockIncorrectLabel'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${false} | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${false} | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${false} | ${false}    | ${'MockIncorrectLabel'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${false} | ${true}     | ${'MockIncorrectLabel'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${true}  | ${false}    | ${'MockIncorrectLabel'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${true}  | ${true}     | ${'MockIncorrectLabel'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${false} | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${false} | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${50}         | ${false} | ${false} | ${false}    | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${50}         | ${false} | ${false} | ${true}     | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${50}         | ${false} | ${true}  | ${false}    | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${50}         | ${false} | ${true}  | ${true}     | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${50}         | ${true}  | ${false} | ${false}    | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${50}         | ${true}  | ${false} | ${true}     | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${50}         | ${true}  | ${true}  | ${false}    | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${50}         | ${true}  | ${true}  | ${true}     | ${'Partial Credit'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${false} | ${false}    | ${'Correct!'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${false} | ${true}     | ${'Correct!'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${true}  | ${false}    | ${'Response recorded'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${true}  | ${true}     | ${'Response recorded'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${false} | ${false}    | ${'Correct'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${false} | ${true}     | ${'Correct'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${true}  | ${false}    | ${'No response given'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${false} | ${false}    | ${'Correct!'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${false} | ${true}     | ${'Correct!'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${true}  | ${false}    | ${'Response recorded'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${true}  | ${true}     | ${'Response recorded'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${false} | ${false}    | ${'Correct'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${false} | ${true}     | ${'Correct'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${true}  | ${false}    | ${'No response given'}
+		${null}                 | ${null}                 | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${null}       | ${false} | ${false} | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${null}       | ${false} | ${false} | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${null}       | ${false} | ${true}  | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${null}       | ${false} | ${true}  | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${null}       | ${true}  | ${false} | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${null}       | ${true}  | ${false} | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${null}       | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${null}       | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${0}          | ${false} | ${false} | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${0}          | ${false} | ${false} | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${0}          | ${false} | ${true}  | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${0}          | ${false} | ${true}  | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${0}          | ${true}  | ${false} | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${0}          | ${true}  | ${false} | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${0}          | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${0}          | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${50}         | ${false} | ${false} | ${false}    | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${50}         | ${false} | ${false} | ${true}     | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${50}         | ${false} | ${true}  | ${false}    | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${50}         | ${false} | ${true}  | ${true}     | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${50}         | ${true}  | ${false} | ${false}    | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${50}         | ${true}  | ${false} | ${true}     | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${50}         | ${true}  | ${true}  | ${false}    | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${50}         | ${true}  | ${true}  | ${true}     | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${100}        | ${false} | ${false} | ${false}    | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${100}        | ${false} | ${false} | ${true}     | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${100}        | ${false} | ${true}  | ${false}    | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${100}        | ${false} | ${true}  | ${true}     | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${100}        | ${true}  | ${false} | ${false}    | ${'Correct'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${100}        | ${true}  | ${false} | ${true}     | ${'Correct'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${100}        | ${true}  | ${true}  | ${false}    | ${'No response given'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${100}        | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${'no-score'} | ${false} | ${false} | ${false}    | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${'no-score'} | ${false} | ${false} | ${true}     | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${'no-score'} | ${false} | ${true}  | ${false}    | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${'no-score'} | ${false} | ${true}  | ${true}     | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${false} | ${false}    | ${'Correct'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${false} | ${true}     | ${'Correct'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${true}  | ${false}    | ${'No response given'}
+		${['MockCorrectLabel']} | ${null}                 | ${null}                   | ${'no-score'} | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${false} | ${false}    | ${'MockIncorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${false} | ${true}     | ${'MockIncorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${true}  | ${false}    | ${'MockIncorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${false} | ${true}  | ${true}     | ${'MockIncorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${false} | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${false} | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${null}       | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${false} | ${false}    | ${'MockIncorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${false} | ${true}     | ${'MockIncorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${true}  | ${false}    | ${'MockIncorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${false} | ${true}  | ${true}     | ${'MockIncorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${false} | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${false} | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${true}  | ${false}    | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${0}          | ${true}  | ${true}  | ${true}     | ${'Incorrect'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${50}         | ${false} | ${false} | ${false}    | ${'MockPartialLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${50}         | ${false} | ${false} | ${true}     | ${'MockPartialLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${50}         | ${false} | ${true}  | ${false}    | ${'MockPartialLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${50}         | ${false} | ${true}  | ${true}     | ${'MockPartialLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${50}         | ${true}  | ${false} | ${false}    | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${50}         | ${true}  | ${false} | ${true}     | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${50}         | ${true}  | ${true}  | ${false}    | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${50}         | ${true}  | ${true}  | ${true}     | ${'Partial Credit'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${false} | ${false}    | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${false} | ${true}     | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${true}  | ${false}    | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${false} | ${true}  | ${true}     | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${false} | ${false}    | ${'Correct'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${false} | ${true}     | ${'Correct'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${true}  | ${false}    | ${'No response given'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${100}        | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${false} | ${false}    | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${false} | ${true}     | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${true}  | ${false}    | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${false} | ${true}  | ${true}     | ${'MockCorrectLabel'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${false} | ${false}    | ${'Correct'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${false} | ${true}     | ${'Correct'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${true}  | ${false}    | ${'No response given'}
+		${['MockCorrectLabel']} | ${['MockPartialLabel']} | ${['MockIncorrectLabel']} | ${'no-score'} | ${true}  | ${true}  | ${true}     | ${'Response recorded'}
 	`(
-		'getLabel($correctLabels, $incorrectLabels, $score, $isReview, $isSurvey, $hasResponse) = "$expectedValue"',
-		({ correctLabels, incorrectLabels, score, isReview, isSurvey, hasResponse, expectedValue }) => {
+		'getLabel($correctLabels, $partialLabels, $incorrectLabels, $score, $isReview, $isSurvey, $hasResponse) = "$expectedValue"',
+		({
+			correctLabels,
+			partialLabels,
+			incorrectLabels,
+			score,
+			isReview,
+			isSurvey,
+			hasResponse,
+			expectedValue
+		}) => {
 			const spy = jest.spyOn(Math, 'random').mockReturnValue(0)
 
-			expect(getLabel(correctLabels, incorrectLabels, score, isReview, isSurvey, hasResponse)).toBe(
-				expectedValue
-			)
+			expect(
+				getLabel(
+					correctLabels,
+					partialLabels,
+					incorrectLabels,
+					score,
+					isReview,
+					isSurvey,
+					hasResponse
+				)
+			).toBe(expectedValue)
 
 			spy.mockRestore()
 		}

--- a/packages/obonode/obojobo-chunks-question/question-outcome.js
+++ b/packages/obonode/obojobo-chunks-question/question-outcome.js
@@ -47,3 +47,44 @@ const QuestionOutcome = props => {
 }
 
 export default QuestionOutcome
+
+/*
+new hotness - failes a whole lot of snapshots, find a way to make it equal to the above while also supporting partial credit
+import React from 'react'
+
+const QuestionOutcome = props => {
+	const isModeSurvey = props.type === 'survey'
+	const score = props.score
+	const isForScreenReader = props.isForScreenReader
+
+	let resultClass = ''
+	let resultText = `${props.feedbackText} - You received a ${score}% on this question.`
+
+	switch(true) {
+		case score === 0:
+			if (isModeSurvey || !isForScreenReader) resultText = props.feedbackText
+			resultClass = 'incorrect'
+			break
+		case score >= 100:
+			if (isModeSurvey || !isForScreenReader) resultText = props.feedbackText
+			resultClass = 'correct'
+			break
+		case score > 0 && score < 100:
+		default:
+			resultClass = 'partially-correct'
+			break
+	}
+	// survey overrides other types
+	if (props.type === 'survey') resultClass = 'survey'
+
+	return (
+		<div className="result-container" aria-hidden={!isForScreenReader}>
+			<p className={`result ${resultClass}`}>
+				{resultText}
+			</p>
+		</div>
+	)
+}
+
+export default QuestionOutcome
+*/

--- a/packages/obonode/obojobo-chunks-question/viewer-component.js
+++ b/packages/obonode/obojobo-chunks-question/viewer-component.js
@@ -174,6 +174,7 @@ export default class Question extends React.Component {
 
 		const feedbackText = getLabel(
 			modelState.correctLabels,
+			modelState.partialLabels,
 			modelState.incorrectLabels,
 			calculatedScoreResponse.score,
 			this.props.mode === 'review',
@@ -326,6 +327,7 @@ export default class Question extends React.Component {
 
 		return getLabel(
 			this.props.model.modelState.correctLabels,
+			this.props.model.modelState.partialLabels,
 			this.props.model.modelState.incorrectLabels,
 			this.getScore(),
 			this.getMode() === 'review',

--- a/packages/obonode/obojobo-chunks-question/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-question/viewer-component.scss
@@ -605,6 +605,10 @@
 				background-color: $color-correct;
 			}
 
+			&.partially-correct {
+				background-color: $color-partially-correct;
+			}
+
 			&.incorrect {
 				background-color: $color-incorrect;
 			}

--- a/packages/obonode/obojobo-chunks-question/viewer-component.test.js
+++ b/packages/obonode/obojobo-chunks-question/viewer-component.test.js
@@ -52,6 +52,7 @@ const questionJSON = {
 			type: 'ObojoboDraft.Chunks.MCAssessment',
 			content: {
 				correctLabels: 'mock-correct-labels',
+				partialLabels: 'mock-partial-labels',
 				incorrectLabels: 'mock-incorrect-labels'
 			},
 			children: [

--- a/packages/obonode/obojobo-sections-assessment/components/assessment-score-report-view.scss
+++ b/packages/obonode/obojobo-sections-assessment/components/assessment-score-report-view.scss
@@ -3,6 +3,7 @@
 .obojobo-draft--sections--assessment--components--score-report {
 	$color-hr: transparentize(rgba(0, 0, 0, 0.3), 0.2);
 	$color-correct: #38ae24;
+	$color-partially-correct: #ffc802;
 	$color-incorrect: #c21f00;
 	$color-bg: white;
 	$color-bg2: #f4f4f4;

--- a/packages/obonode/obojobo-sections-assessment/components/full-review/__snapshots__/basic-review.test.js.snap
+++ b/packages/obonode/obojobo-sections-assessment/components/full-review/__snapshots__/basic-review.test.js.snap
@@ -173,6 +173,7 @@ exports[`BasicReview Basic component correct 1`] = `
         "content": Object {
           "correctLabels": null,
           "incorrectLabels": null,
+          "partialLabels": null,
           "revealAnswer": "default",
           "solution": Object {
             "children": Array [
@@ -397,6 +398,7 @@ exports[`BasicReview Basic component incorrect 1`] = `
         "content": Object {
           "correctLabels": null,
           "incorrectLabels": null,
+          "partialLabels": null,
           "revealAnswer": "default",
           "solution": Object {
             "children": Array [
@@ -621,6 +623,7 @@ exports[`BasicReview Basic component survey 1`] = `
         "content": Object {
           "correctLabels": null,
           "incorrectLabels": null,
+          "partialLabels": null,
           "revealAnswer": "default",
           "solution": Object {
             "children": Array [


### PR DESCRIPTION
Closes #1772.

Adds Materia chunk score verification and displaying highest scores via LTI passback in the viewer.

Adds Materia as a type option for questions.

Also adds support for displaying partial credit in assessment reviews. This is sort of approaching #545, but will likely need some more tuning to fully address MC questions.