### PR TITLE
Use Node 16.

### DIFF
--- a/docker/dockerfiles/obojobo-node-debian.Dockerfile
+++ b/docker/dockerfiles/obojobo-node-debian.Dockerfile
@@ -1,7 +1,7 @@
 # =====================================================================================================
 # Base stage used for  build and final stages
 # =====================================================================================================
-FROM node:14.16.0-alpine AS base_stage
+FROM node:16.19.0-alpine AS base_stage
 
 # ======== PUT NEW NODE BIN DIR IN PATH
 RUN npm config set prefix '/home/node/.npm-global'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "obojobo-next",
-	"version": "15.0.0",
+	"version": "15.1.0",
 	"repository": "https://github.com/ucfopen/Obojobo.git",
 	"homepage": "https://ucfopen.github.io/Obojobo-Docs/",
 	"license": "AGPL-3.0-only",
@@ -102,6 +102,6 @@
 	],
 	"engines": {
 		"yarn": "^1.15.2",
-		"node": "^14.16.0"
+		"node": "^16.19.0"
 	}
 }

--- a/packages/app/obojobo-document-engine/package.json
+++ b/packages/app/obojobo-document-engine/package.json
@@ -4,7 +4,7 @@
 	"license": "AGPL-3.0-only",
 	"description": "",
 	"engines": {
-		"node": "^14.16.0"
+		"node": "^16.19.0"
 	},
 	"main": "index.js",
 	"scripts": {

--- a/packages/app/obojobo-express/__tests__/routes/api/visits.test.js
+++ b/packages/app/obojobo-express/__tests__/routes/api/visits.test.js
@@ -368,7 +368,7 @@ describe('api visits route', () => {
 				expect(response.body.value).toHaveProperty('type', 'reject')
 				expect(response.body.value).toHaveProperty(
 					'message',
-					"Cannot read property 'lis_outcome_service_url' of undefined"
+					"Cannot read properties of undefined (reading 'lis_outcome_service_url')"
 				)
 			})
 	})

--- a/packages/app/obojobo-express/package.json
+++ b/packages/app/obojobo-express/package.json
@@ -28,7 +28,7 @@
 		"precommit": "lint-staged"
 	},
 	"engines": {
-		"node": "^14.16.0"
+		"node": "^16.19.0"
 	},
 	"lint-staged": {
 		"**/*.scss": [

--- a/packages/app/obojobo-module-selector/package.json
+++ b/packages/app/obojobo-module-selector/package.json
@@ -15,7 +15,7 @@
 		"precommit": "lint-staged"
 	},
 	"engines": {
-		"node": "^14.16.0"
+		"node": "^16.19.0"
 	},
 	"lint-staged": {
 		"**/*.scss": [

--- a/packages/app/obojobo-repository/package.json
+++ b/packages/app/obojobo-repository/package.json
@@ -15,7 +15,7 @@
 		"precommit": "lint-staged"
 	},
 	"engines": {
-		"node": "^14.16.0"
+		"node": "^16.19.0"
 	},
 	"lint-staged": {
 		"**/*.scss": [


### PR DESCRIPTION
Closes #2013.

Bumped Node engine version to 16.19.0. Adjusted Dockerfile base image accordingly. Changed test expectations for 'property of undefined' error message.