### PR TITLE
Adjusted stats page access.

### DIFF
--- a/packages/app/obojobo-express/__tests__/express_validators.test.js
+++ b/packages/app/obojobo-express/__tests__/express_validators.test.js
@@ -475,6 +475,28 @@ describe('current user middleware', () => {
 		})
 	})
 
+	// requireCanViewStatsPage
+
+	test('requireCanViewStatsPage calls next and has no validation errors', () => {
+		mockUser.hasPermission = perm => perm === 'canViewStatsPage'
+		mockReq.requireCurrentUser = jest.fn().mockResolvedValue(mockUser)
+		return Validators.requireCanViewStatsPage(mockReq, mockRes, mockNext).then(() => {
+			expect(mockNext).toHaveBeenCalledTimes(1)
+			expect(mockRes.notAuthorized).toHaveBeenCalledTimes(0)
+			expect(mockReq._validationErrors).toBeUndefined()
+		})
+	})
+
+	test('requireCanViewStatsPage doesnt call next and has errors', () => {
+		mockUser.hasPermission = () => false
+		mockReq.requireCurrentUser = jest.fn().mockResolvedValue(mockUser)
+		return Validators.requireCanViewStatsPage(mockReq, mockRes, mockNext).then(() => {
+			expect(mockNext).toHaveBeenCalledTimes(0)
+			expect(mockRes.notAuthorized).toHaveBeenCalledTimes(1)
+			expect(mockReq._validationErrors).toBeUndefined()
+		})
+	})
+
 	// requireCanViewSystemStats
 
 	test('requireCanViewSystemStats calls next and has no validation errors', () => {

--- a/packages/app/obojobo-express/__tests__/models/user.test.js
+++ b/packages/app/obojobo-express/__tests__/models/user.test.js
@@ -390,6 +390,7 @@ describe('user model', () => {
 		expect(u.hasPermission('canDeleteDrafts')).toBe(true)
 		expect(u.hasPermission('canCreateDrafts')).toBe(true)
 		expect(u.hasPermission('canPreviewDrafts')).toBe(true)
+		expect(u.hasPermission('canViewStatsPage')).toBe(false)
 		expect(u.hasPermission('canViewSystemStats')).toBe(false)
 	})
 
@@ -407,6 +408,7 @@ describe('user model', () => {
 		expect(u.hasPermission('canDeleteDrafts')).toBe(true)
 		expect(u.hasPermission('canCreateDrafts')).toBe(true)
 		expect(u.hasPermission('canPreviewDrafts')).toBe(true)
+		expect(u.hasPermission('canViewStatsPage')).toBe(false)
 		expect(u.hasPermission('canViewSystemStats')).toBe(false)
 	})
 
@@ -424,6 +426,7 @@ describe('user model', () => {
 		expect(u.hasPermission('canDeleteDrafts')).toBe(true)
 		expect(u.hasPermission('canCreateDrafts')).toBe(true)
 		expect(u.hasPermission('canPreviewDrafts')).toBe(true)
+		expect(u.hasPermission('canViewStatsPage')).toBe(false)
 		expect(u.hasPermission('canViewSystemStats')).toBe(false)
 	})
 
@@ -441,6 +444,7 @@ describe('user model', () => {
 		expect(u.hasPermission('canDeleteDrafts')).toBe(true)
 		expect(u.hasPermission('canCreateDrafts')).toBe(true)
 		expect(u.hasPermission('canPreviewDrafts')).toBe(true)
+		expect(u.hasPermission('canViewStatsPage')).toBe(false)
 		expect(u.hasPermission('canViewSystemStats')).toBe(false)
 	})
 

--- a/packages/app/obojobo-express/server/config/permission_groups.json
+++ b/packages/app/obojobo-express/server/config/permission_groups.json
@@ -38,6 +38,7 @@
 			"urn:lti:instrole:ims/lis/Observer"
 		],
 		"canViewAsStudent": ["Learner", "urn:lti:role:ims/lis/Learner"],
+		"canViewStatsPage": [],
 		"canViewSystemStats": []
 	},
 	"test": {

--- a/packages/app/obojobo-express/server/express_validators.js
+++ b/packages/app/obojobo-express/server/express_validators.js
@@ -114,6 +114,9 @@ exports.requireCanDeleteDrafts = (req, res, next) =>
 exports.requireCanPreviewDrafts = (req, res, next) =>
 	requireCurrentUser(req, res, next, 'canPreviewDrafts')
 
+exports.requireCanViewStatsPage = (req, res, next) =>
+	requireCurrentUser(req, res, next, 'canViewStatsPage')
+
 exports.requireCanViewSystemStats = (req, res, next) =>
 	requireCurrentUser(req, res, next, 'canViewSystemStats')
 

--- a/packages/app/obojobo-repository/server/routes/stats.js
+++ b/packages/app/obojobo-repository/server/routes/stats.js
@@ -4,7 +4,7 @@ const DraftSummary = require('../models/draft_summary')
 const { webpackAssetPath } = require('obojobo-express/server/asset_resolver')
 const {
 	requireCurrentUser,
-	requireCanViewSystemStats
+	requireCanViewStatsPage
 } = require('obojobo-express/server/express_validators')
 
 // Stats page
@@ -12,20 +12,27 @@ const {
 // NOTE: is an isomorphic react page
 router
 	.route('/stats')
-	.get([requireCurrentUser, requireCanViewSystemStats])
+	.get([requireCurrentUser, requireCanViewStatsPage])
 	.get((req, res) => {
-		return DraftSummary.fetchAll().then(allModules => {
+		const processDrafts = allModules => {
 			const props = {
 				title: 'Stats',
 				allModules: allModules.map(m => JSON.parse(JSON.stringify(m))),
 				currentUser: req.currentUser,
-				doggo: true,
 				// must use webpackAssetPath for all webpack assets to work in dev and production!
 				appCSSUrl: webpackAssetPath('stats.css'),
 				appJsUrl: webpackAssetPath('stats.js')
 			}
 			res.render('pages/page-stats-server.jsx', props)
-		})
+		}
+
+		const canSeeAllModuleStats = req.currentUser.hasPermission('canViewSystemStats')
+
+		if (canSeeAllModuleStats) {
+			return DraftSummary.fetchAll().then(processDrafts)
+		} else {
+			return DraftSummary.fetchByUserId(req.currentUser.id).then(processDrafts)
+		}
 	})
 
 module.exports = router

--- a/packages/app/obojobo-repository/shared/components/__snapshots__/repository-nav.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/repository-nav.test.js.snap
@@ -1,5 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RepositoryNav does not render stats section with just canViewSystemStats 1`] = `
+<div
+  className="repository--section-wrapper repository--stick-to-top"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseLeave={[Function]}
+>
+  <nav
+    className="repository--nav"
+  >
+    <a
+      href="/"
+    >
+      <div
+        className="repository--nav--logo"
+      >
+        Obojobo
+      </div>
+    </a>
+    <div
+      className="repository--nav--links--link"
+    >
+      <a
+        href="/library"
+      >
+        Module Library
+      </a>
+    </div>
+    <div
+      className="repository--nav--links--link"
+    >
+      <a
+        href="/dashboard"
+      >
+        Dashboard
+      </a>
+    </div>
+    <div
+      className="repository--nav--current-user"
+    >
+      <button
+        onClick={[Function]}
+      >
+        <div
+          className="repository--nav--current-user--name"
+        >
+          Display Name
+        </div>
+        <div
+          className="avatar repository--nav--current-user--avatar"
+        >
+          <div
+            className="avatar--image"
+          >
+            <img
+              alt=""
+            />
+          </div>
+        </div>
+      </button>
+      <div
+        className="repository--nav--current-user--menu is-not-open"
+      >
+        <div
+          className="repository--nav--current-user--link"
+        >
+          <a
+            href="/profile/logout"
+          >
+            Log Out
+          </a>
+        </div>
+      </div>
+    </div>
+  </nav>
+</div>
+`;
+
 exports[`RepositoryNav renders correctly with standard expected props 1`] = `
 <div
   className="repository--section-wrapper repository--stick-to-top"
@@ -119,7 +197,7 @@ exports[`RepositoryNav renders correctly with standard expected props but no log
 </div>
 `;
 
-exports[`RepositoryNav renders stats section with canViewSystemStats 1`] = `
+exports[`RepositoryNav renders stats section with canViewStatsPage 1`] = `
 <div
   className="repository--section-wrapper repository--stick-to-top"
   onBlur={[Function]}

--- a/packages/app/obojobo-repository/shared/components/repository-nav.jsx
+++ b/packages/app/obojobo-repository/shared/components/repository-nav.jsx
@@ -41,7 +41,7 @@ const RepositoryNav = props => {
 						<a href="/dashboard">Dashboard</a>
 					</div>
 				) : null}
-				{props.userPerms.indexOf('canViewSystemStats') > -1 ? (
+				{props.userPerms.indexOf('canViewStatsPage') > -1 ? (
 					<div className="repository--nav--links--link">
 						<a href="/stats">Stats</a>
 					</div>

--- a/packages/app/obojobo-repository/shared/components/repository-nav.test.js
+++ b/packages/app/obojobo-repository/shared/components/repository-nav.test.js
@@ -58,8 +58,8 @@ describe('RepositoryNav', () => {
 		expect(component.toJSON()).toMatchSnapshot()
 	})
 
-	test('renders stats section with canViewSystemStats', () => {
-		const component = create(<RepositoryNav {...navProps} userPerms={['canViewSystemStats']} />)
+	test('renders stats section with canViewStatsPage', () => {
+		const component = create(<RepositoryNav {...navProps} userPerms={['canViewStatsPage']} />)
 
 		expect(
 			component.root.findAllByProps({ className: 'repository--nav--current-user' }).length
@@ -69,6 +69,21 @@ describe('RepositoryNav', () => {
 		).toBe(navProps.displayName)
 		expect(component.root.findAllByProps({ href: '/login' }).length).toBe(0)
 		expect(component.root.findAllByProps({ href: '/stats' }).length).toBe(1)
+
+		expect(component.toJSON()).toMatchSnapshot()
+	})
+
+	test('does not render stats section with just canViewSystemStats', () => {
+		const component = create(<RepositoryNav {...navProps} userPerms={['canViewSystemStats']} />)
+
+		expect(
+			component.root.findAllByProps({ className: 'repository--nav--current-user' }).length
+		).toBe(1)
+		expect(
+			component.root.findByProps({ className: 'repository--nav--current-user--name' }).children[0]
+		).toBe(navProps.displayName)
+		expect(component.root.findAllByProps({ href: '/login' }).length).toBe(0)
+		expect(component.root.findAllByProps({ href: '/stats' }).length).toBe(0)
 
 		expect(component.toJSON()).toMatchSnapshot()
 	})


### PR DESCRIPTION
Closes #1859.

Adds a new role that allows access to the stats page but will only display the user's modules. Existing role will continue to display all modules.