### PR TITLE
Add support for x-forwarded-for with multiple ips

### DIFF
--- a/packages/app/obojobo-express/__tests__/express_load_balancer_helper.test.js
+++ b/packages/app/obojobo-express/__tests__/express_load_balancer_helper.test.js
@@ -44,6 +44,19 @@ describe('load balancer helper middleware', () => {
 	test('remoteAddress is updated by x-forwarded-for header', () => {
 		const { req } = mockArgs({ 'x-forwarded-for': '1.1.1.1' })
 		expect(req.connection.encrypted).toBe(false)
+		expect(req.connection.remoteAddress).toBe('1.1.1.1')
+	})
+
+	test('remoteAddress ignores an empty x-forwarded-for header', () => {
+		const { req } = mockArgs({ 'x-forwarded-for': '' })
+		expect(req.connection.encrypted).toBe(false)
+		expect(req.connection.remoteAddress).toBe('5.5.5.5')
+	})
+
+	test('remoteAddress is updated by x-forwarded-for header with proxy chain', () => {
+		const { req } = mockArgs({ 'x-forwarded-for': '1.1.1.1, 1.3.3.4' })
+		expect(req.connection.encrypted).toBe(false)
+		expect(req.connection.remoteAddress).toBe('1.1.1.1')
 	})
 
 	test('encrypted is updated by x-forwarded-proto header', () => {

--- a/packages/app/obojobo-express/server/express_load_balancer_helper.js
+++ b/packages/app/obojobo-express/server/express_load_balancer_helper.js
@@ -1,7 +1,7 @@
 const resolveIP = req => {
 	// make sure the remoteAddress is set behind a load balancer
 	if (req.headers['x-forwarded-for']) {
-		req.connection.remoteAddress = req.headers['x-forwarded-for']
+		req.connection.remoteAddress = req.headers['x-forwarded-for'].split(',')[0].trim()
 	}
 }
 


### PR DESCRIPTION
x-forwarded-for can contain a chain of multiple ip addresses if there are multiple proxies. That can cause errors when attempting to insert into the events table.  This minor change will pick the first value if there are multiple.