### PR TITLE
Partial scoring for pick-all questions

### DIFF
--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/server/mcassessment.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/server/mcassessment.js
@@ -24,12 +24,17 @@ class MCAssessment extends DraftNode {
 
 				const responseIds = new Set(responseRecord.response.ids)
 
-				if (correctIds.size !== responseIds.size) return setScore(0)
+				let score,
+					numCorrect = 0
 
-				let score = 100
-				correctIds.forEach(id => {
-					if (!responseIds.has(id)) score = 0
+				responseIds.forEach(id => {
+					if (correctIds.has(id)) numCorrect++
+					else numCorrect--
 				})
+
+				if (numCorrect <= 0) score = 0
+				else score = (100 * numCorrect) / correctIds.size
+
 				setScore(score)
 				break
 			}

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/server/mcassessment.test.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/server/mcassessment.test.js
@@ -66,14 +66,14 @@ describe('MCAssessment', () => {
 		expect(setScore).toHaveBeenCalledWith(0)
 	})
 
-	test('onCalculateScore sets score to 0 if number of chosen !== number of correct answers (pick-all)', () => {
+	test('onCalculateScore determines partial score if number of chosen !== number of correct answers (pick-all)', () => {
 		const question = { contains: () => true }
 		const responseRecord = { response: { ids: ['test'] } }
 		mcAssessment.node.content = { responseType: 'pick-all' }
 
 		expect(setScore).not.toHaveBeenCalled()
 		mcAssessment.onCalculateScore({}, question, responseRecord, setScore)
-		expect(setScore).toHaveBeenCalledWith(0)
+		expect(setScore).toHaveBeenCalledWith(50)
 	})
 
 	test('onCalculateScore sets score to 0 if any chosen answers are not the correct answer (pick-all)', () => {

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/viewer-component.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/viewer-component.js
@@ -119,16 +119,22 @@ export default class MCAssessment extends OboQuestionAssessmentComponent {
 
 		switch (this.props.model.modelState.responseType) {
 			case 'pick-all': {
-				if (correct.size !== responses.size) {
-					return { score: 0, details: null }
-				}
+				let score,
+					numCorrect = 0
 
-				let score = 100
-				correct.forEach(function(id) {
-					if (!responses.has(id)) {
-						score = 0
+				responses.forEach(function(id) {
+					if (correct.has(id)) {
+						numCorrect++
+					} else {
+						numCorrect--
 					}
 				})
+
+				if (numCorrect <= 0) {
+					score = 0
+				} else {
+					score = (100 * numCorrect) / correct.size
+				}
 
 				return { score, details: null }
 			}

--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/viewer-component.test.js
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/viewer-component.test.js
@@ -238,8 +238,8 @@ describe('MCAssessmentViewerComponent', () => {
 		${'pick-one-multiple-correct'} | ${['b', 'c', 'd']}      | ${100}
 		${'pick-one-multiple-correct'} | ${['a', 'b', 'c', 'd']} | ${100}
 		${'pick-all'}                  | ${[]}                   | ${0}
-		${'pick-all'}                  | ${['a']}                | ${0}
-		${'pick-all'}                  | ${['b']}                | ${0}
+		${'pick-all'}                  | ${['a']}                | ${50}
+		${'pick-all'}                  | ${['b']}                | ${50}
 		${'pick-all'}                  | ${['c']}                | ${0}
 		${'pick-all'}                  | ${['d']}                | ${0}
 		${'pick-all'}                  | ${['a', 'b']}           | ${100}
@@ -248,8 +248,8 @@ describe('MCAssessmentViewerComponent', () => {
 		${'pick-all'}                  | ${['b', 'c']}           | ${0}
 		${'pick-all'}                  | ${['b', 'd']}           | ${0}
 		${'pick-all'}                  | ${['c', 'd']}           | ${0}
-		${'pick-all'}                  | ${['a', 'b', 'c']}      | ${0}
-		${'pick-all'}                  | ${['a', 'b', 'd']}      | ${0}
+		${'pick-all'}                  | ${['a', 'b', 'c']}      | ${50}
+		${'pick-all'}                  | ${['a', 'b', 'd']}      | ${50}
 		${'pick-all'}                  | ${['a', 'c', 'd']}      | ${0}
 		${'pick-all'}                  | ${['b', 'c', 'd']}      | ${0}
 		${'pick-all'}                  | ${['a', 'b', 'c', 'd']} | ${0}


### PR DESCRIPTION
Resolves #545 

MC questions that are pick-all should now calculate their scores based on how many correct/incorrect options were chosen, instead of being all-or-nothing.