### PR TITLE
Fixes numeric/MC question survey toggle misbehavior.

### DIFF
--- a/packages/obonode/obojobo-chunks-numeric-assessment/editor-component.js
+++ b/packages/obonode/obojobo-chunks-numeric-assessment/editor-component.js
@@ -40,7 +40,7 @@ class NumericAssessment extends React.Component {
 			<div
 				className={
 					'component obojobo-draft--chunks--numeric-assessment is-type-' +
-					this.props.element.questionType
+					(this.props.element.questionType || 'default')
 				}
 			>
 				{this.props.children}

--- a/packages/obonode/obojobo-chunks-numeric-assessment/editor-component.test.js
+++ b/packages/obonode/obojobo-chunks-numeric-assessment/editor-component.test.js
@@ -43,6 +43,23 @@ describe('NumericAssessment Editor Node', () => {
 		const component = renderer.create(<NumericAssessment {...props} />)
 		const tree = component.toJSON()
 		expect(tree).toMatchSnapshot()
+
+		expect(component.root.children[0].props.className).toEqual(
+			'component obojobo-draft--chunks--numeric-assessment is-type-mock-question-type'
+		)
+	})
+
+	test('NumericAssessment renders as expected (no questionType)', () => {
+		const props = {
+			editor: {},
+			element: {
+				children: []
+			}
+		}
+		const component = renderer.create(<NumericAssessment {...props} />)
+		expect(component.root.children[0].props.className).toEqual(
+			'component obojobo-draft--chunks--numeric-assessment is-type-default'
+		)
 	})
 
 	test('Button adds an answer choice', () => {

--- a/packages/obonode/obojobo-chunks-question/editor-component.js
+++ b/packages/obonode/obojobo-chunks-question/editor-component.js
@@ -44,6 +44,7 @@ class Question extends React.Component {
 
 		// update this element's content.type
 		const path = ReactEditor.findPath(this.props.editor, this.props.element)
+
 		Transforms.setNodes(
 			this.props.editor,
 			{ content: { ...this.props.element.content, type } },
@@ -72,6 +73,9 @@ class Question extends React.Component {
 
 		const item = Common.Registry.getItemForType(type)
 		const newBlock = item.cloneBlankNode()
+
+		// preserve whether this question is a survey or not
+		newBlock.questionType = this.props.element.content.type
 
 		const path = ReactEditor.findPath(this.props.editor, this.props.element)
 		const hasSolution = this.getHasSolution()


### PR DESCRIPTION
Fixes #1922.

Makes sure `questionType`, whether 'default' or 'survey', is properly applied when changing a question's type between multiple choice or numeric.