### PR TITLE
Prevent saving drafts or updating permissions for users without appropriate access levels. Explain access levels.

### DIFF
--- a/packages/app/obojobo-express/server/routes/api/drafts.js
+++ b/packages/app/obojobo-express/server/routes/api/drafts.js
@@ -45,7 +45,7 @@ router
 
 			if (!hasPerms) {
 				return res.notAuthorized(
-					'Your access level must be "Partial" or higher to retrieve this information.'
+					'In order to edit this module you must have "Partial" or "Full" access.'
 				)
 			}
 
@@ -208,7 +208,21 @@ router
 	.post([requireCanCreateDrafts, requireDraftId, checkValidationRules])
 	.post((req, res) => {
 		return Promise.resolve()
-			.then(() => {
+			.then(async () => {
+				// @TODO: checking permissions should probably be more dynamic, not hard-coded to the repository
+				const access_level = await DraftPermissions.getUserAccessLevelToDraft(
+					req.currentUser.id,
+					req.params.draftId
+				)
+
+				return access_level === FULL || access_level === PARTIAL
+			})
+			.then(canEdit => {
+				if (!canEdit) {
+					return res.notAuthorized(
+						'In order to edit this module you must have "Partial" or "Full" access.'
+					)
+				}
 				let xml
 				let documentInput
 

--- a/packages/app/obojobo-repository/server/routes/api.js
+++ b/packages/app/obojobo-repository/server/routes/api.js
@@ -272,6 +272,14 @@ router
 			const draftId = req.currentDocument.draftId
 			const targetLevel = req.body.accessLevel
 
+			// check currentUser's permissions
+			const canShare =
+				(await DraftPermissions.getUserAccessLevelToDraft(req.currentUser.id, draftId)) === FULL
+			if (!canShare) {
+				res.notAuthorized('Current User does not have permission to share this draft')
+				return
+			}
+
 			// Guard against invalid access levels
 			if (!levelNumber[targetLevel]) {
 				const msg = 'Invalid access level: ' + targetLevel

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.jsx
@@ -121,7 +121,24 @@ class ModulePermissionsDialog extends React.Component {
 				</div>
 				<div className="wrapper">
 					<h1 className="title">Module Access</h1>
-					<div className="sub-title">People who can access this module</div>
+					<div className="sub-title">
+						People who can access this module. Access levels are as follows, note that each level
+						contains the previous level.
+					</div>
+					<div className="access-level-descriptions">
+						<span>
+							<label>Minimal:</label>
+							<p>Can preview, view assessment statistics, and copy the module.</p>
+						</span>
+						<span>
+							<label>Partial:</label>
+							<p>Can edit the module.</p>
+						</span>
+						<span>
+							<label>Full:</label>
+							<p>Can add or change access or delete the module.</p>
+						</span>
+					</div>
 					<Button id="modulePermissionsDialog-addPeopleButton" onClick={this.openPeoplePicker}>
 						Add People
 					</Button>

--- a/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
+++ b/packages/app/obojobo-repository/shared/components/module-permissions-dialog.scss
@@ -67,7 +67,30 @@
 
 	.sub-title {
 		font-size: 0.7em;
-		margin-bottom: 2em;
+		margin-bottom: 0.5em;
+		text-align: left;
+	}
+
+	.access-level-descriptions {
+		margin-bottom: 1em;
+
+		span {
+			display: flex;
+			flex-direction: row;
+
+			label,
+			p {
+				font-size: 0.7em;
+				display: block;
+			}
+
+			label {
+				width: 3em;
+				margin-right: 1.25em;
+				text-align: left;
+				font-weight: bold;
+			}
+		}
 	}
 
 	.access-list-wrapper {


### PR DESCRIPTION
Resolves #2040.

Explanatory text added to Module Permissions window explaining what each access level allows.

Added logic to draft update API endpoint to prevent saving a draft if the user does not have full or partial access to it.

Added logic to permissions update API endpoint to prevent a user without full access to a draft to change other users' access to it.