### PR TITLE
Fixes caliper_store table removal migration's rollback function.

### DIFF
--- a/packages/app/obojobo-express/server/migrations/20210910201141-remove-caliper-table.js
+++ b/packages/app/obojobo-express/server/migrations/20210910201141-remove-caliper-table.js
@@ -28,9 +28,9 @@ exports.down = function(db) {
 				defaultValue: new String('now()')
 			},
 			payload: { type: 'json', notNull: true },
-			is_preview: { type: Boolean }
+			is_preview: { type: 'boolean' }
 		})
-		.then(result => {
+		.then(() => {
 			return db.addIndex('caliper_store', 'caliper_store_created_at_index', ['created_at'])
 		})
 		.then(() => {


### PR DESCRIPTION
Fixes #1977.

Fixes the 'down' operation for the migration that removes the `caliper_store` table.