### PR TITLE
made it so that removing your own access to a module calls onClose()

### DIFF
--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
@@ -39,7 +39,9 @@ class ModulePermissionsDialog extends React.Component {
 			const response = window.confirm('Remove yourself from this module?') //eslint-disable-line no-alert
 			if (!response) return
 		}
+
 		this.props.deleteModulePermissions(this.props.draftId, userId)
+		this.props.onClose()
 	}
 
 	renderModal() {

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.test.js
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.test.js
@@ -262,6 +262,8 @@ describe('ModulePermissionsDialog', () => {
 
 		expect(defaultProps.deleteModulePermissions).toHaveBeenCalledTimes(1)
 		expect(defaultProps.deleteModulePermissions).toHaveBeenCalledWith('mockDraftId', 99)
+		// checks that onClose has been called when removing current user's access
+		expect(defaultProps.onClose).toHaveBeenCalledTimes(1)
 	})
 
 	test('"close" and "done" buttons call props.onClose', () => {


### PR DESCRIPTION
Tested on Firefox, Chrome, and Safari; automated tests pass and coverage is met.