### PR TITLE
Fixes LTI module picker not listing personal modules. Fixes module restoration crashes in dashboard.

### DIFF
--- a/packages/app/obojobo-module-selector/client/js/module-selector.js
+++ b/packages/app/obojobo-module-selector/client/js/module-selector.js
@@ -310,7 +310,10 @@ import '../css/module-selector.scss'
 			.then(respJson => {
 				if (respJson.status !== 'ok') throw 'Failed loading modules'
 
-				data.allItems = data.items = respJson.value
+				// personal module lookup has an extra layer indicating total module count
+				data.allItems = data.items = respJson.value.modules
+					? respJson.value.modules
+					: respJson.value
 				populateSection(section, title, color)
 
 				if (searchEl.value !== '') {

--- a/packages/app/obojobo-repository/shared/actions/dashboard-actions.js
+++ b/packages/app/obojobo-repository/shared/actions/dashboard-actions.js
@@ -369,7 +369,7 @@ const bulkRemoveModulesFromCollection = (draftIds, collectionId) => ({
 const BULK_RESTORE_MODULES = 'BULK_RESTORE_MODULES'
 const bulkRestoreModules = draftIds => ({
 	type: BULK_RESTORE_MODULES,
-	promise: Promise.all(draftIds.map(id => apiRestoreModule(id))).then(apiGetMyModules)
+	promise: Promise.all(draftIds.map(id => apiRestoreModule(id))).then(apiGetMyDeletedModules)
 })
 
 const CREATE_NEW_MODULE = 'CREATE_NEW_MODULE'

--- a/packages/app/obojobo-repository/shared/actions/dashboard-actions.test.js
+++ b/packages/app/obojobo-repository/shared/actions/dashboard-actions.test.js
@@ -1890,7 +1890,7 @@ describe('Dashboard Actions', () => {
 		})
 	}
 	test('bulkRestoreModules returns expected output and calls other functions', () => {
-		return assertBulkRestoreModulesRunsWithOptions('/api/drafts')
+		return assertBulkRestoreModulesRunsWithOptions('/api/drafts-deleted')
 	})
 
 	const assertGetMyDeletedModulesRunsWithOptions = (secondaryLookupUrl, fetchBody, options) => {

--- a/packages/app/obojobo-repository/shared/components/dashboard.jsx
+++ b/packages/app/obojobo-repository/shared/components/dashboard.jsx
@@ -410,7 +410,7 @@ function Dashboard(props) {
 		const response = prompt(
 			`Are you sure you want to DELETE these ${draftIds.length} selected modules? Type 'DELETE' to confirm.`
 		)
-		if (response !== 'DELETE') return
+		if (response !== 'DELETE') return setIsLoading(false)
 		props.bulkDeleteModules(draftIds).then(() => setIsLoading(false))
 	}
 

--- a/packages/app/obojobo-repository/shared/components/dashboard.jsx
+++ b/packages/app/obojobo-repository/shared/components/dashboard.jsx
@@ -447,6 +447,9 @@ function Dashboard(props) {
 				case MODE_RECENT:
 					// Default view is 'only show the five most recent changes', do nothing with the path
 					break
+				case MODE_DELETED:
+					modeUrlString = `${modeUrlString}/deleted`
+					break
 				case MODE_ALL:
 				default:
 					modeUrlString = `${modeUrlString}/all`
@@ -456,7 +459,6 @@ function Dashboard(props) {
 			const commonCookieString = `expires=${expires.toUTCString()}; path=${modeUrlString}`
 			document.cookie = `moduleSortOrder=${moduleSortOrder}; ${commonCookieString}`
 			document.cookie = `collectionSortOrder=${collectionSortOrder}; ${commonCookieString}`
-			// setLastSelectedIndex(0)
 		}, [moduleSortOrder, collectionSortOrder])
 	}
 
@@ -537,7 +539,6 @@ function Dashboard(props) {
 			</React.Fragment>
 		)
 
-		// eslint-disable-next-line no-case-declarations
 		let collectionFilterRender = null
 		if (props.myCollections.length > 0) {
 			collectionFilterRender = (

--- a/packages/app/obojobo-repository/shared/reducers/dashboard-reducer.js
+++ b/packages/app/obojobo-repository/shared/reducers/dashboard-reducer.js
@@ -168,8 +168,7 @@ function DashboardReducer(state, action) {
 						moduleCount: action.payload.value.allCount,
 						filteredModules,
 						selectedModules: [],
-						multiSelectMode: false,
-						showDeletedModules: false
+						multiSelectMode: false
 					}
 				}
 			})
@@ -421,28 +420,24 @@ function DashboardReducer(state, action) {
 			return handle(state, action, {
 				success: prevState => ({
 					...prevState,
-					myModules: action.payload.value,
-					showDeletedModules: false
+					myModules: action.payload.value
 				})
 			})
 
 		case GET_DELETED_MODULES:
 			return handle(state, action, {
 				success: prevState => ({
-					selectedModules: prevState.selectedModules,
-					currentUser: prevState.currentUser,
-					myModules: action.payload.value,
-					showDeletedModules: true
+					...prevState,
+					myModules: action.payload.value
 				})
 			})
 
 		case BULK_RESTORE_MODULES:
 			return handle(state, action, {
 				success: prevState => ({
+					...prevState,
 					selectedModules: [],
-					currentUser: prevState.currentUser,
 					myModules: action.payload.value,
-					showDeletedModules: false,
 					multiSelectMode: false
 				})
 			})

--- a/packages/app/obojobo-repository/shared/reducers/dashboard-reducer.test.js
+++ b/packages/app/obojobo-repository/shared/reducers/dashboard-reducer.test.js
@@ -1205,8 +1205,7 @@ describe('Dashboard Reducer', () => {
 					title: 'C Mock Module'
 				}
 			],
-			selectedModules: [],
-			showDeletedModules: true
+			selectedModules: []
 		}
 
 		const undeletedModules = [
@@ -1223,15 +1222,13 @@ describe('Dashboard Reducer', () => {
 		const action = {
 			type: GET_MODULES,
 			payload: {
-				value: undeletedModules,
-				showDeletedModules: false
+				value: undeletedModules
 			}
 		}
 
 		const handler = dashboardReducer(initialState, action)
 		const newState = handleSuccess(handler)
 		expect(newState.myModules).toEqual(undeletedModules)
-		expect(newState.showDeletedModules).toBe(false)
 	})
 
 	test('GET_DELETED_MODULES action modifies state correctly', () => {
@@ -1251,8 +1248,7 @@ describe('Dashboard Reducer', () => {
 					title: 'C Mock Module'
 				}
 			],
-			selectedModules: [],
-			showDeletedModules: true
+			selectedModules: []
 		}
 
 		const deletedModules = [
@@ -1269,15 +1265,13 @@ describe('Dashboard Reducer', () => {
 		const action = {
 			type: GET_DELETED_MODULES,
 			payload: {
-				value: deletedModules,
-				showDeletedModules: true
+				value: deletedModules
 			}
 		}
 
 		const handler = dashboardReducer(initialState, action)
 		const newState = handleSuccess(handler)
 		expect(newState.myModules).toEqual(deletedModules)
-		expect(newState.showDeletedModules).toBe(true)
 	})
 
 	test('BULK_RESTORE_MODULES action modifies state correctly', () => {
@@ -1298,7 +1292,6 @@ describe('Dashboard Reducer', () => {
 
 		const initialState = {
 			multiSelectMode: true,
-			showDeletedModules: true,
 			selectedModules: ['mockDraftId'],
 			myModules: [
 				{
@@ -1322,7 +1315,6 @@ describe('Dashboard Reducer', () => {
 		expect(newState.myModules).toEqual(mockModuleList)
 		expect(newState.selectedModules).toEqual([])
 		expect(newState.multiSelectMode).toBe(false)
-		expect(newState.showDeletedModules).toBe(false)
 	})
 
 	test('unrecognized action types just return the current state', () => {


### PR DESCRIPTION
Fixed LTI module selector not showing personal modules (or absence thereof). Fixed dashboard crashing in 'deleted' mode after restoring modules. Cleaned up unused/unnecessary state changes in dashboard reducer. Changed API call in dashboard action after restoring deleted modules. Adjusted tests re: actions/reducer changes.