### PR TITLE
issue/2042 - lists render incorrectly in Firefox

### DIFF
--- a/packages/app/obojobo-document-engine/src/scss/main.scss
+++ b/packages/app/obojobo-document-engine/src/scss/main.scss
@@ -239,22 +239,4 @@ body {
 			text-align: center;
 		}
 	}
-
-	.obojobo-draft--chunks--list {
-		.obo-text {
-			display: inline;
-
-			&.align-left {
-				text-align: left;
-			}
-
-			&.align-right {
-				text-align: right;
-			}
-
-			&.align-center {
-				text-align: center;
-			}
-		}
-	}
 }

--- a/packages/app/obojobo-document-engine/src/scss/main.scss
+++ b/packages/app/obojobo-document-engine/src/scss/main.scss
@@ -225,6 +225,8 @@ body {
 	}
 
 	.obo-text {
+		display: block;
+
 		&.align-left {
 			text-align: left;
 		}
@@ -235,6 +237,24 @@ body {
 
 		&.align-center {
 			text-align: center;
+		}
+	}
+
+	.obojobo-draft--chunks--list {
+		.obo-text {
+			display: inline;
+
+			&.align-left {
+				text-align: left;
+			}
+
+			&.align-right {
+				text-align: right;
+			}
+
+			&.align-center {
+				text-align: center;
+			}
 		}
 	}
 }

--- a/packages/app/obojobo-document-engine/src/scss/main.scss
+++ b/packages/app/obojobo-document-engine/src/scss/main.scss
@@ -225,7 +225,7 @@ body {
 	}
 
 	.obo-text {
-		display: block;
+		//display: block;
 
 		&.align-left {
 			text-align: left;

--- a/packages/app/obojobo-document-engine/src/scss/main.scss
+++ b/packages/app/obojobo-document-engine/src/scss/main.scss
@@ -225,8 +225,6 @@ body {
 	}
 
 	.obo-text {
-		//display: block;
-
 		&.align-left {
 			text-align: left;
 		}

--- a/packages/obonode/obojobo-chunks-list/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-list/viewer-component.scss
@@ -1,11 +1,5 @@
 @import '~styles/includes';
 
-.component[data-obo-component='true'] {
-	.obo-text {
-		display: inline;
-	}
-}
-
 .obojobo-draft--chunks--list {
 	ul,
 	ol {

--- a/packages/obonode/obojobo-chunks-list/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-list/viewer-component.scss
@@ -1,5 +1,11 @@
 @import '~styles/includes';
 
+.component[data-obo-component='true'] {
+	.obo-text {
+		display: inline;
+	}
+}
+
 .obojobo-draft--chunks--list {
 	ul,
 	ol {

--- a/packages/obonode/obojobo-chunks-list/viewer-component.scss
+++ b/packages/obonode/obojobo-chunks-list/viewer-component.scss
@@ -35,3 +35,11 @@
 		}
 	}
 }
+
+.component[data-obo-component='true'] {
+	.obojobo-draft--chunks--list {
+		.obo-text {
+			display: inline;
+		}
+	}
+}


### PR DESCRIPTION
The style causing the behavior was a `display:block;` style on obo-text. At first I tried to overwrite this style, but most ways were ineffective (not a high enough priority to overrride) and when I did override it is also affected all the obo-text on the page changing it all to inline. This didn't appear to change the appearance, but I don't want to affect all text.

My current proposal is to remove the specific line that specifies the display as block at a high level since it the removal doesn't appear to affect anything else (other defined display styles take over) and allows the lists to render correctly as their default. However, this is a bit like removing a fence when you don't entirely know why it is there because I don't know if this style is necessary from some reason I am not aware and didn't visually notice. Feedback and suggestions are welcome.