### PR TITLE
Add functionality to the local dev tools.

### DIFF
--- a/packages/app/obojobo-express/server/obo_express_dev.js
+++ b/packages/app/obojobo-express/server/obo_express_dev.js
@@ -207,7 +207,7 @@ module.exports = app => {
 								}
 							</form>
 						</li>
-						<li><b>Add permission to user:</b>
+						<li><b>Remove permission from user:</b>
 							<form id='resource-select-form'
 								method='post'
 								action='/dev/util/permission'>

--- a/packages/app/obojobo-express/server/obo_express_dev.js
+++ b/packages/app/obojobo-express/server/obo_express_dev.js
@@ -1,41 +1,50 @@
+const path = require('path')
+global.oboRequire = name => require(path.resolve(__dirname, '..', name))
+
+const db = require('obojobo-express/server/db')
 const sig = require('oauth-signature')
 const config = require('./config')
 const oauthKey = Object.keys(config.lti.keys)[0]
 const oauthSecret = config.lti.keys[oauthKey]
 const { isTrueParam } = require('obojobo-express/server/util/is_true_param')
 
-const ltiInstructor = {
-	lis_person_contact_email_primary: 'zach@obojobo.com',
-	lis_person_name_family: 'Instructor1',
-	lis_person_name_full: 'Test Instructor1',
-	lis_person_name_given: 'Test',
-	lis_person_sourcedid: 'sis:tstinstructor1',
-	roles: 'Instructor',
-	user_id: '29129',
-	user_image: 'https://s.gravatar.com/avatar/17f34572459fa620071cae55d7f1eacb?s=80'
+const User = require('obojobo-express/server/models/user')
+const DraftSummary = require('obojobo-repository/server/models/draft_summary')
+
+// Normally the query running in User.saveOrCreate would auto-fill the new user's id,
+// but since we're using the user's ID as part of their name and e-mail, we need to know what
+// it is going to be ahead of time
+const getNewUserId = () => {
+	return db.oneOrNone('SELECT MAX(id) AS max_id FROM users')
+		.then(result => parseInt(result.max_id, 10) + 1)
 }
 
-const ltiInstructor2 = {
-	lis_person_contact_email_primary: 'frankie@obojobo.com',
-	lis_person_name_family: 'Instructor2',
-	lis_person_name_full: 'Test Instructor2',
-	lis_person_name_given: 'Test',
-	lis_person_sourcedid: 'sis:tstinstructor2',
-	roles: 'Instructor',
-	user_id: '234111',
-	user_image: 'https://s.gravatar.com/avatar/17f34572459fa620071cae55d7f1eacb?s=80'
+const createNewUser = (id, type) => {
+	// If the database is freshly reset, there won't be any users - assume the first id is 1
+	if( ! id ) id = 1
+	const capType = type.charAt(0).toUpperCase() + type.slice(1)
+
+	const newUser = new User({
+		username: `sis:tst${type}${id}`,
+		email: `test_${type}_${id}@obojobo.com`,
+		firstName: 'Test',
+		lastName: `${capType} ${id}`,
+		roles: [capType]
+	})
+
+	return newUser.saveOrCreate()
 }
 
-const ltiLearner = {
-	lis_person_contact_email_primary: 'ian@obojobo.com',
-	lis_person_name_family: 'Learner1',
-	lis_person_name_full: 'Test Learner1',
-	lis_person_name_given: 'Test',
-	lis_person_sourcedid: 'sis:tstlearner1',
-	roles: 'Learner',
-	user_id: '29111',
+const spoofLTIUser = user => ({
+	lis_person_contact_email_primary: user.email,
+	lis_person_name_family: user.lastName,
+	lis_person_name_full: `${user.firstName} ${user.lastName}`,
+	lis_person_name_given: user.firstName,
+	lis_person_sourcedid: user.username,
+	roles: user.roles[0],
+	user_id: parseInt(user.id, 10) + 10000,
 	user_image: 'https://s.gravatar.com/avatar/17f34572459fa620071cae55d7f1eacb?s=80'
-}
+})
 
 const ltiToolConsumer = {
 	tool_consumer_info_product_family_code: 'obojobo-next',
@@ -77,9 +86,16 @@ const renderLtiLaunch = (paramsIn, method, endpoint, res) => {
 	res.set('Content-Type', 'text/html')
 	res.send(`<html>
 		<body>
-		<form id="form" method="${method}" action="${endpoint}" >${htmlInput}</form>
-		<script>document.getElementById('form').submit()</script>
-		</body></html>`)
+			<form id="form"
+				method="${method}"
+				action="${endpoint}">
+				${htmlInput}
+			</form>
+			<script>
+				document.getElementById('form').submit()
+			</script>
+		</body>
+	</html>`)
 }
 
 // util to get a baseUrl for inernal requests
@@ -92,61 +108,122 @@ module.exports = app => {
 
 	// index page with links to all the launch types
 	app.get('/dev', (req, res) => {
-		res.set('Content-Type', 'text/html')
-		res.send(`<html>
-			<head>
-			<title>Obojobo Next Express Dev Utils</title>
-			<script>
-				const launchInIframe = url => {
-					const iframeEl = document.getElementById('the-iframe')
-					iframeEl.src = url
-					iframeEl.scrollIntoView()
-				}
-			</script>
-			<style>
-				iframe{
-					width: 620px;
-					height: 475px;
-					resize: both;
-					overflow: auto;
-				}
-			</style>
-			</head><body>
-			<h1>Obojobo Next Express Dev Utils</h1>
-			<h2>LTI Tools</h2>
-			<ul>
-				<li><a href="/lti">LTI Instructions</a></li>
-				<li><b>LTI Course Nav:</b> (simulate LTI launch from clicking on LMS nav menu link)
+		const usersPromise = db.manyOrNone("SELECT id, first_name, last_name FROM users ORDER BY id ASC")
+		const draftsPromise = DraftSummary.fetchAll()
+
+		Promise.all([
+			usersPromise,
+			draftsPromise
+		]).then(results => {
+			const users = results[0]
+			const drafts = results[1]
+			const userOptions = users.map(user =>
+				`<option value=${user.id}>${user.first_name} ${user.last_name}</option>`
+			).join('')
+			const draftOptions = drafts.map(draft =>
+				`<option value="${draft.draftId}">${draft.title}</option>`
+			).join('')
+
+			let userSelectRender = '<p>No users found. Create a student or instructor with the buttons above.</p>'
+			if( userOptions && userOptions.length ) {
+				userSelectRender = `
+				<label for='user_id'>Select user:</label>
+				<select name='user_id'>
+					${userOptions}
+				</select>`
+			}
+
+			res.set('Content-Type', 'text/html')
+			res.send(`<html>
+				<head>
+					<title>Obojobo Next Express Dev Utils</title>
+					<script>
+						const launchInIframe = url => {
+							const iframeEl = document.getElementById('the-iframe')
+							iframeEl.src = url
+							iframeEl.scrollIntoView()
+						}
+						const scrollToIframe = () => {
+							const iframeEl = document.getElementById('the-iframe')
+							iframeEl.scrollIntoView()
+						}
+					</script>
+					<style>
+						iframe{
+							width: 620px;
+							height: 475px;
+							resize: both;
+							overflow: auto;
+						}
+					</style>
+				</head>
+				<body>
+					<h1>Obojobo Next Express Dev Utils</h1>
+					<h2>LTI Tools</h2>
 					<ul>
-						<li><a href="/lti/dev/launch/course_navigation?resource_link_id=course_1">Instructor</a></li>
-						<li><a href="/lti/dev/launch/course_navigation?resource_link_id=course_1&instructor=2">Instructor2</a></li>
-						<li><a href="/lti/dev/launch/course_navigation?resource_link_id=course_1&student=1">Student</a></li>
+						<li><b>Create new test users:</b>
+							<p>Add some inputs here for optional first/last/email etc. with reasonable defaults?</p>
+							<ul>
+								<li><a href="/lti/dev/new_user?type=instructor">Create a new test instructor</a></li>
+								<li><a href="/lti/dev/new_user?type=learner">Create a new test learner</a></li>
+							</ul>
+						</li>
+						<li><a href="/lti">LTI Instructions</a></li>
+						<li><b>LTI Course Nav:</b> (simulate LTI launch from clicking on LMS nav menu link)
+							<form id='course-nav-form'
+								method='post'
+								target='_blank'
+								action='/lti/dev/launch/course_navigation'>
+								<input type='hidden' name='resource_link_id' value='course_1' />
+								${userSelectRender}
+								${userOptions.length ? "<button type='submit' value='submit'>Go</button>" : ''}
+							</form>
+						</li>
+						<li><b>LTI Resource Selection:</b> (simulate LTI launch for resource/assignment selection)
+							<form id='resource-select-form'
+								method='get'
+								action='/lti/dev/launch/resource_selection'
+								target='the-iframe'>
+								${userSelectRender}
+								${userOptions.length ? `<button onClick="scrollToIframe()" type='submit' value='submit'>Go</button>` : ''}
+							</form>
+						</li>
+						<li><b>LTI Assignment:</b> (simulate LTI launch for an assignment)
+							<form id='resource-select-form'
+								method='get'
+								action='/lti/dev/launch/view'
+								target='_blank'>
+								${userSelectRender}
+								${
+									userOptions.length ?
+										`<br/>
+										<label for='draft_id'>Select module:</label>
+										<select name='draft_id'>
+											${draftOptions}
+										</select>
+										<br/>
+										<label for='import_enabled'>Score import enabled:</label>
+										<input type='checkbox' name='import_enabled' />
+										<br/>
+										<label for='resource_link_id'>LMS course ID:</label>
+										<input type='text' name='resource_link_id' placeholder="course_1"/>
+										<br/>
+										<button type='submit' value='submit'>Go</button>`
+									: ''
+								}
+							</form>
+						</li>
 					</ul>
-				</li>
-				<li><b>LTI Resource Selection:</b> (simulate LTI launch for resource/assignment selection)
+					<h2>Build Tools</h2>
 					<ul>
-						<li><a href="#" onClick="launchInIframe('/lti/dev/launch/resource_selection')">Instructor</a></li>
-						<li><a href="#" onClick="launchInIframe('/lti/dev/launch/resource_selection?instructor=2')">Instructor2</a></li>
-						<li><a href="#" onClick="launchInIframe('/lti/dev/launch/resource_selection?student=1')">Student</a></li>
+						<li><a href="/routes">Express Routes</a></li>
+						<li><a href="/webpack-dev-server">Webpack Dev Server Assets</a></li>
 					</ul>
-				</li>
-				<li><b>LTI Assignment:</b> (simulate LTI launch for an assignment)
-					<ul>
-						<li><a href="/lti/dev/launch/view?resource_link_id=course_1">Instructor for course_1</a></li>
-						<li><a href="/lti/dev/launch/view?resource_link_id=course_1&student=1">Student for course_1</a></li>
-						<li><a href="/lti/dev/launch/view?resource_link_id=course_2&student=1">Student for course_2</a></li>
-						<li><a href="/lti/dev/launch/view?resource_link_id=course_2&student=1&score_import=1">Student for course_2 w/ import enabled</a></li>
-					</ul>
-				</li>
-			</ul>
-			<h2>Build Tools</h2>
-			<ul>
-				<li><a href="/routes">Express Routes</a></li>
-				<li><a href="/webpack-dev-server">Webpack Dev Server Assets</a></li>
-			</ul>
-			<h2>Iframe for simulating assignment selection overlay</h2>
-			<iframe id="the-iframe"></iframe>
-			</body></html>`)
+					<h2>Iframe for simulating assignment selection overlay</h2>
+					<iframe id="the-iframe" name="the-iframe"></iframe>
+				</body>
+			</html>`)
+		})
 	})
 
 	// json list of every express.js route
@@ -168,96 +245,111 @@ module.exports = app => {
 		res.json(simplifiedEndpoints)
 	})
 
-	// builds a valid course navigation lti launch and submits it
-	app.get('/lti/dev/launch/course_navigation', (req, res) => {
-		const resource_link_id = req.query.resource_link_id || defaultResourceLinkId
-		const instructorOneOrTwo = req.query.instructor === '2' ? ltiInstructor2 : ltiInstructor
-		const person = req.query.student ? ltiLearner : instructorOneOrTwo
-		const method = 'POST'
-		const endpoint = `${baseUrl(req)}/lti/canvas/course_navigation`
-		const params = {
-			launch_presentation_css_url: 'https://example.fake/nope.css',
-			launch_presentation_document_target: 'frame',
-			launch_presentation_locale: 'en-US',
-			launch_presentation_return_url: 'https://example.fake/fake-return.html',
-			lis_course_offering_sourcedid: 'DD-ST101',
-			lis_course_section_sourcedid: 'DD-ST101:C1',
-			lis_outcome_service_url: 'https://example.fake/outcomes/fake',
-			lis_result_sourcedid: 'UzMyOTQ0NzY6Ojo0Mjk3ODUyMjY6OjoyOTEyMw==',
-			lti_message_type: 'basic-lti-launch-request',
-			lti_version: 'LTI-1p0',
-			resource_link_id,
-			resource_link_title: 'Phone home'
-		}
-		renderLtiLaunch(
-			{ ...ltiContext, ...person, ...ltiToolConsumer, ...params },
-			method,
-			endpoint,
-			res
-		)
+	app.post('/lti/dev/launch/course_navigation', (req, res) => {
+		// const resource_link_id = req.query.resource_link_id || defaultResourceLinkId
+		// const instructorOneOrTwo = req.query.instructor === '2' ? ltiInstructor2 : ltiInstructor
+		User.fetchById(req.body.user_id).then(user => {
+			const resource_link_id = req.body.resource_link_id || defaultResourceLinkId
+			const person = spoofLTIUser(user)
+			const params = {
+				launch_presentation_css_url: 'https://example.fake/nope.css',
+				launch_presentation_document_target: 'frame',
+				launch_presentation_locale: 'en-US',
+				launch_presentation_return_url: 'https://example.fake/fake-return.html',
+				lis_course_offering_sourcedid: 'DD-ST101',
+				lis_course_section_sourcedid: 'DD-ST101:C1',
+				lis_outcome_service_url: 'https://example.fake/outcomes/fake',
+				lis_result_sourcedid: 'UzMyOTQ0NzY6Ojo0Mjk3ODUyMjY6OjoyOTEyMw==',
+				lti_message_type: 'basic-lti-launch-request',
+				lti_version: 'LTI-1p0',
+				resource_link_id,
+				resource_link_title: 'Phone home'
+			}
+			renderLtiLaunch(
+				{ ...ltiContext, ...person, ...ltiToolConsumer, ...params },
+				'POST',
+				`${baseUrl(req)}/lti/canvas/course_navigation`,
+				res
+			)
+		})
 	})
 
 	// builds a valid document view lti launch and submits it
 	app.get('/lti/dev/launch/view', (req, res) => {
-		const resource_link_id = req.query.resource_link_id || defaultResourceLinkId
-		const draftId = req.query.draft_id || '00000000-0000-0000-0000-000000000000'
-		const person = req.query.student ? ltiLearner : ltiInstructor
-		const method = 'POST'
-		const endpoint = `${baseUrl(req)}/view/${draftId}`
-		const params = {
-			lis_outcome_service_url: 'https://example.fake/outcomes/fake',
-			lti_message_type: 'basic-lti-launch-request',
-			lti_version: 'LTI-1p0',
-			resource_link_id,
-			score_import: isTrueParam(req.query.score_import) ? 'true' : 'false'
-		}
-		renderLtiLaunch({ ...ltiContext, ...person, ...params }, method, endpoint, res)
+		User.fetchById(req.query.user_id).then(user => {
+			const resource_link_id = req.query.resource_link_id || defaultResourceLinkId
+			const draftId = req.query.draft_id || '00000000-0000-0000-0000-000000000000'
+			const params = {
+				lis_outcome_service_url: 'https://example.fake/outcomes/fake',
+				lti_message_type: 'basic-lti-launch-request',
+				lti_version: 'LTI-1p0',
+				resource_link_id,
+				score_import: isTrueParam(req.query.score_import) ? 'true' : 'false'
+			}
+			renderLtiLaunch(
+				{ ...ltiContext, ...user, ...params },
+				'POST',
+				`${baseUrl(req)}/view/${draftId}`,
+				res
+			)
+		})
 	})
 
 	// builds a valid resourse selection lti launch and submits it
 	app.get('/lti/dev/launch/resource_selection', (req, res) => {
-		const method = 'POST'
-		const person = req.query.student ? ltiLearner : ltiInstructor
-		const endpoint = `${baseUrl(req)}/lti/canvas/resource_selection`
-		const params = {
-			accept_copy_advice: 'false',
-			accept_media_types: '*/*',
-			accept_multiple: 'false',
-			accept_presentation_document_targets: 'embed,frame,iframe,window,popup,overlay,none',
-			accept_unsigned: 'false',
-			auto_create: 'true',
-			can_confirm: 'false',
-			content_item_return_url: `${baseUrl(
-				req
-			)}/lti/dev/return/resource_selection?test=this%20is%20a%20test`,
-			launch_presentation_css_url: 'https://example.fake/nope.css',
-			launch_presentation_locale: 'en-US',
-			lti_message_type: 'ContentItemSelectionRequest',
-			lti_version: 'LTI-1p0',
-			data: "this opaque 'data' should be sent back to the LMS!"
-		}
-		renderLtiLaunch(
-			{ ...ltiContext, ...person, ...ltiToolConsumer, ...params },
-			method,
-			endpoint,
-			res
-		)
+		User.fetchById(req.query.user_id).then(user => {
+			const person = spoofLTIUser(user)
+			const params = {
+				accept_copy_advice: 'false',
+				accept_media_types: '*/*',
+				accept_multiple: 'false',
+				accept_presentation_document_targets: 'embed,frame,iframe,window,popup,overlay,none',
+				accept_unsigned: 'false',
+				auto_create: 'true',
+				can_confirm: 'false',
+				content_item_return_url: `${baseUrl(
+					req
+				)}/lti/dev/return/resource_selection?test=this%20is%20a%20test`,
+				launch_presentation_css_url: 'https://example.fake/nope.css',
+				launch_presentation_locale: 'en-US',
+				lti_message_type: 'ContentItemSelectionRequest',
+				lti_version: 'LTI-1p0',
+				data: "this opaque 'data' should be sent back to the LMS!"
+			}
+			renderLtiLaunch(
+				{ ...ltiContext, ...person, ...ltiToolConsumer, ...params },
+				'POST',
+				`${baseUrl(req)}/lti/canvas/resource_selection`,
+				res
+			)
+		})
 	})
 
 	// route that resource selections will return to
 	app.post('/lti/dev/return/resource_selection', (req, res) => {
 		const data = JSON.parse(req.body.content_items)
 		res.set('Content-Type', 'text/html')
-		res.send(`<html><body><h1>Resource selected!</h1>
-			<ul>
-			<li>URL: ${req.originalUrl}</li>
-			<li>lti_message_type: ${req.body.lti_message_type}</li>
-			<li>Type: ${data['@graph'][0]['@type']}</li>
-			<li>URL: ${data['@graph'][0].url}</li>
-			<li>Title: ${data['@graph'][0].title}</li>
-			<li>Data: ${req.body.data}</li>
-			</ul>
-			<code>${req.body.content_items}</code>
-			</body></html>`)
+		res.send(`<html>
+			<body>
+				<h1>Resource selected!</h1>
+				<ul>
+					<li>URL: ${req.originalUrl}</li>
+					<li>lti_message_type: ${req.body.lti_message_type}</li>
+					<li>Type: ${data['@graph'][0]['@type']}</li>
+					<li>URL: ${data['@graph'][0].url}</li>
+					<li>Title: ${data['@graph'][0].title}</li>
+					<li>Data: ${req.body.data}</li>
+				</ul>
+				<code>${req.body.content_items}</code>
+			</body>
+		</html>`)
+	})
+
+	app.get('/lti/dev/new_user', (req, res) => {
+		getNewUserId().then(newId => {
+			createNewUser(newId, req.query.type).then(() => {
+				res.redirect('/dev')
+			})
+		})
 	})
 }

--- a/packages/app/obojobo-express/server/obo_express_dev.js
+++ b/packages/app/obojobo-express/server/obo_express_dev.js
@@ -28,7 +28,7 @@ const getNewUserId = () => {
 		.then(result => parseInt(result.max_id, 10) + 1)
 }
 
-const createNewUser = (id, type) => {
+const createNewUser = (id, first, last, type) => {
 	// If the database is freshly reset, there won't be any users - assume the first id is 1
 	if (!id) id = 1
 	const capType = type.charAt(0).toUpperCase() + type.slice(1)
@@ -36,8 +36,8 @@ const createNewUser = (id, type) => {
 	const newUser = new User({
 		username: `sis:tst${type}${id}`,
 		email: `test_${type}_${id}@obojobo.com`,
-		firstName: 'Test',
-		lastName: `${capType} ${id}`,
+		firstName: first || 'Test',
+		lastName: last || `${capType} ${id}`,
 		roles: [capType]
 	})
 
@@ -173,15 +173,21 @@ module.exports = app => {
 					<h2>User Management Tools</h2>
 					<ul>
 						<li><b>Create new test users:</b>
-							<p>Add some inputs here for optional first/last/email etc. with reasonable defaults?</p>
-							<ul>
-								<li><a href="/dev/util/new_user?type=instructor">Create a new test instructor</a></li>
-								<li><a href="/dev/util/new_user?type=learner">Create a new test learner</a></li>
-							</ul>
+							<form id='new-user-form'
+								method='post'
+								action='/dev/util/new_user'>
+								<label for='first'>First name:</label>
+								<input type='text' name='first' placeholder='Test (Optional)'/>
+								<br/>
+								<label for='last'>Last name:</label>
+								<input type='text' name='last' placeholder='User (Optional)'/>
+								<br/>
+								<button type='submit' name='type' value='instructor'>Create new test instructor</button>
+								Note: The <b>canViewEditor</b>, <b>canCreateDrafts</b>, <b>canDeleteDrafts</b>, and <b>canPreviewDrafts</b> permissions are implicit for instructors.
+								<br/>
+								<button type='submit' name='type' value='learner'>Create new test learner</button>
+							</form>
 						</li>
-						<p>
-						Note: The <b>canViewEditor</b>, <b>canCreateDrafts</b>, <b>canDeleteDrafts</b>, and <b>canPreviewDrafts</b> permissions are implicit for instructors.
-						</p>
 						<li><b>Add permission to user:</b>
 							<form id='resource-select-form'
 								method='post'
@@ -404,9 +410,10 @@ module.exports = app => {
 		</html>`)
 	})
 
-	app.get('/dev/util/new_user', (req, res) => {
+	app.post('/dev/util/new_user', (req, res) => {
 		getNewUserId().then(newId => {
-			createNewUser(newId, req.query.type).then(() => {
+			const { first, last, type } = req.body
+			createNewUser(newId, first, last, type).then(() => {
 				res.redirect('/dev')
 			})
 		})


### PR DESCRIPTION
Closes #1932.

- Adds the ability to generate new instructor or learner users on demand.
  - Can optionally provide first/last names.
- Adds the ability to add/remove permissions to users on demand.
- Adds the ability to choose a specific user for the login/picker tools.
- Adds the ability to choose a specific user and module for the preview/view tool.
  - Retains option for enabling score imports.

Apparently the dev tools never had unit tests, so they continue to not have unit tests.