### PR TITLE
issue/2026 Fixing Youtube Video Margins

### DIFF
--- a/packages/obonode/obojobo-chunks-multiple-choice-assessment/MCChoice/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-multiple-choice-assessment/MCChoice/viewer-component.scss
@@ -77,6 +77,10 @@
 				padding-left: 0;
 				padding-right: 0;
 				margin-left: -0.4em;
+
+				.obojobo-draft--chunks--you-tube {
+					margin-left: 0.4em;
+				}
 			}
 		}
 	}

--- a/packages/obonode/obojobo-chunks-question/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-question/viewer-component.scss
@@ -196,6 +196,10 @@
 			> div > .component[data-obo-component='true'] {
 				margin-left: -1em;
 				margin-right: -1em;
+
+				.obojobo-draft--chunks--you-tube {
+					margin-left: 1em;
+				}
 			}
 
 			.obojobo-draft--pages--page {


### PR DESCRIPTION
Added two CSS styles in viewer-component that reverse the applied margin styles to YouTube videos placed in Explanation and Feedback portions of the assessment chuck. This will stop the videos from being off center.