### PR TITLE
Makes "All Modules" button always visible

### DIFF
--- a/packages/app/obojobo-repository/shared/components/__snapshots__/dashboard.test.js.snap
+++ b/packages/app/obojobo-repository/shared/components/__snapshots__/dashboard.test.js.snap
@@ -387,6 +387,9 @@ exports[`Dashboard renders with default props 1`] = `
                   New Module
                 </mock-Button>
               </p>
+              <mock-ButtonLink>
+                All Modules
+              </mock-ButtonLink>
             </div>
           </div>
         </div>
@@ -1047,6 +1050,9 @@ exports[`Dashboard renders with mode = MODE_RECENT 1`] = `
                   New Module
                 </mock-Button>
               </p>
+              <mock-ButtonLink>
+                All Modules
+              </mock-ButtonLink>
             </div>
           </div>
         </div>

--- a/packages/app/obojobo-repository/shared/components/dashboard.jsx
+++ b/packages/app/obojobo-repository/shared/components/dashboard.jsx
@@ -601,17 +601,15 @@ function Dashboard(props) {
 		// url is /dashboard
 		case MODE_RECENT:
 		default:
-			if (props.myModules.length < props.moduleCount) {
-				allModulesButtonRender = (
-					<ButtonLink
-						className="repository--all-modules--button"
-						url="/dashboard/all"
-						target="_blank"
-					>
-						All Modules
-					</ButtonLink>
-				)
-			}
+			allModulesButtonRender = (
+				<ButtonLink
+					className="repository--all-modules--button"
+					url="/dashboard/all"
+					target="_blank"
+				>
+					All Modules
+				</ButtonLink>
+			)
 
 			renderCollectionArea()
 

--- a/packages/app/obojobo-repository/shared/components/dashboard.test.js
+++ b/packages/app/obojobo-repository/shared/components/dashboard.test.js
@@ -401,12 +401,6 @@ describe('Dashboard', () => {
 		expect(placeholderComponents[1].findByType(Button).children[0].children[0]).toBe(
 			'New Collection'
 		)
-
-		// 'All Modules' button should not be rendered; myModules.length === moduleCount
-		expect(component.root.findAllByType(ButtonLink).length).toBe(0)
-
-		// Shouldn't be any modal dialogs open, either
-		expect(component.root.findAllByType(ReactModal).length).toBe(0)
 	}
 
 	const expectModeAllOrModeCollectionRender = cookiePath => {


### PR DESCRIPTION
This allows users with less than 6 modules to be able to reach the All Modules page and get to their deleted modules
![Screen Shot 2022-04-20 at 10 07 01 AM](https://user-images.githubusercontent.com/41072160/164249130-b50a5264-35d4-4618-b641-41efa7ef32e7.png)

(fixes #1998)