### PR TITLE
2030 numeric answer validation doesnt detect shorter non numeric strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Our focus is on making and delivering fantastic learning content to students. Ob
 View the [Obojobo Next Documentation](https://ucfopen.github.io/Obojobo-Docs/).
 
 [Join UCF Open Slack Discussions](https://dl.ucf.edu/join-ucfopen)
+[![Join UCF Open Slack Discussions](https://badgen.net/badge/icon/ucfopen?icon=slack&label=slack&color=purple)](https://dl.ucf.edu/join-ucfopen)
 
 The previous version of Obojobo, renamed to Obojobo Classic, is located here: https://github.com/ucfopen/Obojobo-Classic
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Our focus is on making and delivering fantastic learning content to students. Ob
 
 View the [Obojobo Next Documentation](https://ucfopen.github.io/Obojobo-Docs/).
 
-[Join UCF Open Slack Discussions](https://ucf-open-slackin.herokuapp.com/) [![Join UCF Open Slack Discussions](https://ucf-open-slackin.herokuapp.com/badge.svg)](https://ucf-open-slackin.herokuapp.com/)
+[Join UCF Open Slack Discussions](https://dl.ucf.edu/join-ucfopen)
 
 The previous version of Obojobo, renamed to Obojobo Classic, is located here: https://github.com/ucfopen/Obojobo-Classic
 

--- a/packages/obonode/obojobo-chunks-numeric-assessment/NumericAnswer/__snapshots__/editor-component.test.js.snap
+++ b/packages/obonode/obojobo-chunks-numeric-assessment/NumericAnswer/__snapshots__/editor-component.test.js.snap
@@ -12,6 +12,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="exact",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -59,6 +87,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="exact",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -106,6 +162,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="exact",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -153,6 +237,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="exact",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -200,6 +312,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="exact",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -247,6 +387,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="exact",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -294,6 +462,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="exact",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -341,6 +537,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="abs
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -420,6 +644,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="abs
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -499,6 +751,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="abs
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -578,6 +858,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="abs
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -657,6 +965,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="abs
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -736,6 +1072,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="abs
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -815,6 +1179,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="abs
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -894,6 +1286,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="per
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -973,6 +1393,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="per
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1052,6 +1500,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="per
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1131,6 +1607,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="per
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1210,6 +1714,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="per
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1289,6 +1821,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="per
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1368,6 +1928,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="margin",type="per
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1447,6 +2035,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="range",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1508,6 +2124,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="range",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1569,6 +2213,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="range",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1630,6 +2302,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="range",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1691,6 +2391,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="range",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1752,6 +2480,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="range",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"
@@ -1813,6 +2569,34 @@ exports[`NumericAnswer Editor Node NumericAnswer (requirement="range",type="null
       className="select requirement"
     >
       Answer Type
+      <div
+        style={
+          Object {
+            "display": "inline",
+            "left": "0em",
+            "position": "relative",
+            "top": "0%",
+          }
+        }
+      >
+        <div
+          className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+        >
+          <div
+            className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+          >
+            <button
+              aria-label="Click for some examples of how to input your answer"
+              onClick={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              type="button"
+            >
+              ?
+            </button>
+          </div>
+        </div>
+      </div>
       <select
         className="select-item"
         name="requirement"

--- a/packages/obonode/obojobo-chunks-numeric-assessment/NumericAnswer/__snapshots__/numeric-option.test.js.snap
+++ b/packages/obonode/obojobo-chunks-numeric-assessment/NumericAnswer/__snapshots__/numeric-option.test.js.snap
@@ -8,6 +8,34 @@ exports[`NumericOption NumericOption renders as expected with default requiremen
     className="select requirement"
   >
     Answer Type
+    <div
+      style={
+        Object {
+          "display": "inline",
+          "left": "0em",
+          "position": "relative",
+          "top": "0%",
+        }
+      }
+    >
+      <div
+        className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+      >
+        <div
+          className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+        >
+          <button
+            aria-label="Click for some examples of how to input your answer"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            type="button"
+          >
+            ?
+          </button>
+        </div>
+      </div>
+    </div>
     <select
       className="select-item"
       name="requirement"
@@ -48,6 +76,34 @@ exports[`NumericOption NumericOption renders as expected with requirement of \`e
     className="select requirement"
   >
     Answer Type
+    <div
+      style={
+        Object {
+          "display": "inline",
+          "left": "0em",
+          "position": "relative",
+          "top": "0%",
+        }
+      }
+    >
+      <div
+        className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+      >
+        <div
+          className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+        >
+          <button
+            aria-label="Click for some examples of how to input your answer"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            type="button"
+          >
+            ?
+          </button>
+        </div>
+      </div>
+    </div>
     <select
       className="select-item"
       name="requirement"
@@ -89,6 +145,34 @@ exports[`NumericOption NumericOption renders as expected with requirement of \`m
     className="select requirement"
   >
     Answer Type
+    <div
+      style={
+        Object {
+          "display": "inline",
+          "left": "0em",
+          "position": "relative",
+          "top": "0%",
+        }
+      }
+    >
+      <div
+        className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+      >
+        <div
+          className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+        >
+          <button
+            aria-label="Click for some examples of how to input your answer"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            type="button"
+          >
+            ?
+          </button>
+        </div>
+      </div>
+    </div>
     <select
       className="select-item"
       name="requirement"
@@ -160,6 +244,34 @@ exports[`NumericOption NumericOption renders as expected with requirement of \`r
     className="select requirement"
   >
     Answer Type
+    <div
+      style={
+        Object {
+          "display": "inline",
+          "left": "0em",
+          "position": "relative",
+          "top": "0%",
+        }
+      }
+    >
+      <div
+        className="obojobo-draft--chunks--numeric-assessment--input-more-info"
+      >
+        <div
+          className="obojobo-draft--components--more-info-button is-default-label is-mode-hidden"
+        >
+          <button
+            aria-label="Click for some examples of how to input your answer"
+            onClick={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            type="button"
+          >
+            ?
+          </button>
+        </div>
+      </div>
+    </div>
     <select
       className="select-item"
       name="requirement"

--- a/packages/obonode/obojobo-chunks-numeric-assessment/NumericAnswer/numeric-option.js
+++ b/packages/obonode/obojobo-chunks-numeric-assessment/NumericAnswer/numeric-option.js
@@ -18,6 +18,7 @@ import {
 } from '../entry/numeric-entry-statuses'
 import NumericEntryRange from '../range/numeric-entry-range'
 import isRefRelatedTarget from './is-ref-related-target'
+import NumericInputMoreInfoButton from '../numeric-input-more-info-button'
 
 const RANGE_ERROR_SINGULAR = 'singular'
 const RANGE_ERROR_INVERTED = 'inverted'
@@ -157,6 +158,9 @@ const NumericOption = ({ numericChoice, onHandleInputChange, onHandleSelectChang
 				<div className="is-type-range">
 					<label className="select requirement">
 						Answer Type
+						<div style={{ display: 'inline', position: 'relative', left: 0 + 'em', top: 0 + '%' }}>
+							<NumericInputMoreInfoButton></NumericInputMoreInfoButton>
+						</div>
 						<select
 							className="select-item"
 							name="requirement"
@@ -201,6 +205,9 @@ const NumericOption = ({ numericChoice, onHandleInputChange, onHandleSelectChang
 				<div className="is-type-margin">
 					<label className="select requirement">
 						Answer Type
+						<div style={{ display: 'inline', position: 'relative', left: 0 + 'em', top: 0 + '%' }}>
+							<NumericInputMoreInfoButton></NumericInputMoreInfoButton>
+						</div>
 						<select
 							className="select-item"
 							name="requirement"
@@ -257,6 +264,9 @@ const NumericOption = ({ numericChoice, onHandleInputChange, onHandleSelectChang
 				<div className="is-type-exact">
 					<label className="select requirement">
 						Answer Type
+						<div style={{ display: 'inline', position: 'relative', left: 0 + 'em', top: 0 + '%' }}>
+							<NumericInputMoreInfoButton></NumericInputMoreInfoButton>
+						</div>
 						<select
 							className="select-item"
 							name="requirement"


### PR DESCRIPTION
Original issue was to fix the parser so it would not read lowercase letters a-f as hex. A work around was found, but we were concerned with how it would affect Obojobo as a whole. Instead, I implemented a tooltip in the editor that displays to instructors how they can input their answers. 