### PR TITLE
Remove isomorphic data table rendering from Stats page.

### DIFF
--- a/packages/app/obojobo-repository/server/routes/api.js
+++ b/packages/app/obojobo-repository/server/routes/api.js
@@ -11,7 +11,7 @@ const {
 	requireCurrentDocument,
 	checkValidationRules,
 	check,
-	requireCanViewSystemStats
+	requireCanViewStatsPage
 } = require('obojobo-express/server/express_validators')
 const UserModel = require('obojobo-express/server/models/user')
 const { searchForUserByString } = require('../services/search')
@@ -39,12 +39,20 @@ router
 	})
 
 router
-	.route('/drafts-all')
-	.get([requireCurrentUser, requireCanViewSystemStats])
+	.route('/drafts-stats')
+	.get([requireCurrentUser, requireCanViewStatsPage])
 	.get((req, res) => {
-		return DraftSummary.fetchAll()
-			.then(res.success)
-			.catch(res.unexpected)
+		const canSeeAllModuleStats = req.currentUser.hasPermission('canViewSystemStats')
+
+		if (canSeeAllModuleStats) {
+			return DraftSummary.fetchAll()
+				.then(res.success)
+				.catch(res.unexpected)
+		} else {
+			return DraftSummary.fetchByUserId(req.currentUser.id)
+				.then(res.success)
+				.catch(res.unexpected)
+		}
 	})
 
 router

--- a/packages/app/obojobo-repository/server/routes/api.test.js
+++ b/packages/app/obojobo-repository/server/routes/api.test.js
@@ -144,21 +144,68 @@ describe('repository api route', () => {
 			})
 	})
 
-	test('get /drafts-all returns the expected response', () => {
+	test('get /drafts-stats returns the expected response when the user does not have the canViewStatsPage permission', () => {
+		// technically only have to return false for canViewStatsPage, but that's the only one being checked here anyway
+		mockCurrentUser.hasPermission = () => false
+
+		DraftSummary.fetchByUserId = jest.fn()
+		DraftSummary.fetchAll = jest.fn()
+
+		expect.hasAssertions()
+
+		return request(app)
+			.get('/drafts-stats')
+			.then(response => {
+				expect(DraftSummary.fetchByUserId).not.toHaveBeenCalled()
+				expect(DraftSummary.fetchAll).not.toHaveBeenCalled()
+
+				expect(response.statusCode).toBe(401)
+			})
+	})
+
+	test('get /drafts-stats returns the expected response when the user has the canViewStatsPage permission but not the canViewSystemStats permission', () => {
 		const mockResult = [
 			{ draftId: 'mockDraftId1', title: 'whatever1' },
 			{ draftId: 'mockDraftId2', title: 'whatever2' },
 			{ draftId: 'mockDraftId3', title: 'whatever3' }
 		]
 
+		mockCurrentUser.hasPermission = perm => perm === 'canViewStatsPage'
+
+		DraftSummary.fetchByUserId = jest.fn()
+		DraftSummary.fetchByUserId.mockResolvedValueOnce(mockResult)
+		DraftSummary.fetchAll = jest.fn()
+
+		expect.hasAssertions()
+
+		return request(app)
+			.get('/drafts-stats')
+			.then(response => {
+				expect(DraftSummary.fetchByUserId).toHaveBeenCalled()
+				expect(DraftSummary.fetchAll).not.toHaveBeenCalled()
+
+				expect(response.statusCode).toBe(200)
+				expect(response.body).toEqual(mockResult)
+			})
+	})
+
+	test('get /drafts-stats returns the expected response when the user has the canViewStatsPage and canViewSystemStats permissions', () => {
+		const mockResult = [
+			{ draftId: 'mockDraftId1', title: 'whatever1' },
+			{ draftId: 'mockDraftId2', title: 'whatever2' },
+			{ draftId: 'mockDraftId3', title: 'whatever3' }
+		]
+
+		DraftSummary.fetchByUserId = jest.fn()
 		DraftSummary.fetchAll = jest.fn()
 		DraftSummary.fetchAll.mockResolvedValueOnce(mockResult)
 
 		expect.hasAssertions()
 
 		return request(app)
-			.get('/drafts-all')
+			.get('/drafts-stats')
 			.then(response => {
+				expect(DraftSummary.fetchByUserId).not.toHaveBeenCalled()
 				expect(DraftSummary.fetchAll).toHaveBeenCalled()
 
 				expect(response.statusCode).toBe(200)

--- a/packages/app/obojobo-repository/server/routes/stats.js
+++ b/packages/app/obojobo-repository/server/routes/stats.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const router = express.Router()
-const DraftSummary = require('../models/draft_summary')
 const { webpackAssetPath } = require('obojobo-express/server/asset_resolver')
 const {
 	requireCurrentUser,
@@ -14,25 +13,14 @@ router
 	.route('/stats')
 	.get([requireCurrentUser, requireCanViewStatsPage])
 	.get((req, res) => {
-		const processDrafts = allModules => {
-			const props = {
-				title: 'Stats',
-				allModules: allModules.map(m => JSON.parse(JSON.stringify(m))),
-				currentUser: req.currentUser,
-				// must use webpackAssetPath for all webpack assets to work in dev and production!
-				appCSSUrl: webpackAssetPath('stats.css'),
-				appJsUrl: webpackAssetPath('stats.js')
-			}
-			res.render('pages/page-stats-server.jsx', props)
+		const props = {
+			title: 'Stats',
+			currentUser: req.currentUser,
+			// must use webpackAssetPath for all webpack assets to work in dev and production!
+			appCSSUrl: webpackAssetPath('stats.css'),
+			appJsUrl: webpackAssetPath('stats.js')
 		}
-
-		const canSeeAllModuleStats = req.currentUser.hasPermission('canViewSystemStats')
-
-		if (canSeeAllModuleStats) {
-			return DraftSummary.fetchAll().then(processDrafts)
-		} else {
-			return DraftSummary.fetchByUserId(req.currentUser.id).then(processDrafts)
-		}
+		res.render('pages/page-stats-server.jsx', props)
 	})
 
 module.exports = router

--- a/packages/app/obojobo-repository/shared/actions/stats-actions.js
+++ b/packages/app/obojobo-repository/shared/actions/stats-actions.js
@@ -4,6 +4,25 @@ const { apiGetAssessmentDetailsForMultipleDrafts } = require('./shared-api-metho
 
 // ================== ACTIONS ===================
 
+const apiGetStatsPageModules = () => {
+	const JSON_MIME_TYPE = 'application/json'
+	const fetchOptions = {
+		method: 'GET',
+		credentials: 'include',
+		headers: {
+			Accept: JSON_MIME_TYPE,
+			'Content-Type': JSON_MIME_TYPE
+		}
+	}
+	return fetch('/api/drafts-stats', fetchOptions).then(res => res.json())
+}
+
+const LOAD_STATS_PAGE_MODULES_FOR_USER = 'LOAD_STATS_PAGE_MODULES_FOR_USER'
+const loadUserModuleList = () => ({
+	type: LOAD_STATS_PAGE_MODULES_FOR_USER,
+	promise: apiGetStatsPageModules()
+})
+
 const LOAD_MODULE_ASSESSMENT_DETAILS = 'LOAD_MODULE_ASSESSMENT_DETAILS'
 const loadModuleAssessmentDetails = draftIds => ({
 	type: LOAD_MODULE_ASSESSMENT_DETAILS,
@@ -11,6 +30,8 @@ const loadModuleAssessmentDetails = draftIds => ({
 })
 
 module.exports = {
+	LOAD_STATS_PAGE_MODULES_FOR_USER,
 	LOAD_MODULE_ASSESSMENT_DETAILS,
+	loadUserModuleList,
 	loadModuleAssessmentDetails
 }

--- a/packages/app/obojobo-repository/shared/actions/stats-actions.test.js
+++ b/packages/app/obojobo-repository/shared/actions/stats-actions.test.js
@@ -1,10 +1,31 @@
-const { loadModuleAssessmentDetails } = require('./stats-actions')
+const { loadUserModuleList, loadModuleAssessmentDetails } = require('./stats-actions')
 
 jest.mock('./shared-api-methods', () => ({
 	apiGetAssessmentDetailsForMultipleDrafts: () => Promise.resolve()
 }))
 
 describe('statsActions', () => {
+	test('loadUserModuleList returns expected object', async () => {
+		const apiGetStatsPageModulesJson = jest.fn()
+		const originalFetch = global.fetch
+		global.fetch = jest.fn()
+		global.fetch.mockImplementation(() => {
+			return Promise.resolve({
+				json: apiGetStatsPageModulesJson
+			})
+		})
+
+		const result = await loadUserModuleList()
+
+		expect(result).toEqual({
+			type: 'LOAD_STATS_PAGE_MODULES_FOR_USER',
+			promise: expect.any(Promise)
+		})
+		expect(apiGetStatsPageModulesJson).toHaveBeenCalledTimes(1)
+
+		global.fetch = originalFetch
+	})
+
 	test('loadModuleAssessmentDetails returns expected object', async () => {
 		const result = await loadModuleAssessmentDetails(['draft-id-1', 'draft-id-2'])
 

--- a/packages/app/obojobo-repository/shared/components/__snapshots__/stats.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/stats.test.js.snap
@@ -1,6 +1,478 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Stats Renders loaded state correctly 1`] = `
+exports[`Stats Renders "modules loaded" state correctly 1`] = `
+<span
+  id="stats-root"
+>
+  <div
+    className="repository--section-wrapper repository--stick-to-top"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <nav
+      className="repository--nav"
+    >
+      <a
+        href="/"
+      >
+        <div
+          className="repository--nav--logo"
+        >
+          Obojobo
+        </div>
+      </a>
+      <div
+        className="repository--nav--links--link"
+      >
+        <a
+          href="/library"
+        >
+          Module Library
+        </a>
+      </div>
+      <div
+        className="repository--nav--links--link"
+      >
+        <a
+          href="/dashboard"
+        >
+          Dashboard
+        </a>
+      </div>
+      <div
+        className="repository--nav--current-user"
+      >
+        <button
+          onClick={[Function]}
+        >
+          <div
+            className="repository--nav--current-user--name"
+          >
+            firstName lastName
+          </div>
+          <div
+            className="avatar repository--nav--current-user--avatar"
+          >
+            <div
+              className="avatar--image"
+            >
+              <img
+                alt=""
+                src="/path/to/avatar"
+              />
+            </div>
+          </div>
+        </button>
+        <div
+          className="repository--nav--current-user--menu is-not-open"
+        >
+          <div
+            className="repository--nav--current-user--link"
+          >
+            <a
+              href="/profile/logout"
+            >
+              Log Out
+            </a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
+  <div
+    className="repository--section-wrapper--full-width repository--section-wrapper--grey default-bg"
+  >
+    <div
+      className="repository--section-wrapper--full-width-bg"
+    />
+    <section
+      className="repository--title-banner repository--info-banner"
+    >
+      <h1
+        className="repository--title-banner--title"
+      />
+    </section>
+  </div>
+  <div
+    className="repository--section-wrapper"
+  >
+    <section
+      className="repository--main-content"
+    >
+      <input
+        className="repository--drafts-search"
+        onChange={[Function]}
+        placeholder="Search (By title or draftId)"
+        value=""
+      />
+      <div
+        className="repository--data-grid-drafts-container"
+      >
+        <div
+          className="react-data-table-component"
+          columns={
+            Array [
+              Object {
+                "name": "Draft ID",
+                "selector": "draftId",
+                "sortable": true,
+              },
+              Object {
+                "name": "Title",
+                "selector": "title",
+                "sortable": true,
+              },
+              Object {
+                "name": "Created At",
+                "selector": "createdAt",
+                "sortable": true,
+              },
+              Object {
+                "name": "Updated At",
+                "selector": "updatedAt",
+                "sortable": true,
+              },
+              Object {
+                "name": "Latest Version",
+                "selector": "latestVersion",
+                "sortable": true,
+              },
+              Object {
+                "name": "Revision Count",
+                "selector": "revisionCount",
+                "sortable": true,
+              },
+              Object {
+                "cell": [Function],
+                "name": "Preview",
+              },
+            ]
+          }
+          data={Array []}
+          dense={true}
+          keyField="draftId"
+          onSelectedRowsChange={[Function]}
+          pagination={true}
+          paginationComponentOptions={
+            Object {
+              "noRowsPerPage": true,
+            }
+          }
+          paginationPerPage={100}
+          paginationRowsPerPageOptions={
+            Array [
+              100,
+            ]
+          }
+          selectableRows={true}
+          striped={true}
+          title="Modules (0 Results)"
+        >
+          react-data-table-component
+        </div>
+      </div>
+      <button
+        className="repository--button "
+        disabled={true}
+        onClick={[Function]}
+      >
+        Load stats for 0 selected modules
+      </button>
+      <div
+        className="stats"
+      />
+    </section>
+  </div>
+</span>
+`;
+
+exports[`Stats Renders "modules loaded" state correctly 2`] = `
+<span
+  id="stats-root"
+>
+  <div
+    className="repository--section-wrapper repository--stick-to-top"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <nav
+      className="repository--nav"
+    >
+      <a
+        href="/"
+      >
+        <div
+          className="repository--nav--logo"
+        >
+          Obojobo
+        </div>
+      </a>
+      <div
+        className="repository--nav--links--link"
+      >
+        <a
+          href="/library"
+        >
+          Module Library
+        </a>
+      </div>
+      <div
+        className="repository--nav--links--link"
+      >
+        <a
+          href="/dashboard"
+        >
+          Dashboard
+        </a>
+      </div>
+      <div
+        className="repository--nav--current-user"
+      >
+        <button
+          onClick={[Function]}
+        >
+          <div
+            className="repository--nav--current-user--name"
+          >
+            firstName lastName
+          </div>
+          <div
+            className="avatar repository--nav--current-user--avatar"
+          >
+            <div
+              className="avatar--image"
+            >
+              <img
+                alt=""
+                src="/path/to/avatar"
+              />
+            </div>
+          </div>
+        </button>
+        <div
+          className="repository--nav--current-user--menu is-not-open"
+        >
+          <div
+            className="repository--nav--current-user--link"
+          >
+            <a
+              href="/profile/logout"
+            >
+              Log Out
+            </a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
+  <div
+    className="repository--section-wrapper--full-width repository--section-wrapper--grey default-bg"
+  >
+    <div
+      className="repository--section-wrapper--full-width-bg"
+    />
+    <section
+      className="repository--title-banner repository--info-banner"
+    >
+      <h1
+        className="repository--title-banner--title"
+      />
+    </section>
+  </div>
+  <div
+    className="repository--section-wrapper"
+  >
+    <section
+      className="repository--main-content"
+    >
+      <input
+        className="repository--drafts-search"
+        onChange={[Function]}
+        placeholder="Search (By title or draftId)"
+        value=""
+      />
+      <div
+        className="repository--data-grid-drafts-container"
+      >
+        <div
+          className="react-data-table-component"
+          columns={
+            Array [
+              Object {
+                "name": "Draft ID",
+                "selector": "draftId",
+                "sortable": true,
+              },
+              Object {
+                "name": "Title",
+                "selector": "title",
+                "sortable": true,
+              },
+              Object {
+                "name": "Created At",
+                "selector": "createdAt",
+                "sortable": true,
+              },
+              Object {
+                "name": "Updated At",
+                "selector": "updatedAt",
+                "sortable": true,
+              },
+              Object {
+                "name": "Latest Version",
+                "selector": "latestVersion",
+                "sortable": true,
+              },
+              Object {
+                "name": "Revision Count",
+                "selector": "revisionCount",
+                "sortable": true,
+              },
+              Object {
+                "cell": [Function],
+                "name": "Preview",
+              },
+            ]
+          }
+          data={Array []}
+          dense={true}
+          keyField="draftId"
+          onSelectedRowsChange={[Function]}
+          pagination={true}
+          paginationComponentOptions={
+            Object {
+              "noRowsPerPage": true,
+            }
+          }
+          paginationPerPage={100}
+          paginationRowsPerPageOptions={
+            Array [
+              100,
+            ]
+          }
+          selectableRows={true}
+          striped={true}
+          title="Modules (0 Results)"
+        >
+          react-data-table-component
+        </div>
+      </div>
+      <button
+        className="repository--button "
+        disabled={true}
+        onClick={[Function]}
+      >
+        Load stats for 0 selected modules
+      </button>
+      <div
+        className="stats"
+      />
+    </section>
+  </div>
+</span>
+`;
+
+exports[`Stats Renders "modules loading" state correctly 1`] = `
+<span
+  id="stats-root"
+>
+  <div
+    className="repository--section-wrapper repository--stick-to-top"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <nav
+      className="repository--nav"
+    >
+      <a
+        href="/"
+      >
+        <div
+          className="repository--nav--logo"
+        >
+          Obojobo
+        </div>
+      </a>
+      <div
+        className="repository--nav--links--link"
+      >
+        <a
+          href="/library"
+        >
+          Module Library
+        </a>
+      </div>
+      <div
+        className="repository--nav--links--link"
+      >
+        <a
+          href="/dashboard"
+        >
+          Dashboard
+        </a>
+      </div>
+      <div
+        className="repository--nav--current-user"
+      >
+        <button
+          onClick={[Function]}
+        >
+          <div
+            className="repository--nav--current-user--name"
+          >
+            firstName lastName
+          </div>
+          <div
+            className="avatar repository--nav--current-user--avatar"
+          >
+            <div
+              className="avatar--image"
+            >
+              <img
+                alt=""
+                src="/path/to/avatar"
+              />
+            </div>
+          </div>
+        </button>
+        <div
+          className="repository--nav--current-user--menu is-not-open"
+        >
+          <div
+            className="repository--nav--current-user--link"
+          >
+            <a
+              href="/profile/logout"
+            >
+              Log Out
+            </a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
+  <div
+    className="repository--section-wrapper--full-width repository--section-wrapper--grey default-bg"
+  >
+    <div
+      className="repository--section-wrapper--full-width-bg"
+    />
+    <section
+      className="repository--title-banner repository--info-banner"
+    >
+      <h1
+        className="repository--title-banner--title"
+      />
+    </section>
+  </div>
+  Loading...
+</span>
+`;
+
+exports[`Stats Renders correctly when assessment stat fetching has finished 1`] = `
 <span
   id="stats-root"
 >
@@ -514,7 +986,213 @@ exports[`Stats Renders loaded state correctly 1`] = `
 </span>
 `;
 
-exports[`Stats Renders loading state correctly 1`] = `
+exports[`Stats Renders correctly when assessment stat fetching has not started or finished 1`] = `
+<span
+  id="stats-root"
+>
+  <div
+    className="repository--section-wrapper repository--stick-to-top"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <nav
+      className="repository--nav"
+    >
+      <a
+        href="/"
+      >
+        <div
+          className="repository--nav--logo"
+        >
+          Obojobo
+        </div>
+      </a>
+      <div
+        className="repository--nav--links--link"
+      >
+        <a
+          href="/library"
+        >
+          Module Library
+        </a>
+      </div>
+      <div
+        className="repository--nav--links--link"
+      >
+        <a
+          href="/dashboard"
+        >
+          Dashboard
+        </a>
+      </div>
+      <div
+        className="repository--nav--current-user"
+      >
+        <button
+          onClick={[Function]}
+        >
+          <div
+            className="repository--nav--current-user--name"
+          >
+            firstName lastName
+          </div>
+          <div
+            className="avatar repository--nav--current-user--avatar"
+          >
+            <div
+              className="avatar--image"
+            >
+              <img
+                alt=""
+                src="/path/to/avatar"
+              />
+            </div>
+          </div>
+        </button>
+        <div
+          className="repository--nav--current-user--menu is-not-open"
+        >
+          <div
+            className="repository--nav--current-user--link"
+          >
+            <a
+              href="/profile/logout"
+            >
+              Log Out
+            </a>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
+  <div
+    className="repository--section-wrapper--full-width repository--section-wrapper--grey default-bg"
+  >
+    <div
+      className="repository--section-wrapper--full-width-bg"
+    />
+    <section
+      className="repository--title-banner repository--info-banner"
+    >
+      <h1
+        className="repository--title-banner--title"
+      />
+    </section>
+  </div>
+  <div
+    className="repository--section-wrapper"
+  >
+    <section
+      className="repository--main-content"
+    >
+      <input
+        className="repository--drafts-search"
+        onChange={[Function]}
+        placeholder="Search (By title or draftId)"
+        value=""
+      />
+      <div
+        className="repository--data-grid-drafts-container"
+      >
+        <div
+          className="react-data-table-component"
+          columns={
+            Array [
+              Object {
+                "name": "Draft ID",
+                "selector": "draftId",
+                "sortable": true,
+              },
+              Object {
+                "name": "Title",
+                "selector": "title",
+                "sortable": true,
+              },
+              Object {
+                "name": "Created At",
+                "selector": "createdAt",
+                "sortable": true,
+              },
+              Object {
+                "name": "Updated At",
+                "selector": "updatedAt",
+                "sortable": true,
+              },
+              Object {
+                "name": "Latest Version",
+                "selector": "latestVersion",
+                "sortable": true,
+              },
+              Object {
+                "name": "Revision Count",
+                "selector": "revisionCount",
+                "sortable": true,
+              },
+              Object {
+                "cell": [Function],
+                "name": "Preview",
+              },
+            ]
+          }
+          data={
+            Array [
+              Object {
+                "createdAt": "mock-created-at",
+                "draftId": "mock-draft-id-1",
+                "latestVersion": "mock-latest-version",
+                "revisionCount": 1,
+                "title": "mock-title-1",
+                "updatedAt": "mock-updated-at",
+              },
+              Object {
+                "createdAt": "mock-created-at",
+                "draftId": "mock-draft-id-2",
+                "latestVersion": "mock-latest-version",
+                "revisionCount": 1,
+                "title": "mock-title-2",
+                "updatedAt": "mock-updated-at",
+              },
+            ]
+          }
+          dense={true}
+          keyField="draftId"
+          onSelectedRowsChange={[Function]}
+          pagination={true}
+          paginationComponentOptions={
+            Object {
+              "noRowsPerPage": true,
+            }
+          }
+          paginationPerPage={100}
+          paginationRowsPerPageOptions={
+            Array [
+              100,
+            ]
+          }
+          selectableRows={true}
+          striped={true}
+          title="Modules (2 Results)"
+        >
+          react-data-table-component
+        </div>
+      </div>
+      <button
+        className="repository--button "
+        disabled={true}
+        onClick={[Function]}
+      >
+        Load stats for 0 selected modules
+      </button>
+      <div
+        className="stats"
+      />
+    </section>
+  </div>
+</span>
+`;
+
+exports[`Stats Renders correctly when assessment stat fetching has started but not finished 1`] = `
 <span
   id="stats-root"
 >
@@ -717,212 +1395,6 @@ exports[`Stats Renders loading state correctly 1`] = `
       >
         Loading...
       </div>
-    </section>
-  </div>
-</span>
-`;
-
-exports[`Stats Renders non-loaded non-fetching state correctly 1`] = `
-<span
-  id="stats-root"
->
-  <div
-    className="repository--section-wrapper repository--stick-to-top"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-  >
-    <nav
-      className="repository--nav"
-    >
-      <a
-        href="/"
-      >
-        <div
-          className="repository--nav--logo"
-        >
-          Obojobo
-        </div>
-      </a>
-      <div
-        className="repository--nav--links--link"
-      >
-        <a
-          href="/library"
-        >
-          Module Library
-        </a>
-      </div>
-      <div
-        className="repository--nav--links--link"
-      >
-        <a
-          href="/dashboard"
-        >
-          Dashboard
-        </a>
-      </div>
-      <div
-        className="repository--nav--current-user"
-      >
-        <button
-          onClick={[Function]}
-        >
-          <div
-            className="repository--nav--current-user--name"
-          >
-            firstName lastName
-          </div>
-          <div
-            className="avatar repository--nav--current-user--avatar"
-          >
-            <div
-              className="avatar--image"
-            >
-              <img
-                alt=""
-                src="/path/to/avatar"
-              />
-            </div>
-          </div>
-        </button>
-        <div
-          className="repository--nav--current-user--menu is-not-open"
-        >
-          <div
-            className="repository--nav--current-user--link"
-          >
-            <a
-              href="/profile/logout"
-            >
-              Log Out
-            </a>
-          </div>
-        </div>
-      </div>
-    </nav>
-  </div>
-  <div
-    className="repository--section-wrapper--full-width repository--section-wrapper--grey default-bg"
-  >
-    <div
-      className="repository--section-wrapper--full-width-bg"
-    />
-    <section
-      className="repository--title-banner repository--info-banner"
-    >
-      <h1
-        className="repository--title-banner--title"
-      />
-    </section>
-  </div>
-  <div
-    className="repository--section-wrapper"
-  >
-    <section
-      className="repository--main-content"
-    >
-      <input
-        className="repository--drafts-search"
-        onChange={[Function]}
-        placeholder="Search (By title or draftId)"
-        value=""
-      />
-      <div
-        className="repository--data-grid-drafts-container"
-      >
-        <div
-          className="react-data-table-component"
-          columns={
-            Array [
-              Object {
-                "name": "Draft ID",
-                "selector": "draftId",
-                "sortable": true,
-              },
-              Object {
-                "name": "Title",
-                "selector": "title",
-                "sortable": true,
-              },
-              Object {
-                "name": "Created At",
-                "selector": "createdAt",
-                "sortable": true,
-              },
-              Object {
-                "name": "Updated At",
-                "selector": "updatedAt",
-                "sortable": true,
-              },
-              Object {
-                "name": "Latest Version",
-                "selector": "latestVersion",
-                "sortable": true,
-              },
-              Object {
-                "name": "Revision Count",
-                "selector": "revisionCount",
-                "sortable": true,
-              },
-              Object {
-                "cell": [Function],
-                "name": "Preview",
-              },
-            ]
-          }
-          data={
-            Array [
-              Object {
-                "createdAt": "mock-created-at",
-                "draftId": "mock-draft-id-1",
-                "latestVersion": "mock-latest-version",
-                "revisionCount": 1,
-                "title": "mock-title-1",
-                "updatedAt": "mock-updated-at",
-              },
-              Object {
-                "createdAt": "mock-created-at",
-                "draftId": "mock-draft-id-2",
-                "latestVersion": "mock-latest-version",
-                "revisionCount": 1,
-                "title": "mock-title-2",
-                "updatedAt": "mock-updated-at",
-              },
-            ]
-          }
-          dense={true}
-          keyField="draftId"
-          onSelectedRowsChange={[Function]}
-          pagination={true}
-          paginationComponentOptions={
-            Object {
-              "noRowsPerPage": true,
-            }
-          }
-          paginationPerPage={100}
-          paginationRowsPerPageOptions={
-            Array [
-              100,
-            ]
-          }
-          selectableRows={true}
-          striped={true}
-          title="Modules (2 Results)"
-        >
-          react-data-table-component
-        </div>
-      </div>
-      <button
-        className="repository--button "
-        disabled={true}
-        onClick={[Function]}
-      >
-        Load stats for 0 selected modules
-      </button>
-      <div
-        className="stats"
-      />
     </section>
   </div>
 </span>

--- a/packages/app/obojobo-repository/shared/components/pages/page-stats-server.jsx
+++ b/packages/app/obojobo-repository/shared/components/pages/page-stats-server.jsx
@@ -20,6 +20,11 @@ const PageStatsServer = props => {
 }
 
 PageStatsServer.defaultProps = {
+	availableModules: {
+		hasFetched: false,
+		isFetching: false,
+		items: []
+	},
 	assessmentStats: {
 		hasFetched: false,
 		isFetching: false,

--- a/packages/app/obojobo-repository/shared/components/stats-hoc.js
+++ b/packages/app/obojobo-repository/shared/components/stats-hoc.js
@@ -1,8 +1,9 @@
 const Stats = require('./stats')
 const connect = require('react-redux').connect
-const { loadModuleAssessmentDetails } = require('../actions/stats-actions')
+const { loadUserModuleList, loadModuleAssessmentDetails } = require('../actions/stats-actions')
 const mapStoreStateToProps = state => state
 const mapActionsToProps = {
+	loadUserModuleList,
 	loadModuleAssessmentDetails
 }
 module.exports = connect(

--- a/packages/app/obojobo-repository/shared/components/stats-hoc.test.js
+++ b/packages/app/obojobo-repository/shared/components/stats-hoc.test.js
@@ -24,6 +24,7 @@ describe('stats HOC', () => {
 
 		expect(ReactRedux.connect).toHaveBeenCalledTimes(1)
 		expect(ReactRedux.connect).toHaveBeenCalledWith(expect.any(Function), {
+			loadUserModuleList: StatsActions.loadUserModuleList,
 			loadModuleAssessmentDetails: StatsActions.loadModuleAssessmentDetails
 		})
 

--- a/packages/app/obojobo-repository/shared/components/stats.jsx
+++ b/packages/app/obojobo-repository/shared/components/stats.jsx
@@ -2,7 +2,7 @@ require('./modal.scss')
 require('./stats.scss')
 
 const React = require('react')
-const { useState } = require('react')
+const { useState, useEffect } = require('react')
 const RepositoryNav = require('./repository-nav')
 const RepositoryBanner = require('./repository-banner')
 const Button = require('./button')
@@ -26,9 +26,21 @@ const renderAssessmentStats = assessmentStats => {
 	return null
 }
 
-function Stats({ currentUser, title, allModules, assessmentStats, loadModuleAssessmentDetails }) {
+function Stats({
+	currentUser,
+	title,
+	availableModules,
+	assessmentStats,
+	loadUserModuleList,
+	loadModuleAssessmentDetails
+}) {
 	const [selectedDrafts, setSelectedDrafts] = useState([])
 	const [search, setSearch] = useState('')
+
+	// When the component is mounted in the browser, request the list of available modules for the current user
+	useEffect(() => {
+		loadUserModuleList()
+	}, [])
 
 	const loadStats = () => {
 		loadModuleAssessmentDetails(selectedDrafts)
@@ -40,25 +52,18 @@ function Stats({ currentUser, title, allModules, assessmentStats, loadModuleAsse
 
 	const filteredModules =
 		search.length === 0
-			? allModules
-			: allModules.filter(module => {
+			? availableModules.items
+			: availableModules.items.filter(module => {
 					const lcSearch = search.toLowerCase()
 					return (
 						module.draftId.indexOf(lcSearch) > -1 ||
 						module.title.toLowerCase().indexOf(lcSearch) > -1
 					)
-			  }) //eslint-disable-line no-mixed-spaces-and-tabs
+			  })
 
-	return (
-		<span id="stats-root">
-			<RepositoryNav
-				userId={currentUser.id}
-				userPerms={currentUser.perms}
-				avatarUrl={currentUser.avatarUrl}
-				displayName={`${currentUser.firstName} ${currentUser.lastName}`}
-				noticeCount={0}
-			/>
-			<RepositoryBanner title={title} className="default-bg" />
+	let moduleListRender = 'Loading...'
+	if (availableModules.hasFetched) {
+		moduleListRender = (
 			<div className="repository--section-wrapper">
 				<section className="repository--main-content">
 					<input
@@ -79,6 +84,20 @@ function Stats({ currentUser, title, allModules, assessmentStats, loadModuleAsse
 					<div className="stats">{renderAssessmentStats(assessmentStats)}</div>
 				</section>
 			</div>
+		)
+	}
+
+	return (
+		<span id="stats-root">
+			<RepositoryNav
+				userId={currentUser.id}
+				userPerms={currentUser.perms}
+				avatarUrl={currentUser.avatarUrl}
+				displayName={`${currentUser.firstName} ${currentUser.lastName}`}
+				noticeCount={0}
+			/>
+			<RepositoryBanner title={title} className="default-bg" />
+			{moduleListRender}
 		</span>
 	)
 }

--- a/packages/app/obojobo-repository/shared/components/stats.scss
+++ b/packages/app/obojobo-repository/shared/components/stats.scss
@@ -10,7 +10,7 @@
 	}
 
 	.repository--data-grid-drafts-container {
-		height: 30em;
+		max-height: 30em;
 		overflow: scroll;
 		margin-bottom: 1em;
 	}

--- a/packages/app/obojobo-repository/shared/reducers/stats-reducer.js
+++ b/packages/app/obojobo-repository/shared/reducers/stats-reducer.js
@@ -1,9 +1,32 @@
 const { handle } = require('redux-pack')
 
-const { LOAD_MODULE_ASSESSMENT_DETAILS } = require('../actions/stats-actions')
+const {
+	LOAD_STATS_PAGE_MODULES_FOR_USER,
+	LOAD_MODULE_ASSESSMENT_DETAILS
+} = require('../actions/stats-actions')
 
 function StatsReducer(state, action) {
 	switch (action.type) {
+		case LOAD_STATS_PAGE_MODULES_FOR_USER:
+			return handle(state, action, {
+				start: prevState => ({
+					...prevState,
+					availableModules: {
+						isFetching: true,
+						hasFetched: false,
+						items: []
+					}
+				}),
+				success: prevState => ({
+					...prevState,
+					availableModules: {
+						isFetching: false,
+						hasFetched: true,
+						items: action.payload.value
+					}
+				})
+			})
+
 		case LOAD_MODULE_ASSESSMENT_DETAILS:
 			return handle(state, action, {
 				start: prevState => ({

--- a/packages/app/obojobo-repository/shared/reducers/stats-reducer.test.js
+++ b/packages/app/obojobo-repository/shared/reducers/stats-reducer.test.js
@@ -7,7 +7,10 @@ jest.mock('redux-pack', () => {
 
 const statsReducer = require('./stats-reducer')
 
-const { LOAD_MODULE_ASSESSMENT_DETAILS } = require('../actions/stats-actions')
+const {
+	LOAD_STATS_PAGE_MODULES_FOR_USER,
+	LOAD_MODULE_ASSESSMENT_DETAILS
+} = require('../actions/stats-actions')
 
 const Pack = require('redux-pack')
 
@@ -19,12 +22,81 @@ const handleSuccess = handler => {
 }
 
 describe('Stats Reducer', () => {
+	const mockModuleList = [
+		{
+			draftId: 'mock-draft-id-1',
+			title: 'mock-title-1',
+			createdAt: 'mock-created-at',
+			updatedAt: 'mock-updated-at',
+			latestVersion: 'mock-latest-version',
+			revisionCount: 1
+		},
+		{
+			draftId: 'mock-draft-id-2',
+			title: 'mock-title-2',
+			createdAt: 'mock-created-at',
+			updatedAt: 'mock-updated-at',
+			latestVersion: 'mock-latest-version',
+			revisionCount: 1
+		}
+	]
+
 	beforeEach(() => {
 		Pack.handle.mockClear()
 	})
 
-	test('LOAD_MODULE_ASSESSMENT_DETAILS action modifies state correctly', () => {
+	test('LOAD_STATS_PAGE_MODULES_FOR_USER action modifies state correctly', () => {
+		const unalteredAssessmentStats = {
+			isFetching: false,
+			hasFetched: false,
+			items: []
+		}
+
 		const initialState = {
+			availableModules: {
+				isFetching: false,
+				hasFetched: false,
+				items: []
+			},
+			assessmentStats: unalteredAssessmentStats
+		}
+		const action = {
+			type: LOAD_STATS_PAGE_MODULES_FOR_USER,
+			payload: {
+				value: mockModuleList
+			}
+		}
+
+		// asynchronous action - state changes on success
+		const handler = statsReducer(initialState, action)
+		let newState
+
+		newState = handleStart(handler)
+		expect(newState.assessmentStats).toEqual(unalteredAssessmentStats)
+		expect(newState.availableModules).toEqual({
+			isFetching: true,
+			hasFetched: false,
+			items: []
+		})
+
+		newState = handleSuccess(handler)
+		expect(newState.assessmentStats).toEqual(unalteredAssessmentStats)
+		expect(newState.availableModules).not.toEqual(initialState.availableModules)
+		expect(newState.availableModules).toEqual({
+			isFetching: false,
+			hasFetched: true,
+			items: mockModuleList
+		})
+	})
+
+	test('LOAD_MODULE_ASSESSMENT_DETAILS action modifies state correctly', () => {
+		const unalteredAvailableModules = {
+			isFetching: false,
+			hasFetched: false,
+			items: mockModuleList
+		}
+		const initialState = {
+			availableModules: unalteredAvailableModules,
 			assessmentStats: {
 				isFetching: false,
 				hasFetched: false,
@@ -53,6 +125,7 @@ describe('Stats Reducer', () => {
 		let newState
 
 		newState = handleStart(handler)
+		expect(newState.availableModules).toEqual(unalteredAvailableModules)
 		expect(newState.assessmentStats).toEqual({
 			isFetching: true,
 			hasFetched: false,
@@ -60,6 +133,7 @@ describe('Stats Reducer', () => {
 		})
 
 		newState = handleSuccess(handler)
+		expect(newState.availableModules).toEqual(unalteredAvailableModules)
 		expect(newState.assessmentStats).not.toEqual(initialState.assessmentStats)
 		expect(newState.assessmentStats).toEqual({
 			isFetching: false,


### PR DESCRIPTION
Following the most recent deploy to QA, we discovered that the stats page was not rendering properly - the initial (server-side) render of the module list was not being styled at all, whereas client-side renders of assessment stats were being styled properly.

Believing this is due to the module list being rendered on the server and the pre-generated style tag not being preserved after hydration, I refactored the Stats page to render only a basic container on the server which then generates the module list following an API call. Assessment stats are then rendered as before.