### PR TITLE
Standardized clear filter button

### DIFF
--- a/packages/app/obojobo-repository/shared/components/__snapshots__/search.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/search.test.js.snap
@@ -4,13 +4,18 @@ exports[`Search renders correctly with a non-empty value 1`] = `
 <div
   className="repository--nav--links--search is-not-empty"
 >
-  <input
-    name="search"
-    onChange={[Function]}
-    placeholder="Search..."
-    type="search"
-    value="string"
-  />
+  <form>
+    <input
+      name="search"
+      onChange={[Function]}
+      placeholder="Search..."
+      type="search"
+      value="string"
+    />
+    <button
+      onClick={[Function]}
+    />
+  </form>
   <div
     className="repository--nav--links--search--icon"
   >
@@ -32,13 +37,15 @@ exports[`Search renders correctly with focusOnMount=true 1`] = `
 <div
   className="repository--nav--links--search is-empty"
 >
-  <input
-    name="search"
-    onChange={[Function]}
-    placeholder="Search..."
-    type="search"
-    value={null}
-  />
+  <form>
+    <input
+      name="search"
+      onChange={[Function]}
+      placeholder="Search..."
+      type="search"
+      value={null}
+    />
+  </form>
   <div
     className="repository--nav--links--search--icon"
   >
@@ -60,12 +67,14 @@ exports[`Search renders correctly with no props 1`] = `
 <div
   className="repository--nav--links--search is-empty"
 >
-  <input
-    name="search"
-    onChange={[Function]}
-    placeholder="Search..."
-    type="search"
-  />
+  <form>
+    <input
+      name="search"
+      onChange={[Function]}
+      placeholder="Search..."
+      type="search"
+    />
+  </form>
   <div
     className="repository--nav--links--search--icon"
   >

--- a/packages/app/obojobo-repository/shared/components/search.jsx
+++ b/packages/app/obojobo-repository/shared/components/search.jsx
@@ -8,22 +8,31 @@ const Search = props => {
 	const handleChange = e => {
 		if (props.onChange) props.onChange(e.target.value)
 	}
+
 	useEffect(() => {
 		if (props.focusOnMount === true) inputEl.current.focus()
 	}, [])
+
+	const handleCancelSearch = e => {
+		e.preventDefault()
+		props.onChange('')
+	}
 
 	return (
 		<div
 			className={'repository--nav--links--search ' + (props.value ? 'is-not-empty' : 'is-empty')}
 		>
-			<input
-				ref={inputEl}
-				onChange={handleChange}
-				type="search"
-				name="search"
-				value={props.value}
-				placeholder={props.placeholder}
-			/>
+			<form>
+				<input
+					ref={inputEl}
+					onChange={handleChange}
+					type="search"
+					name="search"
+					value={props.value}
+					placeholder={props.placeholder}
+				/>
+				{props.value && <button onClick={handleCancelSearch}></button>}
+			</form>
 			<div className="repository--nav--links--search--icon">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 250.313 250.313">
 					<path

--- a/packages/app/obojobo-repository/shared/components/search.scss
+++ b/packages/app/obojobo-repository/shared/components/search.scss
@@ -21,39 +21,65 @@ $search-input-height: 30px;
 		}
 	}
 
-	input {
-		@include text-input;
+	form {
+		display: flex;
+		align-items: center;
+		justify-content: center;
 
-		z-index: 1;
-		background: none;
-		top: 0;
-		left: 0;
-		width: calc(100% - 2px);
-		line-height: $search-input-height;
-		border: solid 1px $border-color;
-		background-color: white;
-		border-radius: 3px;
-		height: $search-input-height;
-		padding-left: 23px;
-		padding-right: 10px;
-		outline: none;
-		position: relative;
-		-webkit-appearance: none;
+		input {
+			@include text-input;
 
-		&::-webkit-search-cancel-button {
+			z-index: 1;
+			background: none;
+			top: 0;
+			left: 0;
+			width: 100%;
+			line-height: $search-input-height;
+			border: solid 1px $border-color;
+			background-color: white;
+			border-radius: 3px;
+			height: $search-input-height;
+			padding-left: 23px;
+			padding-right: 23px;
+			outline: none;
+			position: relative;
 			-webkit-appearance: none;
 
-			height: 10px;
-			width: 10px;
-			background: white;
-			border-radius: 50%;
-			color: $color-action;
-			cursor: pointer;
-			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23777'><path d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/></svg>");
+			&::-webkit-search-cancel-button {
+				-webkit-appearance: none;
+			}
+
+			&:focus {
+				outline-width: 0;
+			}
 		}
 
-		&:focus {
-			outline-width: 0;
+		button {
+			border: 1px solid transparent;
+			background-color: transparent;
+			cursor: pointer;
+			width: 9px;
+			height: 9px;
+			position: absolute;
+			right: -12px;
+
+			&:after {
+				content: '';
+				width: 9px;
+				height: 9px;
+				position: absolute;
+				background-color: white;
+				z-index: 1;
+				right: 20px;
+				top: 0;
+				bottom: 0;
+				margin: auto;
+				padding: 2px;
+				border-radius: 50%;
+				font-size: 12px;
+				cursor: pointer;
+				background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23777'><path d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/></svg>");
+			}
 		}
 	}
 

--- a/packages/app/obojobo-repository/shared/components/search.scss
+++ b/packages/app/obojobo-repository/shared/components/search.scss
@@ -48,6 +48,7 @@ $search-input-height: 30px;
 			background: white;
 			border-radius: 50%;
 			color: $color-action;
+			cursor: pointer;
 			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23777'><path d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/></svg>");
 		}
 

--- a/packages/app/obojobo-repository/shared/components/search.scss
+++ b/packages/app/obojobo-repository/shared/components/search.scss
@@ -41,8 +41,14 @@ $search-input-height: 30px;
 		-webkit-appearance: none;
 
 		&::-webkit-search-cancel-button {
-			color: red;
-			background: red;
+			-webkit-appearance: none;
+
+			height: 10px;
+			width: 10px;
+			background: white;
+			border-radius: 50%;
+			color: $color-action;
+			background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23777'><path d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/></svg>");
 		}
 
 		&:focus {

--- a/packages/app/obojobo-repository/shared/components/search.scss
+++ b/packages/app/obojobo-repository/shared/components/search.scss
@@ -35,12 +35,12 @@ $search-input-height: 30px;
 			left: 0;
 			width: 100%;
 			line-height: $search-input-height;
-			border: solid 1px $border-color;
+			border: solid 0.0625em $border-color;
 			background-color: white;
-			border-radius: 3px;
+			border-radius: 0.2em;
 			height: $search-input-height;
-			padding-left: 23px;
-			padding-right: 23px;
+			padding-left: 1.5em;
+			padding-right: 1.45em;
 			outline: none;
 			position: relative;
 			-webkit-appearance: none;
@@ -55,28 +55,28 @@ $search-input-height: 30px;
 		}
 
 		button {
-			border: 1px solid transparent;
+			border: 0.1em solid transparent;
 			background-color: transparent;
 			cursor: pointer;
-			width: 9px;
-			height: 9px;
+			width: 0.6em;
+			height: 0.6em;
 			position: absolute;
-			right: -12px;
+			right: -0.75em;
 
 			&:after {
 				content: '';
-				width: 9px;
-				height: 9px;
+				width: 0.6em;
+				height: 0.6em;
 				position: absolute;
 				background-color: white;
 				z-index: 1;
-				right: 20px;
+				right: 1.25em;
 				top: 0;
 				bottom: 0;
 				margin: auto;
-				padding: 2px;
+				padding: 0.125em;
 				border-radius: 50%;
-				font-size: 12px;
+				font-size: 1.1em;
 				cursor: pointer;
 				background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23777'><path d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/></svg>");
 			}

--- a/packages/app/obojobo-repository/shared/components/search.test.js
+++ b/packages/app/obojobo-repository/shared/components/search.test.js
@@ -95,6 +95,22 @@ describe('Search', () => {
 		expect(searchProps.onChange).toHaveBeenCalledWith('string')
 	})
 
+	test('clicks clear filter button', () => {
+		let component
+		act(() => {
+			searchProps = { ...searchProps, value: 'mock-value' }
+			component = create(<Search {...searchProps} />)
+		})
+
+		const mockClickEvent = {
+			preventDefault: () => {}
+		}
+		component.root.findByType('button').props.onClick(mockClickEvent)
+
+		expect(searchProps.onChange).toHaveBeenCalledTimes(1)
+		expect(searchProps.onChange).toHaveBeenCalledWith('')
+	})
+
 	test('does not try to run props.onChange if it does not exist?', () => {
 		delete searchProps.onChange
 		let component


### PR DESCRIPTION
I overrode `web-kit`'s UI for our clear filter button within obo's dashboard's search input, and everything seems to be standardized across browsers now.

Fixes #1930 