### PR TITLE
More info box z-index issue in firefox

### DIFF
--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/editor-nav.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/navigation/editor-nav.scss
@@ -8,7 +8,7 @@
 
 	height: inherit;
 	display: table-cell;
-	z-index: $z-index-above-content;
+	z-index: $z-index-above-most;
 	font-family: $font-default;
 	color: $color-text;
 	background: $color-nav-bg;

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.scss
@@ -3,7 +3,7 @@
 .oboeditor-component {
 	position: relative;
 
-	.is-selected {
+	&.is-selected {
 		z-index: $z-index-above-content;
 	}
 

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/node/editor-component.scss
@@ -3,7 +3,7 @@
 .oboeditor-component {
 	position: relative;
 
-	&.is-selected {
+	.is-selected {
 		z-index: $z-index-above-content;
 	}
 


### PR DESCRIPTION
Fixes #1950 

Adjusted `&.is-selected` to just `.is-selected` in the CSS for nodes, which for whatever CSS reason seems to have fixed things appearing on top of the more info box.