### PR TITLE
Draft: Add Access Levels to Sharing Permissions

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/visual-editor.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/__snapshots__/visual-editor.test.js.snap
@@ -534,6 +534,7 @@ exports[`VisualEditor VisualEditor component 1`] = `
       </button>
     </div>
     <div
+      accessLevel="Full"
       className="mockFileToolbarViewer"
       insertableItems="mock-insertable-items"
       mode="visual"
@@ -1177,6 +1178,7 @@ exports[`VisualEditor VisualEditor component changes pages 1`] = `
       </button>
     </div>
     <div
+      accessLevel="Full"
       className="mockFileToolbarViewer"
       insertableItems="mock-insertable-items"
       mode="visual"
@@ -1820,6 +1822,7 @@ exports[`VisualEditor VisualEditor component changes pages 2`] = `
       </button>
     </div>
     <div
+      accessLevel="Full"
       className="mockFileToolbarViewer"
       insertableItems="mock-insertable-items"
       mode="visual"
@@ -2509,6 +2512,7 @@ exports[`VisualEditor VisualEditor component with no page 1`] = `
       </button>
     </div>
     <div
+      accessLevel="Full"
       className="mockFileToolbarViewer"
       insertableItems="mock-insertable-items"
       mode="visual"
@@ -3148,6 +3152,7 @@ exports[`VisualEditor reload disables event listener and calls location.reload 1
       </button>
     </div>
     <div
+      accessLevel="Full"
       className="mockFileToolbarViewer"
       insertableItems="mock-insertable-items"
       mode="visual"

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/__snapshots__/file-menu.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/__snapshots__/file-menu.test.js.snap
@@ -2,5 +2,5 @@
 
 exports[`File Menu File Menu node 1`] = `
 "<div class=\\"visual-editor--drop-down-menu\\"><div class=\\"dropdown  is-not-open\\" tabindex=\\"-1\\"><button class=\\"menu-title\\">File</button><div class=\\"menu-items\\"><button>Save Module<span>
-CTRL+S</span></button><button>New</button><button>Make a copy...</button><div class=\\"dropdown  is-not-open\\" tabindex=\\"-1\\"><button class=\\"menu-title\\">Download</button><div class=\\"menu-items\\"><button>XML Document (.xml)</button><button>JSON Document (.json)</button></div></div><button>Import from file...</button><button>Delete Module...</button><button>Copy LTI Link</button></div></div></div>"
+CTRL+S</span></button><button>New</button><button>Make a copy...</button><div class=\\"dropdown  is-not-open\\" tabindex=\\"-1\\"><button class=\\"menu-title\\">Download</button><div class=\\"menu-items\\"><button>XML Document (.xml)</button><button>JSON Document (.json)</button></div></div><button>Import from file...</button><button disabled=\\"\\">Delete Module...</button><button>Copy LTI Link</button></div></div></div>"
 `;

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/file-menu.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/toolbars/file-menu.test.js
@@ -166,13 +166,27 @@ describe('File Menu', () => {
 			title: 'mockTitle'
 		}
 
-		const component = mount(<FileMenu draftId="mockDraft" model={model} />)
+		const component = mount(<FileMenu draftId="mockDraft" model={model} accessLevel="Full" />)
 
 		component
 			.findWhere(n => n.type() === 'button' && n.html().includes('Delete Module...'))
 			.simulate('click')
 
 		expect(ModalUtil.show).toHaveBeenCalled()
+	})
+
+	test('FileMenu does not call Delete if accessLevel is not "Full"', () => {
+		const model = {
+			title: 'mockTitle'
+		}
+
+		const component = mount(<FileMenu draftId="mockDraft" model={model} accessLevel="Partial" />)
+
+		component
+			.findWhere(n => n.type() === 'button' && n.html().includes('Delete Module...'))
+			.simulate('click')
+
+		expect(ModalUtil.show).not.toHaveBeenCalled()
 	})
 
 	test('FileMenu calls Copy LTI Link', () => {

--- a/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/oboeditor/components/visual-editor.test.js
@@ -43,6 +43,8 @@ const BREAK_NODE = 'ObojoboDraft.Chunks.Break'
 let restoreConsole
 
 describe('VisualEditor', () => {
+	let props
+
 	beforeEach(() => {
 		jest.clearAllMocks()
 		jest.restoreAllMocks()
@@ -60,6 +62,17 @@ describe('VisualEditor', () => {
 			])
 		)
 		Editor.marks = jest.fn().mockReturnValue({})
+
+		props = {
+			insertableItems: 'mock-insertable-items',
+			page: {
+				attributes: { children: [{ type: 'mockNode' }] },
+				get: jest.fn(),
+				toJSON: () => ({ children: [{ type: 'mockNode' }] })
+			},
+			model: { title: 'Mock Title' },
+			draft: { accessLevel: 'Full' }
+		}
 	})
 
 	afterEach(() => {
@@ -67,30 +80,12 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const component = renderer.create(<VisualEditor {...props} />)
 		expect(component.toJSON()).toMatchSnapshot()
 	})
 
 	test('VisualEditor component handles triple click', () => {
 		const spy = jest.spyOn(Transforms, 'move').mockReturnValueOnce(true)
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const component = mount(<VisualEditor {...props} />)
 
 		// Double click
@@ -120,15 +115,6 @@ describe('VisualEditor', () => {
 	test('VisualEditor component - editor is disable when modal is opened', () => {
 		ModalStore.init()
 
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const component = renderer.create(<VisualEditor {...props} />)
 
 		Dispatcher.trigger('modal:show', { value: 'mockValue' })
@@ -138,15 +124,6 @@ describe('VisualEditor', () => {
 	test('VisualEditor component - editor is disable when modal is closed', () => {
 		ModalStore.init()
 
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const component = renderer.create(<VisualEditor {...props} />)
 
 		Dispatcher.trigger('modal:hide', { value: 'mockValue' })
@@ -154,15 +131,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component with decoration', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		jest.spyOn(Common.Registry, 'getItemForType').mockReturnValue({
 			plugins: {
 				decorate: () => [
@@ -187,15 +155,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component with Elements', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		jest.spyOn(Common.Registry, 'getItemForType').mockReturnValue({
 			plugins: {
 				renderNode: () => <p>Mock Content</p> //eslint-disable-line react/display-name
@@ -226,22 +185,15 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component with no page', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: null,
-			model: { title: 'Mock Title' }
-		}
+		props.page = null
 
 		const component = renderer.create(<VisualEditor {...props} />)
 		expect(component.toJSON()).toMatchSnapshot()
 	})
 
 	test('updating a component with no page doesnt update state', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: null,
-			model: { title: 'Mock Title' }
-		}
+		props.page = null
+
 		const thing = renderer.create(<VisualEditor {...props} />)
 
 		const instance = thing.getInstance()
@@ -253,15 +205,8 @@ describe('VisualEditor', () => {
 	})
 
 	test('updating a component from no page to a page updates state', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }], type: ASSESSMENT_NODE })
-			},
-			model: { title: 'Mock Title' }
-		}
+		props.page.toJSON = () => ({ children: [{ type: 'mockNode' }], type: ASSESSMENT_NODE })
+
 		jest.spyOn(Common.Registry, 'getItemForType').mockReturnValue({
 			oboToSlate: () => ({ text: '' })
 		})
@@ -278,11 +223,8 @@ describe('VisualEditor', () => {
 	})
 
 	test('updating a component from a page to no page updates state', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: null,
-			model: { title: 'Mock Title' }
-		}
+		props.page = null
+
 		const thing = renderer.create(<VisualEditor {...props} />)
 
 		const instance = thing.getInstance()
@@ -296,18 +238,14 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component changes pages', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				id: 1,
-				set: jest.fn(),
-				attributes: {
-					children: [{ type: 'mockNode' }]
-				},
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
+		props.page = {
+			id: 1,
+			set: jest.fn(),
+			attributes: {
+				children: [{ type: 'mockNode' }]
 			},
-			model: { title: 'Mock Title' }
+			get: jest.fn(),
+			toJSON: () => ({ children: [{ type: 'mockNode' }] })
 		}
 
 		let thing
@@ -350,7 +288,8 @@ describe('VisualEditor', () => {
 					]
 				})
 			},
-			model: { title: 'Mock Title' }
+			model: { title: 'Mock Title' },
+			draft: { accessLevel: 'Full' }
 		}
 
 		const newProps = {
@@ -377,7 +316,8 @@ describe('VisualEditor', () => {
 					]
 				})
 			},
-			model: { title: 'Mock Title' }
+			model: { title: 'Mock Title' },
+			draft: { accessLevel: 'Full' }
 		}
 
 		const spy = jest.spyOn(VisualEditor.prototype, 'exportToJSON').mockReturnValueOnce()
@@ -418,7 +358,8 @@ describe('VisualEditor', () => {
 					]
 				})
 			},
-			model: { title: 'Mock Title' }
+			model: { title: 'Mock Title' },
+			draft: { accessLevel: 'Full' }
 		}
 
 		const newProps = {
@@ -445,7 +386,8 @@ describe('VisualEditor', () => {
 					]
 				})
 			},
-			model: { title: 'Mock Title' }
+			model: { title: 'Mock Title' },
+			draft: { accessLevel: 'Full' }
 		}
 
 		const spy = jest.spyOn(VisualEditor.prototype, 'exportToJSON')
@@ -468,14 +410,7 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component refocuses on editor', () => {
-		const props = {
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
+		props.insertableItems = null
 
 		jest.spyOn(ReactEditor, 'focus').mockReturnValue(true)
 		const component = mount(<VisualEditor {...props} />)
@@ -488,15 +423,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component alters value majorly', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const component = mount(<VisualEditor {...props} />)
 
 		const value = [
@@ -510,15 +436,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component alters value majorly with multi-select', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		jest.spyOn(ReactEditor, 'isFocused').mockReturnValue(true)
 		window.getSelection = jest.fn().mockReturnValue({
 			getRangeAt: () => ({
@@ -543,15 +460,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('VisualEditor component alters value majorly with latex', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		jest.spyOn(ReactEditor, 'isFocused').mockReturnValue(true)
 		window.getSelection = jest.fn().mockReturnValue({
 			getRangeAt: () => ({
@@ -576,15 +484,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('toggleEditable changes the state', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const component = mount(<VisualEditor {...props} />)
 		const inst = component.instance()
 
@@ -606,15 +505,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('markUnsaved changes the state', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const component = mount(<VisualEditor {...props} />)
 		const inst = component.instance()
 
@@ -677,7 +567,8 @@ describe('VisualEditor', () => {
 				flatJSON: () => {
 					return { content: {}, children: [] }
 				}
-			}
+			},
+			draft: { accessLevel: 'Full' }
 		}
 
 		const saveModule = jest.spyOn(VisualEditor.prototype, 'saveModule')
@@ -739,7 +630,8 @@ describe('VisualEditor', () => {
 				flatJSON: () => {
 					return { content: {}, children: [] }
 				}
-			}
+			},
+			draft: { accessLevel: 'Full' }
 		}
 
 		const saveModule = jest.spyOn(VisualEditor.prototype, 'saveModule')
@@ -824,7 +716,8 @@ describe('VisualEditor', () => {
 				flatJSON: () => {
 					return { content: {}, children: [] }
 				}
-			}
+			},
+			draft: { accessLevel: 'Full' }
 		}
 		const component = mount(<VisualEditor {...props} />)
 		const plugins = component.instance().plugins
@@ -860,16 +753,6 @@ describe('VisualEditor', () => {
 				type: 'ObojoboDraft.Sections.Assessment',
 				children: [{ type: 'mock node' }]
 			})
-		}
-
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mock node' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mock node' }] })
-			},
-			model: { title: 'Mock Title' }
 		}
 
 		const value = {
@@ -921,16 +804,6 @@ describe('VisualEditor', () => {
 			toJSON: () => ({ children: [{ type: 'mock node' }] })
 		}
 
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mock node' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mock node' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
-
 		const value = ['node-one', 'node-two']
 
 		const thing = mount(<VisualEditor {...props} />)
@@ -963,15 +836,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('exportToJSON returns undefined for null page', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mock node' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mock node' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const thing = mount(<VisualEditor {...props} />)
 
 		expect(thing.instance()).toHaveProperty('exportToJSON', expect.any(Function))
@@ -996,7 +860,8 @@ describe('VisualEditor', () => {
 				get: jest.fn(),
 				toJSON: () => ({ children: [{ type: 'mock node' }] })
 			},
-			model: { title: 'Mock Title' }
+			model: { title: 'Mock Title' },
+			draft: { accessLevel: 'Full' }
 		}
 		const component = mount(<VisualEditor {...props} />)
 
@@ -1027,7 +892,8 @@ describe('VisualEditor', () => {
 				title: 'Mock Title',
 				flatJSON: () => ({ content: {} }),
 				children: []
-			}
+			},
+			draft: { accessLevel: 'Full' }
 		}
 
 		const component = mount(<VisualEditor {...props} />)
@@ -1058,7 +924,8 @@ describe('VisualEditor', () => {
 				title: 'Mock Title',
 				flatJSON: () => ({ content: {} }),
 				children: []
-			}
+			},
+			draft: { accessLevel: 'Full' }
 		}
 
 		const component = mount(<VisualEditor {...props} />)
@@ -1109,7 +976,8 @@ describe('VisualEditor', () => {
 				title: 'Mock Title',
 				flatJSON: () => ({ content: {} }),
 				children: []
-			}
+			},
+			draft: { accessLevel: 'Full' }
 		}
 
 		const component = mount(<VisualEditor {...props} />)
@@ -1231,7 +1099,8 @@ describe('VisualEditor', () => {
 				title: 'Mock Title',
 				flatJSON: () => ({ content: {} }),
 				children: []
-			}
+			},
+			draft: { accessLevel: 'Full' }
 		}
 
 		const component = mount(<VisualEditor {...props} />)
@@ -1293,7 +1162,8 @@ describe('VisualEditor', () => {
 				title: 'Mock Title',
 				flatJSON: () => ({ content: {} }),
 				children: []
-			}
+			},
+			draft: { accessLevel: 'Full' }
 		}
 
 		const component = mount(<VisualEditor {...props} />)
@@ -1336,11 +1206,7 @@ describe('VisualEditor', () => {
 		Object.defineProperty(window, 'location', {
 			value: { reload: jest.fn() }
 		})
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: { toJSON: () => ({ children: [{ type: 'mock node' }] }) },
-			model: { title: 'Mock Title' }
-		}
+
 		const component = renderer.create(<VisualEditor {...props} />)
 
 		component.getInstance().reload()
@@ -1350,15 +1216,6 @@ describe('VisualEditor', () => {
 	})
 
 	test('onResized sets state.contentRect', () => {
-		const props = {
-			insertableItems: 'mock-insertable-items',
-			page: {
-				attributes: { children: [{ type: 'mockNode' }] },
-				get: jest.fn(),
-				toJSON: () => ({ children: [{ type: 'mockNode' }] })
-			},
-			model: { title: 'Mock Title' }
-		}
 		const component = mount(<VisualEditor {...props} />)
 
 		expect(component.state().contentRect).toBe(null)

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-menu.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-menu.js
@@ -143,6 +143,7 @@ class FileMenu extends React.PureComponent {
 			{
 				name: 'Delete Module...',
 				type: 'action',
+				disabled: this.props.accessLevel !== 'Full',
 				action: () => {
 					const buttons = [
 						{

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-toolbar.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/toolbars/file-toolbar.js
@@ -78,6 +78,7 @@ const FileToolbar = props => {
 				onSave={props.onSave}
 				reload={props.reload}
 				mode={props.mode}
+				accessLevel={props.accessLevel}
 			/>
 			<div className="visual-editor--drop-down-menu">
 				<DropDownMenu name="Edit" menu={editMenu} />

--- a/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
+++ b/packages/app/obojobo-document-engine/src/scripts/oboeditor/components/visual-editor.js
@@ -560,6 +560,7 @@ class VisualEditor extends React.Component {
 							<FileToolbarViewer
 								title={this.props.model.title}
 								draftId={this.props.draftId}
+								accessLevel={this.props.draft.accessLevel}
 								onSave={this.saveModule}
 								reload={this.reload}
 								switchMode={this.props.switchMode}

--- a/packages/app/obojobo-express/__tests__/express_current_document.test.js
+++ b/packages/app/obojobo-express/__tests__/express_current_document.test.js
@@ -12,7 +12,7 @@ describe('current document middleware', () => {
 	beforeEach(() => {
 		mockArgs = (() => {
 			const res = {}
-			const req = { session: {} }
+			const req = { session: {}, currentUser: {} }
 			const mockJson = jest.fn().mockImplementation(() => {
 				return true
 			})

--- a/packages/app/obojobo-express/__tests__/models/__snapshots__/user.test.js.snap
+++ b/packages/app/obojobo-express/__tests__/models/__snapshots__/user.test.js.snap
@@ -14,6 +14,7 @@ Array [
 			RETURNING id
 			",
   Object {
+    "accessLevel": undefined,
     "avatarUrl": "https://secure.gravatar.com/avatar/19c0a7d712a610200eb3b9686aa0de4a?s=120&d=retro",
     "firstName": "Roger",
     "id": 3,
@@ -32,6 +33,7 @@ Array [
 
 exports[`user model fetchById fetches one from the database 1`] = `
 Object {
+  "accessLevel": undefined,
   "avatarUrl": "https://secure.gravatar.com/avatar/7cd5405dd878f2f032418e1bd8dfba0c?s=120&d=retro",
   "firstName": "Guest",
   "id": 5,
@@ -71,6 +73,7 @@ Array [
 			RETURNING id
 			",
   Object {
+    "accessLevel": undefined,
     "avatarUrl": "https://secure.gravatar.com/avatar/19c0a7d712a610200eb3b9686aa0de4a?s=120&d=retro",
     "firstName": "Roger",
     "id": 10,

--- a/packages/app/obojobo-express/__tests__/models/draft.test.js
+++ b/packages/app/obojobo-express/__tests__/models/draft.test.js
@@ -299,27 +299,26 @@ describe('Draft Model', () => {
 		})
 	})
 
-	test('deleteByIdAndUser sets delete flag', () => {
+	test('deleteById sets delete flag', () => {
 		expect.hasAssertions()
 		const oboEvents = require('../../server/obo_events')
 
 		db.none.mockResolvedValueOnce()
 
-		return DraftModel.deleteByIdAndUser('draft_id', 'user_id').then(voidResult => {
+		return DraftModel.deleteById('draft_id', 'user_id').then(voidResult => {
 			expect(voidResult).toBe(undefined) //eslint-disable-line no-undefined
 			expect(oboEvents.emit).toHaveBeenCalledWith('EVENT_DRAFT_DELETED', {
-				id: 'draft_id',
-				userId: 'user_id'
+				id: 'draft_id'
 			})
 		})
 	})
 
-	test('deleteByIdAndUser fails as expected', () => {
+	test('deleteById fails as expected', () => {
 		expect.hasAssertions()
 
 		db.none.mockRejectedValueOnce('mock-error')
 
-		return expect(DraftModel.deleteByIdAndUser('draft_id', 'user_id')).rejects.toBe('mock-error')
+		return expect(DraftModel.deleteById('draft_id')).rejects.toBe('mock-error')
 	})
 
 	test('restoreByIdAndUser reverts delete flag', () => {

--- a/packages/app/obojobo-express/__tests__/models/user.test.js
+++ b/packages/app/obojobo-express/__tests__/models/user.test.js
@@ -255,6 +255,7 @@ describe('user model', () => {
 		expect(users).toMatchInlineSnapshot(`
 		Array [
 		  Object {
+		    "accessLevel": undefined,
 		    "avatarUrl": "https://secure.gravatar.com/avatar/19c0a7d712a610200eb3b9686aa0de4a?s=120&d=retro",
 		    "firstName": "Roger",
 		    "id": null,
@@ -264,6 +265,7 @@ describe('user model', () => {
 		    "username": "someusername",
 		  },
 		  Object {
+		    "accessLevel": undefined,
 		    "avatarUrl": "https://secure.gravatar.com/avatar/19c0a7d712a610200eb3b9686aa0de4a?s=120&d=retro",
 		    "firstName": "Roger",
 		    "id": null,
@@ -291,6 +293,7 @@ describe('user model', () => {
 		expect(users).toMatchInlineSnapshot(`
 		Array [
 		  Object {
+		    "accessLevel": undefined,
 		    "avatarUrl": "https://secure.gravatar.com/avatar/19c0a7d712a610200eb3b9686aa0de4a?s=120&d=retro",
 		    "firstName": "Roger",
 		    "id": null,
@@ -300,6 +303,7 @@ describe('user model', () => {
 		    "username": "someusername",
 		  },
 		  Object {
+		    "accessLevel": undefined,
 		    "avatarUrl": "https://secure.gravatar.com/avatar/19c0a7d712a610200eb3b9686aa0de4a?s=120&d=retro",
 		    "firstName": "Roger",
 		    "id": null,

--- a/packages/app/obojobo-express/__tests__/routes/api/drafts.test.js
+++ b/packages/app/obojobo-express/__tests__/routes/api/drafts.test.js
@@ -82,8 +82,9 @@ describe('api draft route', () => {
 		// mock the document returned by fetchById
 		const mockDraftModel = {
 			root: { yell: mockYell },
-			document: 'mock-document-json',
-			authorId: 99
+			document: { title: 'mock-document-json' },
+			authorId: 99,
+			accessLevel: 'Full'
 		}
 
 		// mock the xmlDocument Getter
@@ -112,11 +113,14 @@ describe('api draft route', () => {
 		// mock a yell function that returns a document
 		const mockYell = jest.fn()
 
+		const mockDocument = { title: 'mock-document-json' }
+
 		// mock the document returned by fetchById
 		const mockDraftModel = {
 			root: { yell: mockYell },
-			document: 'mock-document-json',
-			authorId: 99
+			document: mockDocument,
+			authorId: 99,
+			accessLevel: 'Full'
 		}
 
 		DraftModel.fetchById.mockResolvedValueOnce(mockDraftModel)
@@ -136,7 +140,7 @@ describe('api draft route', () => {
 				expect(response.header['content-type']).toContain('application/xml')
 				expect(response.statusCode).toBe(200)
 				expect(response.text).toContain('mock-xml')
-				expect(jsonToXml).toHaveBeenCalledWith('mock-document-json')
+				expect(jsonToXml).toHaveBeenCalledWith(mockDocument)
 			})
 	})
 
@@ -147,10 +151,14 @@ describe('api draft route', () => {
 		const mockYell = jest.fn()
 
 		// mock the document returned by fetchById
+
+		const mockDocument = { title: 'mock-document-json' }
+
 		const mockDraftModel = {
 			root: { yell: mockYell },
-			document: 'mock-document-json',
-			authorId: 99
+			document: mockDocument,
+			authorId: 99,
+			accessLevel: 'Full'
 		}
 
 		DraftModel.fetchById.mockResolvedValueOnce(mockDraftModel)
@@ -168,7 +176,7 @@ describe('api draft route', () => {
 				expect(response.header['content-type']).toContain('application/json')
 				expect(response.statusCode).toBe(200)
 				expect(response.body).toHaveProperty('status', 'ok')
-				expect(response.body).toHaveProperty('value', 'mock-document-json')
+				expect(response.body).toHaveProperty('value', mockDocument)
 				expect(jsonToXml).not.toHaveBeenCalled()
 			})
 	})
@@ -180,10 +188,13 @@ describe('api draft route', () => {
 		const mockYell = jest.fn()
 
 		// mock the document returned by fetchById
+		const mockDocument = { title: 'mock-document' }
+
 		const mockDraftModel = {
 			root: { yell: mockYell },
-			document: 'mock-document-json',
-			authorId: 99
+			document: mockDocument,
+			authorId: 99,
+			accessLevel: 'Full'
 		}
 
 		DraftModel.fetchDraftByVersion.mockResolvedValueOnce(mockDraftModel)
@@ -203,7 +214,7 @@ describe('api draft route', () => {
 				expect(response.header['content-type']).toContain('application/json')
 				expect(response.statusCode).toBe(200)
 				expect(response.body).toHaveProperty('status', 'ok')
-				expect(response.body).toHaveProperty('value', 'mock-document-json')
+				expect(response.body).toHaveProperty('value', mockDocument)
 				expect(DraftModel.fetchDraftByVersion).toHaveBeenCalledWith(
 					'00000000-0000-0000-0000-000000000000',
 					'00000000-0000-0000-0000-000000000001'
@@ -219,9 +230,11 @@ describe('api draft route', () => {
 		const mockYell = jest.fn()
 
 		// mock the document returned by fetchById
+		const mockDocument = { title: 'mock-document' }
+
 		const mockDraftModel = {
 			root: { yell: mockYell },
-			document: 'mock-document-json',
+			document: mockDocument,
 			authorId: 99
 		}
 
@@ -256,9 +269,11 @@ describe('api draft route', () => {
 		const mockYell = jest.fn()
 
 		// mock the document returned by fetchById
+		const mockDocument = { title: 'mock-document' }
+
 		const mockDraftModel = {
 			root: { yell: mockYell },
-			document: 'mock-document-json',
+			document: mockDocument,
 			authorId: 99
 		}
 
@@ -277,7 +292,7 @@ describe('api draft route', () => {
 				expect(response.header['content-type']).toContain('application/json')
 				expect(response.statusCode).toBe(200)
 				expect(response.body).toHaveProperty('status', 'ok')
-				expect(response.body).toHaveProperty('value', 'mock-document-json')
+				expect(response.body).toHaveProperty('value', mockDocument)
 				expect(jsonToXml).not.toHaveBeenCalled()
 			})
 	})
@@ -289,9 +304,11 @@ describe('api draft route', () => {
 		const mockYell = jest.fn()
 
 		// mock the document returned by fetchById
+		const mockDocument = { title: 'mock-document' }
+
 		const mockDraftModel = {
 			root: { yell: mockYell },
-			document: 'mock-document-json',
+			document: mockDocument,
 			authorId: 99
 		}
 
@@ -310,7 +327,7 @@ describe('api draft route', () => {
 				expect(response.header['content-type']).toContain('application/json')
 				expect(response.statusCode).toBe(200)
 				expect(response.body).toHaveProperty('status', 'ok')
-				expect(response.body).toHaveProperty('value', 'mock-document-json')
+				expect(response.body).toHaveProperty('value', mockDocument)
 			})
 	})
 
@@ -321,9 +338,11 @@ describe('api draft route', () => {
 		const mockYell = jest.fn()
 
 		// mock the document returned by fetchById
+		const mockDocument = { title: 'mock-document' }
+
 		const mockDraftModel = {
 			root: { yell: mockYell },
-			document: 'mock-document-json',
+			document: mockDocument,
 			authorId: 99
 		}
 
@@ -342,7 +361,7 @@ describe('api draft route', () => {
 				expect(response.header['content-type']).toContain('application/json')
 				expect(response.statusCode).toBe(200)
 				expect(response.body).toHaveProperty('status', 'ok')
-				expect(response.body).toHaveProperty('value', 'mock-document-json')
+				expect(response.body).toHaveProperty('value', mockDocument)
 			})
 	})
 

--- a/packages/app/obojobo-express/server/express_current_document.js
+++ b/packages/app/obojobo-express/server/express_current_document.js
@@ -32,7 +32,7 @@ const requireCurrentDocument = req => {
 		return Promise.reject(new Error('DraftDocument Required'))
 	}
 
-	return DraftDocument.fetchById(draftId).then(draftDocument => {
+	return DraftDocument.fetchById(draftId, req.currentUser.id).then(draftDocument => {
 		setCurrentDocument(req, draftDocument)
 		return req.currentDocument
 	})

--- a/packages/app/obojobo-express/server/migrations/20220321130020-add-access-levels-to-draft.js
+++ b/packages/app/obojobo-express/server/migrations/20220321130020-add-access-levels-to-draft.js
@@ -1,0 +1,39 @@
+'use strict'
+
+var dbm
+var type
+var seed
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+	dbm = options.dbmigrate
+	type = dbm.dataType
+	seed = seedLink
+}
+
+exports.up = function(db) {
+	return db
+		.addColumn('repository_map_user_to_draft', 'access_level', {
+			type: 'varchar',
+			length: 7,
+			defaultValue: 'Full'
+		})
+		.then(() => {
+			return db.addIndex('repository_map_user_to_draft', 'user_access_level_index', [
+				'access_level'
+			])
+		})
+}
+
+exports.down = function(db) {
+	return db
+		.removeIndex('repository_map_user_to_draft', 'user_access_level_index')
+		.then(() => db.removeColumn('repository_map_user_to_draft', 'access_level'))
+}
+
+exports._meta = {
+	version: 1
+}

--- a/packages/app/obojobo-express/server/models/__mocks__/draft.js
+++ b/packages/app/obojobo-express/server/models/__mocks__/draft.js
@@ -22,7 +22,7 @@ MockDraft.updateContent = jest.fn().mockResolvedValue('mockUpdatedContentId')
 MockDraft.findDuplicateIds = jest.fn().mockReturnValue(null)
 MockDraft.fetchDraftByVersion = jest.fn().mockImplementation(() => Promise.resolve(new MockDraft()))
 MockDraft.restoreByIdAndUser = jest.fn().mockImplementation(() => Promise.resolve(new MockDraft()))
-MockDraft.deleteByIdAndUser = jest.fn().mockResolvedValue(null)
+MockDraft.deleteById = jest.fn().mockResolvedValue(null)
 
 MockDraft.mockGetChildNodeById = mockGetChildNodeById
 MockDraft.__setMockYell = newMock => {

--- a/packages/app/obojobo-express/server/models/draft.js
+++ b/packages/app/obojobo-express/server/models/draft.js
@@ -80,25 +80,23 @@ class Draft {
 		return draftNode
 	}
 
-	static deleteByIdAndUser(id, userId) {
+	static deleteById(id) {
 		return db
 			.none(
 				`
 			UPDATE drafts
 			SET deleted = TRUE
 			WHERE id = $[id]
-			AND user_id = $[userId]
 			`,
 				{
-					id,
-					userId
+					id
 				}
 			)
 			.then(() => {
-				oboEvents.emit(Draft.EVENT_DRAFT_DELETED, { id, userId })
+				oboEvents.emit(Draft.EVENT_DRAFT_DELETED, { id })
 			})
 			.catch(error => {
-				logger.logError('Draft deleteByIdAndUser Error', error)
+				logger.logError('Draft deleteById Error', error)
 				throw error
 			})
 	}
@@ -110,7 +108,6 @@ class Draft {
 			UPDATE drafts
 			SET deleted = FALSE
 			WHERE id = $[id]
-			AND user_id = $[userId]
 			`,
 				{
 					id,

--- a/packages/app/obojobo-express/server/models/user.js
+++ b/packages/app/obojobo-express/server/models/user.js
@@ -173,7 +173,16 @@ class User {
 	}
 
 	toJSON() {
-		const allowedKeys = ['id', 'firstName', 'lastName', 'username', 'roles', 'perms', 'avatarUrl']
+		const allowedKeys = [
+			'id',
+			'firstName',
+			'lastName',
+			'username',
+			'roles',
+			'perms',
+			'avatarUrl',
+			'accessLevel'
+		]
 		const safeUser = {}
 		copyAttributesFn(safeUser, this, allowedKeys)
 		return safeUser

--- a/packages/app/obojobo-express/server/routes/api/drafts.js
+++ b/packages/app/obojobo-express/server/routes/api/drafts.js
@@ -263,16 +263,18 @@ router
 	.route('/:draftId')
 	.delete([requireCanDeleteDrafts, requireDraftId, checkValidationRules])
 	.delete(async (req, res) => {
-		const hasPerms = await DraftPermissions.userHasPermissionToDraft(
+		const access_level = await DraftPermissions.getUserAccessLevelToDraft(
 			req.currentUser.id,
 			req.params.draftId
 		)
 
+		const hasPerms = access_level === 'Full'
+
 		if (!hasPerms) {
-			return res.notAuthorized('You must be the author of this draft to delete it')
+			return res.notAuthorized('You must have "Full" access to this draft to delete it')
 		}
 
-		return DraftModel.deleteByIdAndUser(req.params.draftId, req.currentUser.id)
+		return DraftModel.deleteById(req.params.draftId)
 			.then(res.success)
 			.catch(res.unexpected)
 	})

--- a/packages/app/obojobo-express/server/routes/api/drafts.js
+++ b/packages/app/obojobo-express/server/routes/api/drafts.js
@@ -34,15 +34,15 @@ router
 	.get([requireDraftId, requireCanViewEditor, checkContentId, checkValidationRules])
 	.get(async (req, res) => {
 		try {
-			// @TODO: checking permissions should probably be more dynamic, not hard-coded to the repository
-			const hasPerms = await DraftPermissions.userHasPermissionToDraft(
+			const access_level = await DraftPermissions.getUserAccessLevelToDraft(
 				req.currentUser.id,
 				req.params.draftId
 			)
+			const hasPerms = access_level === 'Full' || access_level === 'Partial'
 
 			if (!hasPerms) {
 				return res.notAuthorized(
-					'You must be the author of this draft to retrieve this information'
+					'Your access level must be "Partial" or higher to edit this module.'
 				)
 			}
 

--- a/packages/app/obojobo-express/server/routes/api/drafts.js
+++ b/packages/app/obojobo-express/server/routes/api/drafts.js
@@ -54,7 +54,11 @@ router
 				// get the current version
 				draftModel = await DraftModel.fetchById(req.params.draftId)
 			}
+
+			// Get the draft document and attach the user's access level for module deletion purposes
 			const draftDocument = draftModel.document
+			draftDocument.accessLevel = access_level
+
 			res.format({
 				'application/xml': async () => {
 					let xml = await draftModel.xmlDocument

--- a/packages/app/obojobo-repository/server/models/collection.js
+++ b/packages/app/obojobo-repository/server/models/collection.js
@@ -129,7 +129,7 @@ class Collection {
 
 		const whereSQL = `repository_collections.id = $[collectionId]`
 
-		return DraftSummary.fetchAndJoinWhere(joinOn, whereSQL, { collectionId: this.id })
+		return DraftSummary.fetchAndJoinWhere('', joinOn, whereSQL, { collectionId: this.id })
 			.then(draftSummaries => {
 				this.drafts = draftSummaries
 				return this

--- a/packages/app/obojobo-repository/server/models/collection.test.js
+++ b/packages/app/obojobo-repository/server/models/collection.test.js
@@ -226,6 +226,8 @@ describe('Collection Model', () => {
 		db.one.mockResolvedValueOnce(mockRawCollection)
 		DraftSummary.fetchAndJoinWhere.mockResolvedValueOnce(mockDrafts)
 
+		const selectSQL = ''
+
 		const joinSQL = `
 			JOIN repository_map_drafts_to_collections
 				ON repository_map_drafts_to_collections.draft_id = drafts.id
@@ -237,7 +239,7 @@ describe('Collection Model', () => {
 		return CollectionModel.fetchById('mockCollectionId')
 			.then(collection => collection.loadRelatedDrafts())
 			.then(collection => {
-				expect(DraftSummary.fetchAndJoinWhere).toHaveBeenCalledWith(joinSQL, whereSQL, {
+				expect(DraftSummary.fetchAndJoinWhere).toHaveBeenCalledWith(selectSQL, joinSQL, whereSQL, {
 					collectionId: 'mockCollectionId'
 				})
 				expect(collection.drafts).toEqual(mockDrafts)
@@ -254,6 +256,8 @@ describe('Collection Model', () => {
 		db.one.mockResolvedValueOnce(mockRawCollection)
 		DraftSummary.fetchAndJoinWhere.mockRejectedValueOnce(mockError)
 
+		const selectSQL = ''
+
 		const joinSQL = `
 			JOIN repository_map_drafts_to_collections
 				ON repository_map_drafts_to_collections.draft_id = drafts.id
@@ -265,7 +269,7 @@ describe('Collection Model', () => {
 		return CollectionModel.fetchById('mockCollectionId')
 			.then(collection => collection.loadRelatedDrafts())
 			.catch(error => {
-				expect(DraftSummary.fetchAndJoinWhere).toHaveBeenCalledWith(joinSQL, whereSQL, {
+				expect(DraftSummary.fetchAndJoinWhere).toHaveBeenCalledWith(selectSQL, joinSQL, whereSQL, {
 					collectionId: 'mockCollectionId'
 				})
 				expect(error).toBe(mockError)

--- a/packages/app/obojobo-repository/server/models/draft_summary.js
+++ b/packages/app/obojobo-repository/server/models/draft_summary.js
@@ -174,7 +174,7 @@ class DraftSummary {
 
 	static fetchDeletedByUserId(userId) {
 		return DraftSummary.fetchAndJoinWhere(
-			'',
+			`repository_map_user_to_draft.access_level AS access_level,`,
 			`JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`,
 			`repository_map_user_to_draft.user_id = $[userId] AND access_level = 'Full'`,

--- a/packages/app/obojobo-repository/server/models/draft_summary.js
+++ b/packages/app/obojobo-repository/server/models/draft_summary.js
@@ -53,7 +53,7 @@ class DraftSummary {
 		this.draftId = draft_id
 		this.title = title
 		this.userId = user_id
-		this.access_level = access_level
+		this.accessLevel = access_level
 		this.createdAt = created_at
 		this.updatedAt = updated_at
 		this.latestVersion = latest_version
@@ -85,6 +85,7 @@ class DraftSummary {
 
 	static fetchByUserId(userId) {
 		return DraftSummary.fetchAndJoinWhere(
+			`repository_map_user_to_draft.access_level AS access_level,`,
 			`JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`,
 			`repository_map_user_to_draft.user_id = $[userId]`,
@@ -105,6 +106,7 @@ class DraftSummary {
 
 	static fetchAllInCollection(collectionId) {
 		return DraftSummary.fetchAndJoinWhere(
+			'',
 			`JOIN repository_map_drafts_to_collections
 				ON repository_map_drafts_to_collections.draft_id = drafts.id`,
 			`repository_map_drafts_to_collections.collection_id = $[collectionId]`,
@@ -114,6 +116,7 @@ class DraftSummary {
 
 	static fetchAllInCollectionForUser(collectionId, userId) {
 		return DraftSummary.fetchAndJoinWhere(
+			`repository_map_user_to_draft.access_level AS access_level,`,
 			`JOIN repository_map_drafts_to_collections
 				ON repository_map_drafts_to_collections.draft_id = drafts.id
 			JOIN repository_map_user_to_draft
@@ -171,6 +174,7 @@ class DraftSummary {
 
 	static fetchDeletedByUserId(userId) {
 		return DraftSummary.fetchAndJoinWhere(
+			'',
 			`JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`,
 			`repository_map_user_to_draft.user_id = $[userId]`,
@@ -178,8 +182,8 @@ class DraftSummary {
 		)
 	}
 
-	static fetchAndJoinWhere(joinSQL, whereSQL, queryValues) {
-		const query = buildQueryWhere(whereSQL, joinSQL, '', queryValues.deleted)
+	static fetchAndJoinWhere(selectSQL, joinSQL, whereSQL, queryValues) {
+		const query = buildQueryWhere(whereSQL, joinSQL, selectSQL, queryValues.deleted)
 
 		return db
 			.any(query, queryValues)

--- a/packages/app/obojobo-repository/server/models/draft_summary.js
+++ b/packages/app/obojobo-repository/server/models/draft_summary.js
@@ -177,7 +177,7 @@ class DraftSummary {
 			'',
 			`JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`,
-			`repository_map_user_to_draft.user_id = $[userId]`,
+			`repository_map_user_to_draft.user_id = $[userId] AND access_level = 'Full'`,
 			{ userId, deleted: 'TRUE' }
 		)
 	}

--- a/packages/app/obojobo-repository/server/models/draft_summary.test.js
+++ b/packages/app/obojobo-repository/server/models/draft_summary.test.js
@@ -221,7 +221,8 @@ describe('DraftSummary Model', () => {
 		const whereSQL = 'repository_map_user_to_draft.user_id = $[userId]'
 		const joinSQL = `JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`
-		const query = queryBuilder(whereSQL, joinSQL)
+		const selectSQL = 'repository_map_user_to_draft.access_level AS access_level,'
+		const query = queryBuilder(whereSQL, joinSQL, selectSQL)
 
 		return DraftSummary.fetchByUserId(0).then(summary => {
 			const [actualQuery, options] = db.any.mock.calls[0]
@@ -275,7 +276,8 @@ describe('DraftSummary Model', () => {
 				ON repository_map_drafts_to_collections.draft_id = drafts.id
 			JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`
-		const query = queryBuilder(whereSQL, joinSQL)
+		const selectSQL = `repository_map_user_to_draft.access_level AS access_level,`
+		const query = queryBuilder(whereSQL, joinSQL, selectSQL)
 
 		return DraftSummary.fetchAllInCollectionForUser('mockCollectionId', 0).then(summary => {
 			expect(db.any).toHaveBeenCalledWith(query, { collectionId: 'mockCollectionId', userId: 0 })
@@ -362,12 +364,18 @@ describe('DraftSummary Model', () => {
 
 		const whereSQL = ''
 		const joinSQL = ''
+		const selectSQL = ''
 		const mockQueryValues = { id: 'mockDraftId' }
 
-		return DraftSummary.fetchAndJoinWhere(whereSQL, joinSQL, mockQueryValues).catch(err => {
-			expect(logger.logError).toHaveBeenCalledWith('Error loading DraftSummary by query', mockError)
-			expect(err).toBe(mockError)
-		})
+		return DraftSummary.fetchAndJoinWhere(selectSQL, whereSQL, joinSQL, mockQueryValues).catch(
+			err => {
+				expect(logger.logError).toHaveBeenCalledWith(
+					'Error loading DraftSummary by query',
+					mockError
+				)
+				expect(err).toBe(mockError)
+			}
+		)
 	})
 
 	test('fetchWhere catches database errors', () => {
@@ -654,7 +662,9 @@ describe('DraftSummary Model', () => {
 		const whereSQL = 'repository_map_user_to_draft.user_id = $[userId]'
 		const joinSQL = `JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`
-		const query = queryBuilder(whereSQL, joinSQL, '', 'TRUE')
+		const selectSQL = ''
+
+		const query = queryBuilder(whereSQL, joinSQL, selectSQL, 'TRUE')
 
 		return DraftSummary.fetchDeletedByUserId(0).then(summary => {
 			expect(db.any).toHaveBeenCalledWith(query, { userId: 0, deleted: 'TRUE' })

--- a/packages/app/obojobo-repository/server/models/draft_summary.test.js
+++ b/packages/app/obojobo-repository/server/models/draft_summary.test.js
@@ -659,7 +659,7 @@ describe('DraftSummary Model', () => {
 		db.any = jest.fn()
 		db.any.mockResolvedValueOnce(mockRawDraftSummary)
 
-		const whereSQL = 'repository_map_user_to_draft.user_id = $[userId]'
+		const whereSQL = `repository_map_user_to_draft.user_id = $[userId] AND access_level = 'Full'`
 		const joinSQL = `JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`
 		const selectSQL = ''

--- a/packages/app/obojobo-repository/server/models/draft_summary.test.js
+++ b/packages/app/obojobo-repository/server/models/draft_summary.test.js
@@ -662,7 +662,7 @@ describe('DraftSummary Model', () => {
 		const whereSQL = `repository_map_user_to_draft.user_id = $[userId] AND access_level = 'Full'`
 		const joinSQL = `JOIN repository_map_user_to_draft
 				ON repository_map_user_to_draft.draft_id = drafts.id`
-		const selectSQL = ''
+		const selectSQL = 'repository_map_user_to_draft.access_level AS access_level,'
 
 		const query = queryBuilder(whereSQL, joinSQL, selectSQL, 'TRUE')
 

--- a/packages/app/obojobo-repository/server/routes/api.js
+++ b/packages/app/obojobo-repository/server/routes/api.js
@@ -259,6 +259,44 @@ router
 		}
 	})
 
+// update a user's access level
+router
+	.route('/drafts/:draftId/permission/update')
+	.post([requireCurrentUser, requireCurrentDocument])
+	.post(async (req, res) => {
+		try {
+			const userId = req.body.userId
+			const draftId = req.currentDocument.draftId
+			const targetLevel = req.body.accessLevel
+
+			// Guard against invalid access levels
+			// if (!["Full", "Partial", "Minimal"].includes(accessLevel)) {
+			// 	res.status(400).send("Invalid access level")
+			// }
+
+			// check if same access level
+			const currentLevel = await DraftPermissions.getUserAccessLevelToDraft(
+				req.body.userId,
+				draftId
+			)
+
+			if (currentLevel === targetLevel) {
+				res.success()
+				return
+			}
+
+			// make sure the target userId exists
+			// fetchById will throw if not found
+			await UserModel.fetchById(userId)
+
+			// add permissions
+			await DraftPermissions.updateAccessLevel(draftId, userId, targetLevel)
+			res.success()
+		} catch (error) {
+			res.unexpected(error)
+		}
+	})
+
 // delete a permission for a user to a draft
 router
 	.route('/drafts/:draftId/permission/:userId')

--- a/packages/app/obojobo-repository/server/routes/dashboard.js
+++ b/packages/app/obojobo-repository/server/routes/dashboard.js
@@ -54,7 +54,7 @@ const renderDashboard = (req, res, options) => {
 			switch (options.mode) {
 				case MODE_COLLECTION:
 					pageTitle = 'View Collection'
-					return DraftSummary.fetchAllInCollection(options.collection.id, req.currentUser.id)
+					return DraftSummary.fetchAllInCollectionForUser(options.collection.id, req.currentUser.id)
 				case MODE_ALL:
 					return DraftSummary.fetchByUserId(req.currentUser.id)
 				case MODE_DELETED:

--- a/packages/app/obojobo-repository/server/routes/dashboard.test.js
+++ b/packages/app/obojobo-repository/server/routes/dashboard.test.js
@@ -325,12 +325,12 @@ describe('repository dashboard route', () => {
 		CollectionSummary.fetchByUserId = jest.fn()
 		CollectionSummary.fetchByUserId.mockResolvedValueOnce(mockCollectionSummary)
 
-		DraftSummary.fetchAllInCollection = jest.fn()
+		DraftSummary.fetchAllInCollectionForUser = jest.fn()
 		DraftSummary.fetchByUserId = jest.fn()
 		DraftSummary.fetchDeletedByUserId = jest.fn()
 		DraftSummary.fetchRecentByUserId = jest.fn()
 
-		DraftSummary.fetchAllInCollection.mockResolvedValueOnce(mockModuleSummary)
+		DraftSummary.fetchAllInCollectionForUser.mockResolvedValueOnce(mockModuleSummary)
 
 		const path = 'collections/mock-collection-safe-name-mockCollectionShortId'
 
@@ -356,8 +356,8 @@ describe('repository dashboard route', () => {
 				expect(CollectionSummary.fetchByUserId).toHaveBeenCalledTimes(1)
 				expect(CollectionSummary.fetchByUserId).toHaveBeenCalledWith(mockCurrentUser.id)
 
-				expect(DraftSummary.fetchAllInCollection).toHaveBeenCalledTimes(1)
-				expect(DraftSummary.fetchAllInCollection).toHaveBeenCalledWith(
+				expect(DraftSummary.fetchAllInCollectionForUser).toHaveBeenCalledTimes(1)
+				expect(DraftSummary.fetchAllInCollectionForUser).toHaveBeenCalledWith(
 					mockSingleCollection.id,
 					mockCurrentUser.id
 				)

--- a/packages/app/obojobo-repository/shared/actions/dashboard-actions.js
+++ b/packages/app/obojobo-repository/shared/actions/dashboard-actions.js
@@ -42,6 +42,15 @@ const apiAddPermissionsToModule = (draftId, userId) => {
 	return fetch(`/api/drafts/${draftId}/permission`, options).then(res => res.json())
 }
 
+const apiUpdatePermissionsForModule = (draftId, userId, accessLevel) => {
+	const options = {
+		...defaultOptions(),
+		method: 'POST',
+		body: `{"userId":${userId}, "accessLevel":"${accessLevel}"}`
+	}
+	return fetch(`/api/drafts/${draftId}/permission/update`, options).then(res => res.json())
+}
+
 const apiGetPermissionsForModule = draftId => {
 	return fetch(`/api/drafts/${draftId}/permission`, defaultOptions()).then(res => res.json())
 }
@@ -260,6 +269,14 @@ const addUserToModule = (draftId, userId) => ({
 	promise: apiAddPermissionsToModule(draftId, userId).then(() =>
 		apiGetPermissionsForModule(draftId)
 	)
+})
+
+const CHANGE_ACCESS_LEVEL = 'CHANGE_ACCESS_LEVEL'
+const changeAccessLevel = (draftId, userId, accessLevel) => ({
+	type: CHANGE_ACCESS_LEVEL,
+	promise: apiUpdatePermissionsForModule(draftId, userId, accessLevel).then(() => {
+		apiGetPermissionsForModule(draftId)
+	})
 })
 
 const DELETE_MODULE_PERMISSIONS = 'DELETE_MODULE_PERMISSIONS'
@@ -613,6 +630,7 @@ module.exports = {
 	LOAD_USER_SEARCH,
 	CLOSE_MODAL,
 	ADD_USER_TO_MODULE,
+	CHANGE_ACCESS_LEVEL,
 	LOAD_USERS_FOR_MODULE,
 	CREATE_NEW_MODULE,
 	CLEAR_PEOPLE_SEARCH_RESULTS,
@@ -661,6 +679,7 @@ module.exports = {
 	deleteModulePermissions,
 	searchForUser,
 	addUserToModule,
+	changeAccessLevel,
 	createNewCollection,
 	createNewModule,
 	showModulePermissions,

--- a/packages/app/obojobo-repository/shared/actions/dashboard-actions.test.js
+++ b/packages/app/obojobo-repository/shared/actions/dashboard-actions.test.js
@@ -219,6 +219,36 @@ describe('Dashboard Actions', () => {
 		})
 	})
 
+	test('changeAccessLevel returns the expected output and calls other functions correctly', () => {
+		global.fetch.mockResolvedValueOnce(standardFetchResponse)
+
+		const actionReply = DashboardActions.changeAccessLevel('mockDraftId', 99, 'Partial')
+
+		expect(global.fetch).toHaveBeenCalledWith('/api/drafts/mockDraftId/permission/update', {
+			...defaultFetchOptions,
+			method: 'POST',
+			body: '{"userId":99, "accessLevel":"Partial"}'
+		})
+		global.fetch.mockReset()
+		global.fetch.mockResolvedValueOnce({
+			json: () => ({ value: 'mockSecondaryPermissionsVal' })
+		})
+
+		expect(actionReply).toEqual({
+			type: DashboardActions.CHANGE_ACCESS_LEVEL,
+			promise: expect.any(Object)
+		})
+
+		// should get draft permissions after changing them
+		return actionReply.promise.then(() => {
+			expect(standardFetchResponse.json).toHaveBeenCalled()
+			expect(global.fetch).toHaveBeenCalledWith(
+				'/api/drafts/mockDraftId/permission',
+				defaultFetchOptions
+			)
+		})
+	})
+
 	// three (plus one default) ways of calling deleteModulePermissions
 	const assertDeleteModulePermissionsRunsWithOptions = (secondaryLookupUrl, options) => {
 		global.fetch.mockResolvedValueOnce(standardFetchResponse)

--- a/packages/app/obojobo-repository/shared/components/__snapshots__/button-link.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/button-link.test.js.snap
@@ -11,6 +11,14 @@ exports[`ButtonLink renders when given props 1`] = `
 </a>
 `;
 
+exports[`ButtonLink renders with disabled prop 1`] = `
+<a
+  className="repository--button  disabled"
+>
+  Link Text
+</a>
+`;
+
 exports[`ButtonLink renders with no extra classes 1`] = `
 <a
   className="repository--button "

--- a/packages/app/obojobo-repository/shared/components/__snapshots__/module-menu.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/module-menu.test.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ModuleMenu ModuleMenu renders correctly with className prop 1`] = `
+exports[`ModuleMenu ModuleMenu renders correctly with "Full" access level 1`] = `
 <div
   className="repository--module-icon--menu-wrapper"
 >
   <div
-    className="repository--module-icon--menu extra-class"
+    className="repository--module-icon--menu "
   >
     <a
       className="repository--button "
@@ -40,6 +40,100 @@ exports[`ModuleMenu ModuleMenu renders correctly with className prop 1`] = `
 </div>
 `;
 
+exports[`ModuleMenu ModuleMenu renders correctly with "Minimal" access level 1`] = `
+<div
+  className="repository--module-icon--menu-wrapper"
+>
+  <div
+    className="repository--module-icon--menu "
+  >
+    <a
+      className="repository--button "
+      download={null}
+      href="/preview/mockDraftId"
+      target="_blank"
+    >
+      Preview
+    </a>
+    <hr />
+    <button
+      className="repository--button more"
+      onClick={[Function]}
+    >
+      More...
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ModuleMenu ModuleMenu renders correctly with "Partial" access level 1`] = `
+<div
+  className="repository--module-icon--menu-wrapper"
+>
+  <div
+    className="repository--module-icon--menu "
+  >
+    <a
+      className="repository--button "
+      download={null}
+      href="/preview/mockDraftId"
+      target="_blank"
+    >
+      Preview
+    </a>
+    <a
+      className="repository--button "
+      download={null}
+      href="/url/for/editor"
+      target="_blank"
+    >
+      Edit
+    </a>
+    <hr />
+    <button
+      className="repository--button more"
+      onClick={[Function]}
+    >
+      More...
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ModuleMenu ModuleMenu renders correctly with className prop 1`] = `
+<div
+  className="repository--module-icon--menu-wrapper"
+>
+  <div
+    className="repository--module-icon--menu extra-class"
+  >
+    <a
+      className="repository--button "
+      download={null}
+      href="/preview/mockDraftId"
+      target="_blank"
+    >
+      Preview
+    </a>
+    <a
+      className="repository--button "
+      download={null}
+      href="/url/for/editor"
+      target="_blank"
+    >
+      Edit
+    </a>
+    <hr />
+    <button
+      className="repository--button more"
+      onClick={[Function]}
+    >
+      More...
+    </button>
+  </div>
+</div>
+`;
+
 exports[`ModuleMenu ModuleMenu renders correctly with standard expected props 1`] = `
 <div
   className="repository--module-icon--menu-wrapper"
@@ -63,12 +157,6 @@ exports[`ModuleMenu ModuleMenu renders correctly with standard expected props 1`
     >
       Edit
     </a>
-    <button
-      className="repository--button "
-      onClick={[Function]}
-    >
-      Share
-    </button>
     <hr />
     <button
       className="repository--button more"

--- a/packages/app/obojobo-repository/shared/components/__snapshots__/module-options-dialog.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/module-options-dialog.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] = `
+exports[`ModuleOptionsDialog renders correctly with Full access level 1`] = `
 <div
   className="module-permissions-dialog"
 >
@@ -39,6 +39,356 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
     </h1>
     <p>
       Your Access Level: 
+      Full
+    </p>
+    <div
+      className="buttons-with-labels"
+    >
+      <a
+        className="repository--button "
+        download={null}
+        href="/preview/mockDraftId"
+        target="_blank"
+      >
+        Preview
+      </a>
+      <div
+        className="label"
+      >
+        View with preview controls.
+      </div>
+      <a
+        className="repository--button "
+        download={null}
+        href="/url/for/editor"
+        target="_blank"
+      >
+        Edit
+      </a>
+      <div
+        className="label"
+      >
+        Write, edit, and update.
+      </div>
+      <button
+        className="repository--button "
+        disabled={false}
+        onClick={[Function]}
+      >
+        Share
+      </button>
+      <div
+        className="label"
+      >
+        Add or remove collaborators.
+      </div>
+      <button
+        className="repository--button "
+        onClick={[Function]}
+      >
+        Assessment Stats
+      </button>
+      <div
+        className="label"
+      >
+        View scores by student.
+      </div>
+      <button
+        className="repository--button "
+        disabled={false}
+        onClick={[Function]}
+      >
+        Version History
+      </button>
+      <div
+        className="label"
+      >
+        View and restore previous versions.
+      </div>
+      <button
+        className="repository--button "
+        onClick={[Function]}
+      >
+        Manage Collections
+      </button>
+      <div
+        className="label"
+      >
+        Add to or remove from private collections.
+      </div>
+      <button
+        className="repository--button "
+        disabled={false}
+        onClick={[Function]}
+      >
+        Download JSON
+      </button>
+      <div
+        className="label"
+      >
+        Download a copy in JSON format.
+      </div>
+      <button
+        className="repository--button "
+        disabled={false}
+        onClick={[Function]}
+      >
+        Download XML
+      </button>
+      <div
+        className="label"
+      >
+        Download a copy in XML format.
+      </div>
+      <a
+        className="repository--button "
+        download={null}
+        href="/library/mockDraftId"
+        target="_blank"
+      >
+        Public Page
+      </a>
+      <div
+        className="label"
+      >
+        Visit this modules public page.
+      </div>
+      <button
+        className="repository--button dangerous-button delete-button"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Delete
+      </button>
+      <div
+        className="label delete-label"
+      >
+        Say farewell.
+      </div>
+    </div>
+    <button
+      className="repository--button done-button secondary-button"
+      onClick={[Function]}
+    >
+      Close
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ModuleOptionsDialog renders correctly with Minimal access level 1`] = `
+<div
+  className="module-permissions-dialog"
+>
+  <div
+    className="top-bar"
+  >
+    <div
+      className="repository--module-icon--image"
+    >
+      <img
+        height="100%"
+        src="/library/module-icon/mockDraftId"
+        width="100%"
+      />
+    </div>
+    <div
+      className="module-title"
+    >
+      Mock Module Title
+    </div>
+    <button
+      aria-label="Close"
+      className="repository--button close-button"
+      onClick={[Function]}
+    >
+      ×
+    </button>
+  </div>
+  <div
+    className="wrapper"
+  >
+    <h1
+      className="title"
+    >
+      Module Options
+    </h1>
+    <p>
+      Your Access Level: 
+      Minimal
+    </p>
+    <div
+      className="buttons-with-labels"
+    >
+      <a
+        className="repository--button "
+        download={null}
+        href="/preview/mockDraftId"
+        target="_blank"
+      >
+        Preview
+      </a>
+      <div
+        className="label"
+      >
+        View with preview controls.
+      </div>
+      <a
+        className="repository--button  disabled"
+      >
+        Edit
+      </a>
+      <div
+        className="label"
+      >
+        Write, edit, and update.
+      </div>
+      <button
+        className="repository--button "
+        disabled={true}
+        onClick={[Function]}
+      >
+        Share
+      </button>
+      <div
+        className="label"
+      >
+        Add or remove collaborators.
+      </div>
+      <button
+        className="repository--button "
+        onClick={[Function]}
+      >
+        Assessment Stats
+      </button>
+      <div
+        className="label"
+      >
+        View scores by student.
+      </div>
+      <button
+        className="repository--button "
+        disabled={true}
+        onClick={[Function]}
+      >
+        Version History
+      </button>
+      <div
+        className="label"
+      >
+        View and restore previous versions.
+      </div>
+      <button
+        className="repository--button "
+        onClick={[Function]}
+      >
+        Manage Collections
+      </button>
+      <div
+        className="label"
+      >
+        Add to or remove from private collections.
+      </div>
+      <button
+        className="repository--button "
+        disabled={true}
+        onClick={[Function]}
+      >
+        Download JSON
+      </button>
+      <div
+        className="label"
+      >
+        Download a copy in JSON format.
+      </div>
+      <button
+        className="repository--button "
+        disabled={true}
+        onClick={[Function]}
+      >
+        Download XML
+      </button>
+      <div
+        className="label"
+      >
+        Download a copy in XML format.
+      </div>
+      <a
+        className="repository--button "
+        download={null}
+        href="/library/mockDraftId"
+        target="_blank"
+      >
+        Public Page
+      </a>
+      <div
+        className="label"
+      >
+        Visit this modules public page.
+      </div>
+      <button
+        className="repository--button dangerous-button delete-button"
+        disabled={true}
+        onClick={[Function]}
+      >
+        Delete
+      </button>
+      <div
+        className="label delete-label"
+      >
+        Say farewell.
+      </div>
+    </div>
+    <button
+      className="repository--button done-button secondary-button"
+      onClick={[Function]}
+    >
+      Close
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ModuleOptionsDialog renders correctly with Partial access level 1`] = `
+<div
+  className="module-permissions-dialog"
+>
+  <div
+    className="top-bar"
+  >
+    <div
+      className="repository--module-icon--image"
+    >
+      <img
+        height="100%"
+        src="/library/module-icon/mockDraftId"
+        width="100%"
+      />
+    </div>
+    <div
+      className="module-title"
+    >
+      Mock Module Title
+    </div>
+    <button
+      aria-label="Close"
+      className="repository--button close-button"
+      onClick={[Function]}
+    >
+      ×
+    </button>
+  </div>
+  <div
+    className="wrapper"
+  >
+    <h1
+      className="title"
+    >
+      Module Options
+    </h1>
+    <p>
+      Your Access Level: 
+      Partial
     </p>
     <div
       className="buttons-with-labels"
@@ -117,6 +467,7 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
       </div>
       <button
         className="repository--button "
+        disabled={false}
         onClick={[Function]}
       >
         Download JSON
@@ -128,6 +479,7 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
       </div>
       <button
         className="repository--button "
+        disabled={false}
         onClick={[Function]}
       >
         Download XML
@@ -153,6 +505,182 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
       <button
         className="repository--button dangerous-button delete-button"
         disabled={true}
+        onClick={[Function]}
+      >
+        Delete
+      </button>
+      <div
+        className="label delete-label"
+      >
+        Say farewell.
+      </div>
+    </div>
+    <button
+      className="repository--button done-button secondary-button"
+      onClick={[Function]}
+    >
+      Close
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] = `
+<div
+  className="module-permissions-dialog"
+>
+  <div
+    className="top-bar"
+  >
+    <div
+      className="repository--module-icon--image"
+    >
+      <img
+        height="100%"
+        src="/library/module-icon/mockDraftId"
+        width="100%"
+      />
+    </div>
+    <div
+      className="module-title"
+    >
+      Mock Module Title
+    </div>
+    <button
+      aria-label="Close"
+      className="repository--button close-button"
+      onClick={[Function]}
+    >
+      ×
+    </button>
+  </div>
+  <div
+    className="wrapper"
+  >
+    <h1
+      className="title"
+    >
+      Module Options
+    </h1>
+    <p>
+      Your Access Level: 
+      Full
+    </p>
+    <div
+      className="buttons-with-labels"
+    >
+      <a
+        className="repository--button "
+        download={null}
+        href="/preview/mockDraftId"
+        target="_blank"
+      >
+        Preview
+      </a>
+      <div
+        className="label"
+      >
+        View with preview controls.
+      </div>
+      <a
+        className="repository--button "
+        download={null}
+        href="/url/for/editor"
+        target="_blank"
+      >
+        Edit
+      </a>
+      <div
+        className="label"
+      >
+        Write, edit, and update.
+      </div>
+      <button
+        className="repository--button "
+        disabled={false}
+        onClick={[Function]}
+      >
+        Share
+      </button>
+      <div
+        className="label"
+      >
+        Add or remove collaborators.
+      </div>
+      <button
+        className="repository--button "
+        onClick={[Function]}
+      >
+        Assessment Stats
+      </button>
+      <div
+        className="label"
+      >
+        View scores by student.
+      </div>
+      <button
+        className="repository--button "
+        disabled={false}
+        onClick={[Function]}
+      >
+        Version History
+      </button>
+      <div
+        className="label"
+      >
+        View and restore previous versions.
+      </div>
+      <button
+        className="repository--button "
+        onClick={[Function]}
+      >
+        Manage Collections
+      </button>
+      <div
+        className="label"
+      >
+        Add to or remove from private collections.
+      </div>
+      <button
+        className="repository--button "
+        disabled={false}
+        onClick={[Function]}
+      >
+        Download JSON
+      </button>
+      <div
+        className="label"
+      >
+        Download a copy in JSON format.
+      </div>
+      <button
+        className="repository--button "
+        disabled={false}
+        onClick={[Function]}
+      >
+        Download XML
+      </button>
+      <div
+        className="label"
+      >
+        Download a copy in XML format.
+      </div>
+      <a
+        className="repository--button "
+        download={null}
+        href="/library/mockDraftId"
+        target="_blank"
+      >
+        Public Page
+      </a>
+      <div
+        className="label"
+      >
+        Visit this modules public page.
+      </div>
+      <button
+        className="repository--button dangerous-button delete-button"
+        disabled={false}
         onClick={[Function]}
       >
         Delete

--- a/packages/app/obojobo-repository/shared/components/__snapshots__/module-options-dialog.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/module-options-dialog.test.js.snap
@@ -44,126 +44,166 @@ exports[`ModuleOptionsDialog renders correctly with Full access level 1`] = `
     <div
       className="buttons-with-labels"
     >
-      <a
-        className="repository--button "
-        download={null}
-        href="/preview/mockDraftId"
-        target="_blank"
-      >
-        Preview
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View with preview controls.
+        <a
+          className="repository--button "
+          download={null}
+          href="/preview/mockDraftId"
+          target="_blank"
+        >
+          Preview
+        </a>
+        <div
+          className="label"
+        >
+          View with preview controls.
+        </div>
       </div>
-      <a
-        className="repository--button "
-        download={null}
-        href="/url/for/editor"
-        target="_blank"
-      >
-        Edit
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Write, edit, and update.
+        <a
+          className="repository--button "
+          download={null}
+          href="/url/for/editor"
+          target="_blank"
+        >
+          Edit
+        </a>
+        <div
+          className="label"
+        >
+          Write, edit, and update.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Share
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Add or remove collaborators.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Share
+        </button>
+        <div
+          className="label"
+        >
+          Add or remove collaborators.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        onClick={[Function]}
-      >
-        Assessment Stats
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View scores by student.
+        <button
+          className="repository--button "
+          onClick={[Function]}
+        >
+          Assessment Stats
+        </button>
+        <div
+          className="label"
+        >
+          View scores by student.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Version History
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View and restore previous versions.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Version History
+        </button>
+        <div
+          className="label"
+        >
+          View and restore previous versions.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        onClick={[Function]}
-      >
-        Manage Collections
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Add to or remove from private collections.
+        <button
+          className="repository--button "
+          onClick={[Function]}
+        >
+          Manage Collections
+        </button>
+        <div
+          className="label"
+        >
+          Add to or remove from private collections.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Download JSON
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Download a copy in JSON format.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Download JSON
+        </button>
+        <div
+          className="label"
+        >
+          Download a copy in JSON format.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Download XML
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Download a copy in XML format.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Download XML
+        </button>
+        <div
+          className="label"
+        >
+          Download a copy in XML format.
+        </div>
       </div>
-      <a
-        className="repository--button "
-        download={null}
-        href="/library/mockDraftId"
-        target="_blank"
-      >
-        Public Page
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Visit this modules public page.
+        <a
+          className="repository--button "
+          download={null}
+          href="/library/mockDraftId"
+          target="_blank"
+        >
+          Public Page
+        </a>
+        <div
+          className="label"
+        >
+          Visit this modules public page.
+        </div>
       </div>
-      <button
-        className="repository--button dangerous-button delete-button"
-        disabled={false}
-        onClick={[Function]}
-      >
-        Delete
-      </button>
       <div
-        className="label delete-label"
+        className="button-label-group"
       >
-        Say farewell.
+        <button
+          className="repository--button dangerous-button delete-button"
+          disabled={false}
+          onClick={[Function]}
+        >
+          Delete
+        </button>
+        <div
+          className="label delete-label"
+        >
+          Say farewell.
+        </div>
       </div>
     </div>
     <button
@@ -220,123 +260,69 @@ exports[`ModuleOptionsDialog renders correctly with Minimal access level 1`] = `
     <div
       className="buttons-with-labels"
     >
-      <a
-        className="repository--button "
-        download={null}
-        href="/preview/mockDraftId"
-        target="_blank"
-      >
-        Preview
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View with preview controls.
+        <a
+          className="repository--button "
+          download={null}
+          href="/preview/mockDraftId"
+          target="_blank"
+        >
+          Preview
+        </a>
+        <div
+          className="label"
+        >
+          View with preview controls.
+        </div>
       </div>
-      <a
-        className="repository--button  disabled"
-      >
-        Edit
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Write, edit, and update.
+        <button
+          className="repository--button "
+          onClick={[Function]}
+        >
+          Assessment Stats
+        </button>
+        <div
+          className="label"
+        >
+          View scores by student.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={true}
-        onClick={[Function]}
-      >
-        Share
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Add or remove collaborators.
+        <button
+          className="repository--button "
+          onClick={[Function]}
+        >
+          Manage Collections
+        </button>
+        <div
+          className="label"
+        >
+          Add to or remove from private collections.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        onClick={[Function]}
-      >
-        Assessment Stats
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View scores by student.
-      </div>
-      <button
-        className="repository--button "
-        disabled={true}
-        onClick={[Function]}
-      >
-        Version History
-      </button>
-      <div
-        className="label"
-      >
-        View and restore previous versions.
-      </div>
-      <button
-        className="repository--button "
-        onClick={[Function]}
-      >
-        Manage Collections
-      </button>
-      <div
-        className="label"
-      >
-        Add to or remove from private collections.
-      </div>
-      <button
-        className="repository--button "
-        disabled={true}
-        onClick={[Function]}
-      >
-        Download JSON
-      </button>
-      <div
-        className="label"
-      >
-        Download a copy in JSON format.
-      </div>
-      <button
-        className="repository--button "
-        disabled={true}
-        onClick={[Function]}
-      >
-        Download XML
-      </button>
-      <div
-        className="label"
-      >
-        Download a copy in XML format.
-      </div>
-      <a
-        className="repository--button "
-        download={null}
-        href="/library/mockDraftId"
-        target="_blank"
-      >
-        Public Page
-      </a>
-      <div
-        className="label"
-      >
-        Visit this modules public page.
-      </div>
-      <button
-        className="repository--button dangerous-button delete-button"
-        disabled={true}
-        onClick={[Function]}
-      >
-        Delete
-      </button>
-      <div
-        className="label delete-label"
-      >
-        Say farewell.
+        <a
+          className="repository--button "
+          download={null}
+          href="/library/mockDraftId"
+          target="_blank"
+        >
+          Public Page
+        </a>
+        <div
+          className="label"
+        >
+          Visit this modules public page.
+        </div>
       </div>
     </div>
     <button
@@ -393,126 +379,134 @@ exports[`ModuleOptionsDialog renders correctly with Partial access level 1`] = `
     <div
       className="buttons-with-labels"
     >
-      <a
-        className="repository--button "
-        download={null}
-        href="/preview/mockDraftId"
-        target="_blank"
-      >
-        Preview
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View with preview controls.
+        <a
+          className="repository--button "
+          download={null}
+          href="/preview/mockDraftId"
+          target="_blank"
+        >
+          Preview
+        </a>
+        <div
+          className="label"
+        >
+          View with preview controls.
+        </div>
       </div>
-      <a
-        className="repository--button "
-        download={null}
-        href="/url/for/editor"
-        target="_blank"
-      >
-        Edit
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Write, edit, and update.
+        <a
+          className="repository--button "
+          download={null}
+          href="/url/for/editor"
+          target="_blank"
+        >
+          Edit
+        </a>
+        <div
+          className="label"
+        >
+          Write, edit, and update.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={true}
-        onClick={[Function]}
-      >
-        Share
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Add or remove collaborators.
+        <button
+          className="repository--button "
+          onClick={[Function]}
+        >
+          Assessment Stats
+        </button>
+        <div
+          className="label"
+        >
+          View scores by student.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        onClick={[Function]}
-      >
-        Assessment Stats
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View scores by student.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Version History
+        </button>
+        <div
+          className="label"
+        >
+          View and restore previous versions.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Version History
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View and restore previous versions.
+        <button
+          className="repository--button "
+          onClick={[Function]}
+        >
+          Manage Collections
+        </button>
+        <div
+          className="label"
+        >
+          Add to or remove from private collections.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        onClick={[Function]}
-      >
-        Manage Collections
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Add to or remove from private collections.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Download JSON
+        </button>
+        <div
+          className="label"
+        >
+          Download a copy in JSON format.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Download JSON
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Download a copy in JSON format.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Download XML
+        </button>
+        <div
+          className="label"
+        >
+          Download a copy in XML format.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Download XML
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Download a copy in XML format.
-      </div>
-      <a
-        className="repository--button "
-        download={null}
-        href="/library/mockDraftId"
-        target="_blank"
-      >
-        Public Page
-      </a>
-      <div
-        className="label"
-      >
-        Visit this modules public page.
-      </div>
-      <button
-        className="repository--button dangerous-button delete-button"
-        disabled={true}
-        onClick={[Function]}
-      >
-        Delete
-      </button>
-      <div
-        className="label delete-label"
-      >
-        Say farewell.
+        <a
+          className="repository--button "
+          download={null}
+          href="/library/mockDraftId"
+          target="_blank"
+        >
+          Public Page
+        </a>
+        <div
+          className="label"
+        >
+          Visit this modules public page.
+        </div>
       </div>
     </div>
     <button
@@ -569,126 +563,166 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
     <div
       className="buttons-with-labels"
     >
-      <a
-        className="repository--button "
-        download={null}
-        href="/preview/mockDraftId"
-        target="_blank"
-      >
-        Preview
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View with preview controls.
+        <a
+          className="repository--button "
+          download={null}
+          href="/preview/mockDraftId"
+          target="_blank"
+        >
+          Preview
+        </a>
+        <div
+          className="label"
+        >
+          View with preview controls.
+        </div>
       </div>
-      <a
-        className="repository--button "
-        download={null}
-        href="/url/for/editor"
-        target="_blank"
-      >
-        Edit
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Write, edit, and update.
+        <a
+          className="repository--button "
+          download={null}
+          href="/url/for/editor"
+          target="_blank"
+        >
+          Edit
+        </a>
+        <div
+          className="label"
+        >
+          Write, edit, and update.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Share
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Add or remove collaborators.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Share
+        </button>
+        <div
+          className="label"
+        >
+          Add or remove collaborators.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        onClick={[Function]}
-      >
-        Assessment Stats
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View scores by student.
+        <button
+          className="repository--button "
+          onClick={[Function]}
+        >
+          Assessment Stats
+        </button>
+        <div
+          className="label"
+        >
+          View scores by student.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Version History
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        View and restore previous versions.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Version History
+        </button>
+        <div
+          className="label"
+        >
+          View and restore previous versions.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        onClick={[Function]}
-      >
-        Manage Collections
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Add to or remove from private collections.
+        <button
+          className="repository--button "
+          onClick={[Function]}
+        >
+          Manage Collections
+        </button>
+        <div
+          className="label"
+        >
+          Add to or remove from private collections.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Download JSON
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Download a copy in JSON format.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Download JSON
+        </button>
+        <div
+          className="label"
+        >
+          Download a copy in JSON format.
+        </div>
       </div>
-      <button
-        className="repository--button "
-        disabled={false}
-        onClick={[Function]}
-      >
-        Download XML
-      </button>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Download a copy in XML format.
+        <button
+          className="repository--button "
+          disabled={false}
+          onClick={[Function]}
+        >
+          Download XML
+        </button>
+        <div
+          className="label"
+        >
+          Download a copy in XML format.
+        </div>
       </div>
-      <a
-        className="repository--button "
-        download={null}
-        href="/library/mockDraftId"
-        target="_blank"
-      >
-        Public Page
-      </a>
       <div
-        className="label"
+        className="button-label-group"
       >
-        Visit this modules public page.
+        <a
+          className="repository--button "
+          download={null}
+          href="/library/mockDraftId"
+          target="_blank"
+        >
+          Public Page
+        </a>
+        <div
+          className="label"
+        >
+          Visit this modules public page.
+        </div>
       </div>
-      <button
-        className="repository--button dangerous-button delete-button"
-        disabled={false}
-        onClick={[Function]}
-      >
-        Delete
-      </button>
       <div
-        className="label delete-label"
+        className="button-label-group"
       >
-        Say farewell.
+        <button
+          className="repository--button dangerous-button delete-button"
+          disabled={false}
+          onClick={[Function]}
+        >
+          Delete
+        </button>
+        <div
+          className="label delete-label"
+        >
+          Say farewell.
+        </div>
       </div>
     </div>
     <button

--- a/packages/app/obojobo-repository/shared/components/__snapshots__/module-options-dialog.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/module-options-dialog.test.js.snap
@@ -37,6 +37,9 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
     >
       Module Options
     </h1>
+    <p>
+      Your Access Level: 
+    </p>
     <div
       className="buttons-with-labels"
     >
@@ -68,6 +71,7 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
       </div>
       <button
         className="repository--button "
+        disabled={true}
         onClick={[Function]}
       >
         Share
@@ -90,6 +94,7 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
       </div>
       <button
         className="repository--button "
+        disabled={false}
         onClick={[Function]}
       >
         Version History
@@ -147,6 +152,7 @@ exports[`ModuleOptionsDialog renders correctly with standard expected props 1`] 
       </div>
       <button
         className="repository--button dangerous-button delete-button"
+        disabled={true}
         onClick={[Function]}
       >
         Delete

--- a/packages/app/obojobo-repository/shared/components/button-link.jsx
+++ b/packages/app/obojobo-repository/shared/components/button-link.jsx
@@ -2,15 +2,23 @@ require('./button.scss')
 
 const React = require('react')
 
-const ButtonLink = props => (
-	<a
-		href={props.url}
-		target={props.target}
-		download={props.download || null}
-		className={`repository--button ${props.className || ''}`}
-	>
-		{props.children}
-	</a>
-)
+const ButtonLink = props => {
+	if (props.disabled) {
+		return (
+			<a className={`repository--button ${props.className || ''} disabled`}>{props.children}</a>
+		)
+	} else {
+		return (
+			<a
+				href={props.url}
+				target={props.target}
+				download={props.download || null}
+				className={`repository--button ${props.className || ''}`}
+			>
+				{props.children}
+			</a>
+		)
+	}
+}
 
 module.exports = ButtonLink

--- a/packages/app/obojobo-repository/shared/components/button-link.test.js
+++ b/packages/app/obojobo-repository/shared/components/button-link.test.js
@@ -27,4 +27,15 @@ describe('ButtonLink', () => {
 
 		expect(tree).toMatchSnapshot()
 	})
+
+	test('renders with disabled prop', () => {
+		const mockProps = {
+			disabled: true
+		}
+
+		const component = renderer.create(<ButtonLink {...mockProps}>Link Text</ButtonLink>)
+		const tree = component.toJSON()
+
+		expect(tree).toMatchSnapshot()
+	})
 })

--- a/packages/app/obojobo-repository/shared/components/button.scss
+++ b/packages/app/obojobo-repository/shared/components/button.scss
@@ -6,10 +6,6 @@
 		border: 1px solid $color-transparent;
 		border-bottom: 1px solid $color-transparent;
 		opacity: 0.4;
-
-		&:hover {
-			background: $color-button-bg;
-		}
 	}
 
 	border: 0;

--- a/packages/app/obojobo-repository/shared/components/button.scss
+++ b/packages/app/obojobo-repository/shared/components/button.scss
@@ -6,6 +6,10 @@
 		border: 1px solid $color-transparent;
 		border-bottom: 1px solid $color-transparent;
 		opacity: 0.4;
+
+		&:hover {
+			background: $color-button-bg;
+		}
 	}
 
 	border: 0;
@@ -18,7 +22,8 @@
 	text-decoration: none;
 	font-size: 0.7em;
 
-	&:disabled {
+	&:disabled,
+	&.disabled {
 		@include disabled();
 	}
 

--- a/packages/app/obojobo-repository/shared/components/button.test.js
+++ b/packages/app/obojobo-repository/shared/components/button.test.js
@@ -20,7 +20,8 @@ describe('Button', () => {
 		const mockOnClick = jest.fn()
 
 		const mockProps = {
-			onClick: mockOnClick
+			onClick: mockOnClick,
+			disabled: false
 		}
 
 		const component = mount(<Button {...mockProps}>Button Text</Button>)

--- a/packages/app/obojobo-repository/shared/components/dashboard-hoc.js
+++ b/packages/app/obojobo-repository/shared/components/dashboard-hoc.js
@@ -3,6 +3,7 @@ const connect = require('react-redux').connect
 const {
 	closeModal,
 	addUserToModule,
+	changeAccessLevel,
 	loadUsersForModule,
 	deleteModulePermissions,
 	createNewCollection,
@@ -51,6 +52,7 @@ const mapActionsToProps = {
 	createNewModule,
 	closeModal,
 	addUserToModule,
+	changeAccessLevel,
 	loadUsersForModule,
 	deleteModulePermissions,
 	filterModules,

--- a/packages/app/obojobo-repository/shared/components/dashboard-hoc.test.js
+++ b/packages/app/obojobo-repository/shared/components/dashboard-hoc.test.js
@@ -57,6 +57,7 @@ describe('Dashboard HOC', () => {
 			moduleRemoveFromCollection: DashboardActions.moduleRemoveFromCollection,
 			checkModuleLock: DashboardActions.checkModuleLock,
 			bulkRestoreModules: DashboardActions.bulkRestoreModules,
+			changeAccessLevel: DashboardActions.changeAccessLevel,
 			getDeletedModules: DashboardActions.getDeletedModules,
 			getModules: DashboardActions.getModules
 		})

--- a/packages/app/obojobo-repository/shared/components/dashboard.jsx
+++ b/packages/app/obojobo-repository/shared/components/dashboard.jsx
@@ -49,6 +49,7 @@ const renderPermissionsDialog = (props, extension) => (
 		loadUsersForModule={props.loadUsersForModule}
 		onClose={props.closeModal}
 		addUserToModule={props.addUserToModule}
+		changeAccessLevel={props.changeAccessLevel}
 		draftPermissions={props.draftPermissions}
 		deleteModulePermissions={extension.deleteModulePermissions}
 		currentUserId={props.currentUser.id}

--- a/packages/app/obojobo-repository/shared/components/dashboard.jsx
+++ b/packages/app/obojobo-repository/shared/components/dashboard.jsx
@@ -468,6 +468,7 @@ function Dashboard(props) {
 		props
 			.bulkRemoveModulesFromCollection(draftIds, props.collection.id)
 			.then(() => setIsLoading(false))
+		clearSelection()
 	}
 
 	const deleteModules = drafts => {
@@ -484,6 +485,8 @@ function Dashboard(props) {
 		const draftIds = drafts.map(draft => draft.draftId)
 
 		props.bulkDeleteModules(draftIds).then(() => setIsLoading(false))
+
+		clearSelection()
 	}
 
 	const restoreModules = drafts => {
@@ -495,6 +498,7 @@ function Dashboard(props) {
 			// eslint-disable-next-line no-alert
 			window.alert('The selected modules were successfully restored.')
 		})
+		clearSelection()
 	}
 
 	// Set a cookie when moduleSortOrder changes on the client
@@ -613,6 +617,7 @@ function Dashboard(props) {
 
 		// eslint-disable-next-line no-case-declarations
 		let collectionFilterRender = null
+
 		if (props.myCollections.length > 0) {
 			collectionFilterRender = (
 				<Search
@@ -778,7 +783,11 @@ function Dashboard(props) {
 				bulkCollectionActionButton = (
 					<Button
 						className="multi-select secondary-button"
-						onClick={() => props.showCollectionBulkAddModulesDialog(props.selectedModules)}
+						onClick={() =>
+							props.showCollectionBulkAddModulesDialog(
+								props.selectedModules.map(draft => draft.draftId)
+							)
+						}
 					>
 						Add All To Collection
 					</Button>

--- a/packages/app/obojobo-repository/shared/components/dashboard.test.js
+++ b/packages/app/obojobo-repository/shared/components/dashboard.test.js
@@ -1222,7 +1222,7 @@ describe('Dashboard', () => {
 	})
 
 	test('"Add All To Collection" button calls functions appropriately', () => {
-		const mockSelectedModules = ['mockId', 'mockId2']
+		const mockSelectedModules = [standardMyModules[0], standardMyModules[1]]
 
 		dashboardProps.showCollectionBulkAddModulesDialog = jest.fn(() => Promise.resolve())
 
@@ -1251,7 +1251,7 @@ describe('Dashboard', () => {
 		})
 		expect(dashboardProps.showCollectionBulkAddModulesDialog).toHaveBeenCalledTimes(1)
 		expect(dashboardProps.showCollectionBulkAddModulesDialog).toHaveBeenCalledWith(
-			mockSelectedModules
+			mockSelectedModules.map(module => module.draftId)
 		)
 
 		component.unmount()
@@ -1266,6 +1266,7 @@ describe('Dashboard', () => {
 		dashboardProps.myModules = [...standardMyModules]
 		dashboardProps.multiSelectMode = true
 		dashboardProps.selectedModules = mockSelectedModules
+		dashboardProps.deselectModules = jest.fn()
 
 		dashboardProps.mode = MODE_COLLECTION
 		dashboardProps.collection = {
@@ -1310,8 +1311,9 @@ describe('Dashboard', () => {
 
 	test('"Delete All" button calls functions appropriately', async () => {
 		dashboardProps.bulkDeleteModules = jest.fn(() => Promise.resolve())
-		dashboardProps.selectedModules = ['mockId', 'mockId2']
+		dashboardProps.selectedModules = [standardMyModules[0], standardMyModules[1]]
 		dashboardProps.multiSelectMode = true
+		dashboardProps.deselectModules = jest.fn()
 		const reusableComponent = <Dashboard {...dashboardProps} />
 		let component
 		act(() => {
@@ -2086,6 +2088,7 @@ describe('Dashboard', () => {
 		dashboardProps.myModules = [...standardMyModules]
 		dashboardProps.multiSelectMode = true
 		dashboardProps.selectedModules = mockSelectedModules
+		dashboardProps.deselectModules = jest.fn()
 
 		dashboardProps.bulkRestoreModules = jest.fn().mockResolvedValue(true)
 

--- a/packages/app/obojobo-repository/shared/components/module-menu.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-menu.jsx
@@ -20,10 +20,12 @@ const ModuleMenu = props => {
 				<ButtonLink url={`/preview/${props.draftId}`} target="_blank">
 					Preview
 				</ButtonLink>
-				<ButtonLink url={urlForEditor(props.editor, props.draftId)} target="_blank">
-					Edit
-				</ButtonLink>
-				<Button onClick={onShare}>Share</Button>
+				{props.accessLevel === 'Minimal' ? null : (
+					<ButtonLink url={urlForEditor(props.editor, props.draftId)} target="_blank">
+						Edit
+					</ButtonLink>
+				)}
+				{props.accessLevel === 'Full' ? <Button onClick={onShare}>Share</Button> : null}
 				<hr />
 				<Button onClick={onMore} className="more">
 					More...

--- a/packages/app/obojobo-repository/shared/components/module-menu.test.js
+++ b/packages/app/obojobo-repository/shared/components/module-menu.test.js
@@ -35,6 +35,24 @@ describe('ModuleMenu', () => {
 		expect(component.toJSON()).toMatchSnapshot()
 	})
 
+	test('ModuleMenu renders correctly with "Minimal" access level', () => {
+		defaultProps.accessLevel = 'Minimal'
+		const component = create(<ModuleMenu {...defaultProps} />)
+		expect(component.toJSON()).toMatchSnapshot()
+	})
+
+	test('ModuleMenu renders correctly with "Partial" access level', () => {
+		defaultProps.accessLevel = 'Partial'
+		const component = create(<ModuleMenu {...defaultProps} />)
+		expect(component.toJSON()).toMatchSnapshot()
+	})
+
+	test('ModuleMenu renders correctly with "Full" access level', () => {
+		defaultProps.accessLevel = 'Full'
+		const component = create(<ModuleMenu {...defaultProps} />)
+		expect(component.toJSON()).toMatchSnapshot()
+	})
+
 	test('ModuleMenu renders correctly with className prop', () => {
 		defaultProps.className = 'extra-class'
 		const component = create(<ModuleMenu {...defaultProps} />)
@@ -53,6 +71,7 @@ describe('ModuleMenu', () => {
 
 	test('"Share" button onClick calls showModulePermissions', () => {
 		defaultProps.showModulePermissions = jest.fn()
+		defaultProps.accessLevel = 'Full'
 		const component = create(<ModuleMenu {...defaultProps} />)
 
 		component.root.findAllByType(Button)[0].props.onClick()
@@ -63,6 +82,7 @@ describe('ModuleMenu', () => {
 
 	test('"More..." button onClick calls showModuleMore', () => {
 		defaultProps.showModuleMore = jest.fn()
+		defaultProps.accessLevel = 'Full'
 		const component = create(<ModuleMenu {...defaultProps} />)
 
 		component.root.findAllByType(Button)[1].props.onClick()

--- a/packages/app/obojobo-repository/shared/components/module-options-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-options-dialog.jsx
@@ -33,13 +33,18 @@ const ModuleOptionsDialog = props => (
 		</div>
 		<div className="wrapper">
 			<h1 className="title">Module Options</h1>
+			<p>Your Access Level: {props.accessLevel}</p>
 			<div className="buttons-with-labels">
 				<ButtonLink url={`/preview/${props.draftId}`} target="_blank">
 					Preview
 				</ButtonLink>
 				<div className="label">View with preview controls.</div>
 
-				<ButtonLink url={urlForEditor(props.editor, props.draftId)} target="_blank">
+				<ButtonLink
+					url={urlForEditor(props.editor, props.draftId)}
+					target="_blank"
+					disabled={props.accessLevel === 'Minimal'}
+				>
 					Edit
 				</ButtonLink>
 				<div className="label">Write, edit, and update.</div>
@@ -49,6 +54,7 @@ const ModuleOptionsDialog = props => (
 					onClick={() => {
 						props.showModulePermissions(props)
 					}}
+					disabled={props.accessLevel !== 'Full'}
 				>
 					Share
 				</Button>
@@ -67,6 +73,7 @@ const ModuleOptionsDialog = props => (
 				<Button
 					id="moduleOptionsDialog-showVersionHistoryButton"
 					onClick={() => props.showVersionHistory(props)}
+					disabled={props.accessLevel === 'Minimal'}
 				>
 					Version History
 				</Button>
@@ -119,6 +126,7 @@ const ModuleOptionsDialog = props => (
 							props.stopLoadingAnimation
 						)
 					}}
+					disabled={props.accessLevel !== 'Full'}
 				>
 					Delete
 				</Button>

--- a/packages/app/obojobo-repository/shared/components/module-options-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-options-dialog.jsx
@@ -94,6 +94,7 @@ const ModuleOptionsDialog = props => (
 					onClick={() => {
 						downloadDocument(props.draftId, 'json')
 					}}
+					disabled={props.accessLevel === 'Minimal'}
 				>
 					Download JSON
 				</Button>
@@ -104,6 +105,7 @@ const ModuleOptionsDialog = props => (
 					onClick={() => {
 						downloadDocument(props.draftId, 'xml')
 					}}
+					disabled={props.accessLevel === 'Minimal'}
 				>
 					Download XML
 				</Button>

--- a/packages/app/obojobo-repository/shared/components/module-options-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-options-dialog.jsx
@@ -35,104 +35,132 @@ const ModuleOptionsDialog = props => (
 			<h1 className="title">Module Options</h1>
 			<p>Your Access Level: {props.accessLevel}</p>
 			<div className="buttons-with-labels">
-				<ButtonLink url={`/preview/${props.draftId}`} target="_blank">
-					Preview
-				</ButtonLink>
-				<div className="label">View with preview controls.</div>
+				<div className="button-label-group">
+					<ButtonLink url={`/preview/${props.draftId}`} target="_blank">
+						Preview
+					</ButtonLink>
+					<div className="label">View with preview controls.</div>
+				</div>
 
-				<ButtonLink
-					url={urlForEditor(props.editor, props.draftId)}
-					target="_blank"
-					disabled={props.accessLevel === 'Minimal'}
-				>
-					Edit
-				</ButtonLink>
-				<div className="label">Write, edit, and update.</div>
+				{props.accessLevel === 'Minimal' ? null : (
+					<div className="button-label-group">
+						<ButtonLink url={urlForEditor(props.editor, props.draftId)} target="_blank">
+							Edit
+						</ButtonLink>
+						<div className="label">Write, edit, and update.</div>
+					</div>
+				)}
 
-				<Button
-					id="moduleOptionsDialog-shareButton"
-					onClick={() => {
-						props.showModulePermissions(props)
-					}}
-					disabled={props.accessLevel !== 'Full'}
-				>
-					Share
-				</Button>
-				<div className="label">Add or remove collaborators.</div>
+				{props.accessLevel !== 'Full' ? null : (
+					<div className="button-label-group">
+						<Button
+							id="moduleOptionsDialog-shareButton"
+							onClick={() => {
+								props.showModulePermissions(props)
+							}}
+							disabled={props.accessLevel !== 'Full'}
+						>
+							Share
+						</Button>
+						<div className="label">Add or remove collaborators.</div>
+					</div>
+				)}
 
-				<Button
-					id="moduleOptionsDialog-assessmentScoreData"
-					onClick={() => {
-						props.showAssessmentScoreData(props)
-					}}
-				>
-					Assessment Stats
-				</Button>
-				<div className="label">View scores by student.</div>
+				<div className="button-label-group">
+					<Button
+						id="moduleOptionsDialog-assessmentScoreData"
+						onClick={() => {
+							props.showAssessmentScoreData(props)
+						}}
+					>
+						Assessment Stats
+					</Button>
+					<div className="label">View scores by student.</div>
+				</div>
 
-				<Button
-					id="moduleOptionsDialog-showVersionHistoryButton"
-					onClick={() => props.showVersionHistory(props)}
-					disabled={props.accessLevel === 'Minimal'}
-				>
-					Version History
-				</Button>
-				<div className="label">View and restore previous versions.</div>
+				{props.accessLevel === 'Minimal' ? null : (
+					<div className="button-label-group">
+						<Button
+							id="moduleOptionsDialog-showVersionHistoryButton"
+							onClick={() => props.showVersionHistory(props)}
+							disabled={props.accessLevel === 'Minimal'}
+						>
+							Version History
+						</Button>
+						<div className="label">View and restore previous versions.</div>
+					</div>
+				)}
 
-				<Button
-					id="moduleOptionsDialog-manageCollectionsButton"
-					onClick={() => {
-						props.showModuleManageCollections(props)
-					}}
-				>
-					Manage Collections
-				</Button>
-				<div className="label">Add to or remove from private collections.</div>
+				<div className="button-label-group">
+					<Button
+						id="moduleOptionsDialog-manageCollectionsButton"
+						onClick={() => {
+							props.showModuleManageCollections(props)
+						}}
+					>
+						Manage Collections
+					</Button>
+					<div className="label">Add to or remove from private collections.</div>
+				</div>
 
-				<Button
-					id="moduleOptionsDialog-downloadJSONButton"
-					onClick={() => {
-						downloadDocument(props.draftId, 'json')
-					}}
-					disabled={props.accessLevel === 'Minimal'}
-				>
-					Download JSON
-				</Button>
-				<div className="label">Download a copy in JSON format.</div>
+				{props.accessLevel === 'Minimal' ? null : (
+					<div className="button-label-group">
+						<Button
+							id="moduleOptionsDialog-downloadJSONButton"
+							onClick={() => {
+								downloadDocument(props.draftId, 'json')
+							}}
+							disabled={props.accessLevel === 'Minimal'}
+						>
+							Download JSON
+						</Button>
+						<div className="label">Download a copy in JSON format.</div>
+					</div>
+				)}
 
-				<Button
-					id="moduleOptionsDialog-downloadXMLButton"
-					onClick={() => {
-						downloadDocument(props.draftId, 'xml')
-					}}
-					disabled={props.accessLevel === 'Minimal'}
-				>
-					Download XML
-				</Button>
-				<div className="label">Download a copy in XML format.</div>
+				{props.accessLevel === 'Minimal' ? null : (
+					<div className="button-label-group">
+						<Button
+							id="moduleOptionsDialog-downloadXMLButton"
+							onClick={() => {
+								downloadDocument(props.draftId, 'xml')
+							}}
+							disabled={props.accessLevel === 'Minimal'}
+						>
+							Download XML
+						</Button>
+						<div className="label">Download a copy in XML format.</div>
+					</div>
+				)}
 
-				<ButtonLink url={`/library/${props.draftId}`} target="_blank">
-					Public Page
-				</ButtonLink>
-				<div className="label">Visit this modules public page.</div>
+				<div className="button-label-group">
+					<ButtonLink url={`/library/${props.draftId}`} target="_blank">
+						Public Page
+					</ButtonLink>
+					<div className="label">Visit this modules public page.</div>
+				</div>
 
-				<Button
-					id="moduleOptionsDialog-deleteButton"
-					className="dangerous-button delete-button"
-					onClick={() => {
-						deleteModule(
-							props.title,
-							props.draftId,
-							props.deleteModule,
-							props.startLoadingAnimation,
-							props.stopLoadingAnimation
-						)
-					}}
-					disabled={props.accessLevel !== 'Full'}
-				>
-					Delete
-				</Button>
-				<div className="label delete-label">Say farewell.</div>
+				{props.accessLevel !== 'Full' ? null : (
+					<div className="button-label-group">
+						<Button
+							id="moduleOptionsDialog-deleteButton"
+							className="dangerous-button delete-button"
+							onClick={() => {
+								deleteModule(
+									props.title,
+									props.draftId,
+									props.deleteModule,
+									props.startLoadingAnimation,
+									props.stopLoadingAnimation
+								)
+							}}
+							disabled={props.accessLevel !== 'Full'}
+						>
+							Delete
+						</Button>
+						<div className="label delete-label">Say farewell.</div>
+					</div>
+				)}
 			</div>
 			<Button className="done-button secondary-button" onClick={props.onClose}>
 				Close

--- a/packages/app/obojobo-repository/shared/components/module-options-dialog.test.js
+++ b/packages/app/obojobo-repository/shared/components/module-options-dialog.test.js
@@ -47,8 +47,7 @@ describe('ModuleOptionsDialog', () => {
 
 		const component = create(<ModuleOptionsDialog {...defaultProps} />)
 
-		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledTimes(1)
-		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledWith('mockEditorType', 'mockDraftId')
+		expect(mockRepositoryUtils.urlForEditor).not.toHaveBeenCalled()
 
 		expect(component.toJSON()).toMatchSnapshot()
 	})

--- a/packages/app/obojobo-repository/shared/components/module-options-dialog.test.js
+++ b/packages/app/obojobo-repository/shared/components/module-options-dialog.test.js
@@ -20,7 +20,8 @@ describe('ModuleOptionsDialog', () => {
 		defaultProps = {
 			draftId: 'mockDraftId',
 			title: 'Mock Module Title',
-			editor: 'mockEditorType'
+			editor: 'mockEditorType',
+			accessLevel: 'Full'
 		}
 
 		mockRepositoryUtils = require('../repository-utils')
@@ -33,6 +34,37 @@ describe('ModuleOptionsDialog', () => {
 	})
 
 	test('renders correctly with standard expected props', () => {
+		const component = create(<ModuleOptionsDialog {...defaultProps} />)
+
+		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledTimes(1)
+		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledWith('mockEditorType', 'mockDraftId')
+
+		expect(component.toJSON()).toMatchSnapshot()
+	})
+
+	test('renders correctly with Minimal access level', () => {
+		defaultProps.accessLevel = 'Minimal'
+
+		const component = create(<ModuleOptionsDialog {...defaultProps} />)
+
+		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledTimes(1)
+		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledWith('mockEditorType', 'mockDraftId')
+
+		expect(component.toJSON()).toMatchSnapshot()
+	})
+
+	test('renders correctly with Partial access level', () => {
+		defaultProps.accessLevel = 'Partial'
+
+		const component = create(<ModuleOptionsDialog {...defaultProps} />)
+
+		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledTimes(1)
+		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledWith('mockEditorType', 'mockDraftId')
+
+		expect(component.toJSON()).toMatchSnapshot()
+	})
+
+	test('renders correctly with Full access level', () => {
 		const component = create(<ModuleOptionsDialog {...defaultProps} />)
 
 		expect(mockRepositoryUtils.urlForEditor).toHaveBeenCalledTimes(1)

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
@@ -81,7 +81,7 @@ class ModulePermissionsDialog extends React.Component {
 							onChange={event => this.changeAccessLevel(p.id, event.target.value)}
 							disabled={p.id === this.props.currentUserId}
 						>
-							<option value="Full" selected={p.accessLevel == 'Full'}>
+							<option value="Full" selected={p.accessLevel === 'Full'}>
 								Full
 							</option>
 							<option value="Partial" selected={p.accessLevel === 'Partial'}>

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
@@ -77,7 +77,10 @@ class ModulePermissionsDialog extends React.Component {
 				<PeopleListItem key={p.id} isMe={p.id === this.props.currentUserId} {...p}>
 					<div className="repository--main-content--sort access-level">
 						<span>Access Level:</span>
-						<select onChange={event => this.changeAccessLevel(p.id, event.target.value)}>
+						<select
+							onChange={event => this.changeAccessLevel(p.id, event.target.value)}
+							disabled={p.id === this.props.currentUserId}
+						>
 							<option value="Full" selected={p.accessLevel == 'Full'}>
 								Full
 							</option>

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
@@ -75,7 +75,7 @@ class ModulePermissionsDialog extends React.Component {
 		if (this.props.draftPermissions[this.props.draftId]) {
 			accessListItemsRender = this.props.draftPermissions[this.props.draftId].items.map(p => (
 				<PeopleListItem key={p.id} isMe={p.id === this.props.currentUserId} {...p}>
-					<div className="repository--main-content--sort access-level">
+					<div className="access-level-dropdown">
 						<span>Access Level:</span>
 						<select
 							onChange={event => this.changeAccessLevel(p.id, event.target.value)}
@@ -84,10 +84,10 @@ class ModulePermissionsDialog extends React.Component {
 							<option value="Full" selected={p.accessLevel == 'Full'}>
 								Full
 							</option>
-							<option value="Partial" selected={p.accessLevel == 'Partial'}>
+							<option value="Partial" selected={p.accessLevel === 'Partial'}>
 								Partial
 							</option>
-							<option value="Minimal" selected={p.accessLevel == 'Minimal'}>
+							<option value="Minimal" selected={p.accessLevel === 'Minimal'}>
 								Minimal
 							</option>
 						</select>
@@ -97,6 +97,7 @@ class ModulePermissionsDialog extends React.Component {
 						onClick={() => {
 							this.removePerson(p.id)
 						}}
+						disabled={p.id === this.props.currentUserId}
 					>
 						×
 					</Button>

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
@@ -15,6 +15,7 @@ class ModulePermissionsDialog extends React.Component {
 		this.closePeoplePicker = this.closePeoplePicker.bind(this)
 		this.addPerson = this.addPerson.bind(this)
 		this.removePerson = this.removePerson.bind(this)
+		this.changeAccessLevel = this.changeAccessLevel.bind(this)
 	}
 
 	componentDidMount() {
@@ -44,6 +45,10 @@ class ModulePermissionsDialog extends React.Component {
 		this.props.onClose()
 	}
 
+	changeAccessLevel(userId, targetLevel) {
+		this.props.changeAccessLevel(this.props.draftId, userId, targetLevel)
+	}
+
 	renderModal() {
 		if (this.state.peoplePickerOpen) {
 			return (
@@ -70,6 +75,20 @@ class ModulePermissionsDialog extends React.Component {
 		if (this.props.draftPermissions[this.props.draftId]) {
 			accessListItemsRender = this.props.draftPermissions[this.props.draftId].items.map(p => (
 				<PeopleListItem key={p.id} isMe={p.id === this.props.currentUserId} {...p}>
+					<div className="repository--main-content--sort access-level">
+						<span>Access Level:</span>
+						<select onChange={event => this.changeAccessLevel(p.id, event.target.value)}>
+							<option value="Full" selected={p.accessLevel == 'Full'}>
+								Full
+							</option>
+							<option value="Partial" selected={p.accessLevel == 'Partial'}>
+								Partial
+							</option>
+							<option value="Minimal" selected={p.accessLevel == 'Minimal'}>
+								Minimal
+							</option>
+						</select>
+					</div>
 					<Button
 						className="close-button"
 						onClick={() => {

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
@@ -52,6 +52,11 @@
 	.wrapper {
 		padding-left: 1.25em;
 		padding-right: 1.25em;
+
+		p {
+			font-size: 0.8em;
+			margin: 0;
+		}
 	}
 
 	.title {

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
@@ -75,7 +75,7 @@
 		$dimensions-avatar: 1.8em;
 		$dimensions-close-button: 1.2em;
 
-		text-align: left;
+		// text-align: left;
 		height: 11.5em;
 		overflow-y: scroll;
 		list-style: none;

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
@@ -126,3 +126,49 @@
 		}
 	}
 }
+
+.access-level-dropdown {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	margin: 5px;
+	font-size: 0.8em;
+
+	select {
+		font-family: 'Libre Franklin', Arial, sans-serif;
+		border-radius: 0.25em;
+		background-color: #ffffff;
+		padding: 0.7em 3em 0.7em 0.5em;
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		appearance: none;
+
+		/* prettier-ignore */
+		background-image:
+			linear-gradient(
+				45deg,
+				transparent 50%,
+				gray 50%
+			),
+			linear-gradient(135deg, gray 50%, transparent 50%);
+
+		/* prettier-ignore */
+		background-position:
+			calc(100% - 1.5em) 1.1em,
+			calc(100% - 1.1em) 1.1em,
+			calc(100% - 2.5em) 0.5em;
+
+		// stylelint-disable unit-disallowed-list
+		background-size: 0.4em 0.4em, 0.4em 0.4em, 0.1em 1.5em;
+		background-repeat: no-repeat;
+		cursor: pointer;
+		position: relative;
+		align-self: center;
+		margin-left: 10px;
+		font-size: 0.9em;
+
+		&:disabled {
+			cursor: not-allowed;
+		}
+	}
+}

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
@@ -108,14 +108,13 @@
 
 	.buttons-with-labels {
 		text-align: left;
-		margin: 2em 0;
-		display: grid;
-		grid-template-columns: 8em auto;
+		margin: 1em 0;
 		grid-gap: 0.6em;
 		align-items: center;
 
 		.label {
 			font-size: 0.8em;
+			margin-left: 0.6em;
 		}
 
 		.repository--button {
@@ -125,50 +124,57 @@
 			margin-right: 1em;
 		}
 	}
-}
 
-.access-level-dropdown {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	margin: 5px;
-	font-size: 0.8em;
+	.button-label-group {
+		display: grid;
+		grid-template-columns: 8em auto;
+		margin: 0.6em;
+		align-items: center;
+	}
 
-	select {
-		font-family: 'Libre Franklin', Arial, sans-serif;
-		border-radius: 0.25em;
-		background-color: #ffffff;
-		padding: 0.7em 3em 0.7em 0.5em;
-		-webkit-appearance: none;
-		-moz-appearance: none;
-		appearance: none;
+	.access-level-dropdown {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		margin: 5px;
+		font-size: 0.8em;
 
-		/* prettier-ignore */
-		background-image:
-			linear-gradient(
-				45deg,
-				transparent 50%,
-				gray 50%
-			),
-			linear-gradient(135deg, gray 50%, transparent 50%);
+		select {
+			font-family: 'Libre Franklin', Arial, sans-serif;
+			border-radius: 0.25em;
+			background-color: #ffffff;
+			padding: 0.7em 3em 0.7em 0.5em;
+			-webkit-appearance: none;
+			-moz-appearance: none;
+			appearance: none;
 
-		/* prettier-ignore */
-		background-position:
-			calc(100% - 1.5em) 1.1em,
-			calc(100% - 1.1em) 1.1em,
-			calc(100% - 2.5em) 0.5em;
+			/* prettier-ignore */
+			background-image:
+				linear-gradient(
+					45deg,
+					transparent 50%,
+					gray 50%
+				),
+				linear-gradient(135deg, gray 50%, transparent 50%);
 
-		// stylelint-disable unit-disallowed-list
-		background-size: 0.4em 0.4em, 0.4em 0.4em, 0.1em 1.5em;
-		background-repeat: no-repeat;
-		cursor: pointer;
-		position: relative;
-		align-self: center;
-		margin-left: 10px;
-		font-size: 0.9em;
+			/* prettier-ignore */
+			background-position:
+				calc(100% - 1.5em) 1.1em,
+				calc(100% - 1.1em) 1.1em,
+				calc(100% - 2.5em) 0.5em;
 
-		&:disabled {
-			cursor: not-allowed;
+			// stylelint-disable unit-disallowed-list
+			background-size: 0.4em 0.4em, 0.4em 0.4em, 0.1em 1.5em;
+			background-repeat: no-repeat;
+			cursor: pointer;
+			position: relative;
+			align-self: center;
+			margin-left: 10px;
+			font-size: 0.9em;
+
+			&:disabled {
+				cursor: not-allowed;
+			}
 		}
 	}
 }

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.test.js
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.test.js
@@ -30,6 +30,7 @@ describe('ModulePermissionsDialog', () => {
 			loadUsersForModule: jest.fn(),
 			addUserToModule: jest.fn(),
 			deleteModulePermissions: jest.fn(),
+			changeAccessLevel: jest.fn(),
 			onClose: jest.fn()
 		}
 	})
@@ -207,6 +208,33 @@ describe('ModulePermissionsDialog', () => {
 
 		expect(defaultProps.deleteModulePermissions).toHaveBeenCalledTimes(1)
 		expect(defaultProps.deleteModulePermissions).toHaveBeenCalledWith('mockDraftId', 1)
+	})
+
+	test('props.changeAccessLevel is called when a peopleListItem access level is changed', () => {
+		defaultProps.draftPermissions['mockDraftId'] = {
+			items: [{ id: 1, accessLevel: 'Full' }, { id: 99, accessLevel: 'Mimimal' }]
+		}
+		const reusableComponent = <ModulePermissionsDialog {...defaultProps} />
+		let component
+		act(() => {
+			component = create(reusableComponent)
+		})
+
+		expectLoadUsersForModuleToBeCalledOnceWithId()
+
+		const peopleListItems = component.root.findAllByType(PeopleListItem)
+		expect(peopleListItems.length).toBe(2)
+		expect(peopleListItems[0].props.id).toBe(1)
+		expect(peopleListItems[0].props.isMe).toBe(false)
+		expect(peopleListItems[1].props.id).toBe(99)
+		expect(peopleListItems[1].props.isMe).toBe(true)
+
+		act(() => {
+			peopleListItems[0].findByType('select').props.onChange({ target: { value: 'Partial' } })
+		})
+
+		expect(defaultProps.changeAccessLevel).toHaveBeenCalledTimes(1)
+		expect(defaultProps.changeAccessLevel).toHaveBeenCalledWith('mockDraftId', 1, 'Partial')
 	})
 
 	test('confirmation window denied when "x" button is clicked on peopleList item for current user', () => {

--- a/packages/app/obojobo-repository/shared/components/module.jsx
+++ b/packages/app/obojobo-repository/shared/components/module.jsx
@@ -71,7 +71,7 @@ const Module = props => {
 					draftId={props.draftId}
 					editor={props.editor}
 					title={props.title}
-					accessLevel={props.access_level}
+					accessLevel={props.accessLevel}
 				/>
 			) : null}
 			{props.children}

--- a/packages/app/obojobo-repository/shared/components/module.jsx
+++ b/packages/app/obojobo-repository/shared/components/module.jsx
@@ -67,7 +67,12 @@ const Module = props => {
 				</a>
 			)}
 			{isMenuOpen && !props.isDeleted ? (
-				<ModuleMenu draftId={props.draftId} editor={props.editor} title={props.title} />
+				<ModuleMenu
+					draftId={props.draftId}
+					editor={props.editor}
+					title={props.title}
+					accessLevel={props.access_level}
+				/>
 			) : null}
 			{props.children}
 		</div>

--- a/packages/app/obojobo-repository/shared/components/people-list-item.jsx
+++ b/packages/app/obojobo-repository/shared/components/people-list-item.jsx
@@ -3,18 +3,20 @@ require('./people-list-item.scss')
 const React = require('react')
 const Avatar = require('./avatar')
 
-const PeopleListItem = props => (
-	<li className="people-list-item">
-		<Avatar avatarUrl={props.avatarUrl} />
-		<div className="user-info">
-			<div className="user-name">
-				{`${props.firstName} ${props.lastName}`} {props.isMe ? <i>(me)</i> : null}
+const PeopleListItem = props => {
+	return (
+		<li className="people-list-item">
+			<Avatar avatarUrl={props.avatarUrl} />
+			<div className="user-info">
+				<div className="user-name">
+					{`${props.firstName} ${props.lastName}`} {props.isMe ? <i>(me)</i> : null}
+				</div>
+				<div className="user-username">{props.username}</div>
 			</div>
-			<div className="user-username">{props.username}</div>
-		</div>
-		{props.children}
-	</li>
-)
+			{props.children}
+		</li>
+	)
+}
 
 PeopleListItem.defaultProps = {
 	firstName: '',

--- a/packages/obonode/obojobo-sections-assessment/server/express.js
+++ b/packages/obonode/obojobo-sections-assessment/server/express.js
@@ -214,9 +214,10 @@ router
 	.get((req, res) => {
 		let currentUserHasPermissionToDraft
 
-		return DraftPermissions.userHasPermissionToDraft(req.currentUser.id, req.params.draftId)
+		return DraftPermissions.getUserAccessLevelToDraft(req.currentUser.id, req.params.draftId)
 			.then(result => {
-				currentUserHasPermissionToDraft = result
+				currentUserHasPermissionToDraft =
+					result === 'Full' || result === 'Partial' || result === 'Minimal'
 
 				// Users must either have some level of permissions to this draft, or have
 				// the canViewSystemStats permission

--- a/packages/obonode/obojobo-sections-assessment/server/express.test.js
+++ b/packages/obonode/obojobo-sections-assessment/server/express.test.js
@@ -488,7 +488,7 @@ describe('server/express', () => {
 			}
 			next()
 		})
-		DraftPermissions.userHasPermissionToDraft.mockResolvedValueOnce(true)
+		DraftPermissions.getUserAccessLevelToDraft.mockResolvedValueOnce('Full')
 		AssessmentModel.fetchAttemptHistoryDetails.mockResolvedValueOnce(mockReturnValue)
 
 		const response = await request(app)
@@ -530,7 +530,7 @@ describe('server/express', () => {
 			}
 			next()
 		})
-		DraftPermissions.userHasPermissionToDraft.mockResolvedValueOnce(true)
+		DraftPermissions.getUserAccessLevelToDraft.mockResolvedValueOnce('Full')
 		AssessmentModel.fetchAttemptHistoryDetails.mockResolvedValueOnce(mockReturnValue)
 
 		const response = await request(app)
@@ -587,7 +587,7 @@ describe('server/express', () => {
 			}
 			next()
 		})
-		DraftPermissions.userHasPermissionToDraft.mockResolvedValueOnce(false)
+		DraftPermissions.getUserAccessLevelToDraft.mockResolvedValueOnce(null)
 		AssessmentModel.fetchAttemptHistoryDetails.mockResolvedValueOnce(mockReturnValue)
 
 		const response = await request(app)
@@ -642,7 +642,7 @@ describe('server/express', () => {
 			}
 			next()
 		})
-		DraftPermissions.userHasPermissionToDraft.mockResolvedValueOnce(false)
+		DraftPermissions.getUserAccessLevelToDraft.mockResolvedValueOnce(null)
 		AssessmentModel.fetchAttemptHistoryDetails.mockResolvedValueOnce(mockReturnValue)
 
 		const response = await request(app)
@@ -662,7 +662,7 @@ describe('server/express', () => {
 
 	test('GET /api/assessments/:draftId/details fails', async () => {
 		expect.hasAssertions()
-		DraftPermissions.userHasPermissionToDraft.mockResolvedValueOnce(true)
+		DraftPermissions.getUserAccessLevelToDraft.mockResolvedValueOnce('Full')
 		AssessmentModel.fetchAttemptHistoryDetails.mockRejectedValueOnce(Error('Oops!'))
 
 		const response = await request(app)


### PR DESCRIPTION
**_This PR has a migration_**

(fixes #1983)

This adds different access levels (Full, Partial, and Minimal) to modules. When sharing, the user will have the option of giving them Full, Partial, or Minimal access.

Full: All options
Partial: View stats, copy, edit, preview
Minimal: View stats, copy, preview

**Changes:**
All existing modules will give every user that already has access Full level permissions.

Previously, anyone with access had the option to delete a module, but this would only work for the module creator, and in every other instance, this would fail silently. Now, anyone with Full level access can delete and restore the module. If a module was deleted but you didn't have Full level access to it, it won't appear in your Deleted Modules, but it will re-appear in your modules if it's restored by someone with Full access.

When sharing a module, the default access level will be Full, but this can be changed afterwards. Also, a user cannot change their own access level, this is to prevent the situation of a module not having anyone with Full access.
<img width="1552" alt="Screen Shot 2022-04-19 at 12 23 01 PM" src="https://user-images.githubusercontent.com/41072160/164050374-95326f07-5699-42ec-ab11-f3c9382f0167.png">


When showing the module menus, only the actions that a user has access to for each module will appear.
* Minimal:
<img width="1552" alt="Minimal module menu" src="https://user-images.githubusercontent.com/41072160/164045970-acf2e9d2-fb8e-48cf-a4c9-fa1d342b80f7.png"> 
<img width="1552" alt="Minimal module options" src="https://user-images.githubusercontent.com/41072160/164045965-77d0b46d-9ebb-4394-a101-7194bba4937e.png">

* Partial:
<img width="1552" alt="Partial module menu" src="https://user-images.githubusercontent.com/41072160/164046319-d344ad6d-fb0d-4f04-9f8c-9489e7974716.png">
<img width="1552" alt="Partial module options" src="https://user-images.githubusercontent.com/41072160/164046307-46a554c4-bff6-498b-8bd1-f21227240e2f.png">

* Full:
<img width="1552" alt="Full module menu" src="https://user-images.githubusercontent.com/41072160/164046750-caaeb868-8328-45b7-9763-2d3da766996d.png">
<img width="1552" alt="Screen Shot 2022-04-19 at 12 17 36 PM" src="https://user-images.githubusercontent.com/41072160/164049469-5d232b1b-8cf1-4ccc-b68c-167318574418.png">

In the editor, the 'Delete' button is disabled for users with a Partial access level.
<img width="1552" alt="Screen Shot 2022-04-19 at 12 26 32 PM" src="https://user-images.githubusercontent.com/41072160/164050975-b3cbdadd-1bcf-448a-babb-d3118acaaf84.png">

When selecting modules for bulk operations, if a certain operation isn't available for all selected items (because of the user's access level), that button will be disabled.

<img width="1552" alt="Screen Shot 2022-04-19 at 12 30 31 PM" src="https://user-images.githubusercontent.com/41072160/164052755-180ffa03-87d6-4b5b-a035-afad607c1c35.png">

<img width="1552" alt="Screen Shot 2022-04-19 at 12 30 38 PM" src="https://user-images.githubusercontent.com/41072160/164052732-fcd3c4de-ce56-401d-9c21-f9ee850c05ce.png">
