### PR TITLE
Issue/1770 Offset focus outline on gems

### DIFF
--- a/packages/app/obojobo-repository/shared/components/module.scss
+++ b/packages/app/obojobo-repository/shared/components/module.scss
@@ -1,10 +1,12 @@
 @import '../../client/css/defaults';
 
 .repository--module-icon {
+	$padding-module-icon: 0.8em;
+
 	position: relative;
 	font-family: $font-default;
 	width: $dimension-module-icon;
-	padding: 0.8em;
+	padding: $padding-module-icon;
 	border-radius: 0.25em;
 	background-color: none;
 	font-size: 0.75em;
@@ -24,7 +26,7 @@
 	}
 
 	:focus {
-		outline-offset: 9px;
+		outline-offset: $padding-module-icon;
 	}
 
 	> a {

--- a/packages/app/obojobo-repository/shared/components/module.scss
+++ b/packages/app/obojobo-repository/shared/components/module.scss
@@ -24,7 +24,6 @@
 	}
 
 	:focus {
-		outline: 2px solid hsla(220, 100%, 50%, 80%);
 		outline-offset: 7.5px;
 	}
 

--- a/packages/app/obojobo-repository/shared/components/module.scss
+++ b/packages/app/obojobo-repository/shared/components/module.scss
@@ -24,7 +24,7 @@
 	}
 
 	:focus {
-		outline-offset: 7.5px;
+		outline-offset: 9px;
 	}
 
 	> a {

--- a/packages/app/obojobo-repository/shared/components/module.scss
+++ b/packages/app/obojobo-repository/shared/components/module.scss
@@ -23,6 +23,11 @@
 		word-wrap: break-word;
 	}
 
+	:focus {
+		outline: 2px solid hsla(220, 100%, 50%, 80%);
+		outline-offset: 7.5px;
+	}
+
 	> a {
 		text-decoration: none;
 		color: black;


### PR DESCRIPTION
I used the `outline-offset` property to move the focus around the gems under `.repository--module-icon` tag out 9px, so that focus is spaced around them properly. This should only effect focus of the gems in the module menu.