### PR TITLE
Saves assessment attempt responses, recalls them when resuming an unfinished attempt.

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/Viewer/util/assessment-api.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/util/assessment-api.test.js
@@ -37,6 +37,28 @@ describe('assessment-api', () => {
 		})
 	})
 
+	test('saveAttempt calls fetch', () => {
+		expect.hasAssertions()
+
+		const mockAttemptId = 'mockAttemptId'
+
+		const args = {
+			draftId: 'mockDraftId',
+			draftContentId: 'mockDraftContentId',
+			assessmentId: 'mockAssessmentId',
+			attemptId: mockAttemptId,
+			state: {},
+			visitId: 'mockVisitId'
+		}
+		return AssessmentAPI.saveAttempt(args).then(result => {
+			// this is passed as a query parameter, not in the post body
+			delete args.attemptId
+			expect(API.post).toHaveBeenCalledWith(`/api/assessments/attempt/${mockAttemptId}/save`, args)
+			expect(API.processJsonResults).toHaveBeenCalled()
+			expect(result).toEqual(mockJsonResult)
+		})
+	})
+
 	test('resumeAttempt calls fetch', () => {
 		expect.hasAssertions()
 		const args = { attemptId: 999 }

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store/assessment-machine-states.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store/assessment-machine-states.js
@@ -11,6 +11,7 @@ export default {
 	SEND_RESPONSES_FAILED: 'sendResponsesFailed',
 	END_ATTEMPT_FAILED: 'endAttemptFailed',
 	STARTING_ATTEMPT: 'startingAttempt',
+	SAVING_ATTEMPT: 'savingAttempt',
 	RESUMING_ATTEMPT: 'resumingAttempt',
 	SENDING_RESPONSES: 'sendingResponses',
 	ENDING_ATTEMPT: 'endingAttempt',

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store/assessment-state-actions.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/stores/assessment-store/assessment-state-actions.js
@@ -1,6 +1,7 @@
 export default {
 	FETCH_ATTEMPT_HISTORY: 'fetchAttemptHistory',
 	START_ATTEMPT: 'startAttempt',
+	SAVE_ATTEMPT: 'saveAttempt',
 	PROMPT_FOR_RESUME: 'promptForResume',
 	PROMPT_FOR_IMPORT: 'promptForImport',
 	IMPORT_ATTEMPT: 'importAttempt',

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/util/assessment-api.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/util/assessment-api.js
@@ -26,7 +26,15 @@ const AssessmentAPI = {
 			visitId
 		}).then(API.processJsonResults)
 	},
-
+	saveAttempt({ draftId, draftContentId, assessmentId, attemptId, state, visitId }) {
+		return API.post(`/api/assessments/attempt/${attemptId}/save`, {
+			draftId,
+			draftContentId,
+			assessmentId,
+			state,
+			visitId
+		}).then(API.processJsonResults)
+	},
 	endAttempt({ attemptId, draftId, visitId }) {
 		return API.post(`/api/assessments/attempt/${attemptId}/end`, { draftId, visitId }).then(
 			API.processJsonResults

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-resume.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-resume.js
@@ -46,11 +46,19 @@ const resumeAttempt = async (
 	await Promise.all(attemptStart.getSendToClientPromises(assessmentNode, attempt.state, req, res))
 
 	attempt.questions = []
+	attempt.questionResponses = []
 
 	for (const node of attempt.state.chosen) {
 		if (node.type === QUESTION_NODE_TYPE) {
 			const questionNode = assessmentNode.draftTree.getChildNodeById(node.id)
 			attempt.questions.push(questionNode.toObject())
+		}
+	}
+
+	const responsesRaw = await AssessmentModel.fetchResponsesForAttempts([attempt.id])
+	if (responsesRaw.get(attempt.id)) {
+		for (const response of responsesRaw.get(attempt.id)) {
+			attempt.questionResponses.push(response)
 		}
 	}
 

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-resume.test.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-resume.test.js
@@ -35,7 +35,7 @@ describe('Resume Attempt Route', () => {
 		insertEvent.mockReset()
 	})
 
-	test('returns attempt with chosen questions', async () => {
+	test('returns attempt with chosen questions, questions do not have responses', async () => {
 		expect.hasAssertions()
 
 		const questionNode1 = {
@@ -82,6 +82,9 @@ describe('Resume Attempt Route', () => {
 		const mockCurrentUser = { id: 1 }
 		AssessmentModel.fetchAttemptById.mockResolvedValue(mockAttempt)
 
+		const mockResponses = new Map()
+		AssessmentModel.fetchResponsesForAttempts.mockResolvedValue(mockResponses)
+
 		const result = await resumeAttempt(
 			mockCurrentUser,
 			mockCurrentVisit,
@@ -98,6 +101,122 @@ describe('Resume Attempt Route', () => {
 		  "draftContentId": "mockContentId",
 		  "draftId": "mockDraftId",
 		  "number": "mockAttemptNumber",
+		  "questionResponses": Array [],
+		  "questions": Array [
+		    "mock-to-object",
+		    "mock-to-object",
+		  ],
+		  "state": Object {
+		    "chosen": Array [
+		      Object {
+		        "id": "node1",
+		        "type": "ObojoboDraft.Chunks.Question",
+		      },
+		      Object {
+		        "id": "node2",
+		        "type": "ObojoboDraft.Chunks.Question",
+		      },
+		      Object {
+		        "id": "node3",
+		        "type": "NOT_A_QUESTION_NODE_TYPE",
+		      },
+		    ],
+		  },
+		}
+	`)
+	})
+
+	test('returns attempt with chosen questions, questions have responses', async () => {
+		expect.hasAssertions()
+
+		const questionNode1 = {
+			id: 'node1',
+			type: QUESTION_NODE_TYPE
+		}
+
+		const questionNode2 = {
+			id: 'node2',
+			type: QUESTION_NODE_TYPE
+		}
+
+		const nonQuestionNode = {
+			id: 'node3',
+			type: 'NOT_A_QUESTION_NODE_TYPE'
+		}
+
+		const mockAttempt = {
+			assessmentId: 'mockAssessmentId',
+			id: 'mockAttemptId',
+			number: 'mockAttemptNumber',
+			draftId: 'mockDraftId',
+			draftContentId: 'mockContentId',
+			state: {
+				chosen: [questionNode1, questionNode2, nonQuestionNode]
+			}
+		}
+
+		const mockAssessmentNode = {
+			draftTree: {
+				// called to get question nodes by id
+				getChildNodeById: jest.fn().mockReturnValue({
+					toObject: () => 'mock-to-object'
+				})
+			}
+		}
+
+		const mockCurrentDocument = {
+			draftId: 'mockDraftId',
+			contentId: 'mockContentId',
+			getChildNodeById: jest.fn().mockReturnValue(mockAssessmentNode)
+		}
+		const mockCurrentVisit = { id: 'mockVisitId', is_preview: 'mockIsPreview' }
+		const mockCurrentUser = { id: 1 }
+		AssessmentModel.fetchAttemptById.mockResolvedValue(mockAttempt)
+
+		const mockResponsesMap = new Map()
+		mockResponsesMap.set(mockAttempt.id, [
+			{
+				id: 0,
+				created_at: 0,
+				attempt_id: 'mock-attempt-id',
+				assessment_id: 'mock-assessment-id',
+				question_id: 'mock-question-id',
+				score: 0,
+				response: { value: 'mock-value-1' }
+			}
+		])
+		const mockResponses = mockResponsesMap
+		AssessmentModel.fetchResponsesForAttempts.mockResolvedValue(mockResponses)
+
+		const result = await resumeAttempt(
+			mockCurrentUser,
+			mockCurrentVisit,
+			mockCurrentDocument,
+			'mockAttemptId',
+			'mockHostName',
+			'mockRemoteAddress'
+		)
+
+		expect(result).toMatchInlineSnapshot(`
+		Object {
+		  "assessmentId": "mockAssessmentId",
+		  "attemptId": "mockAttemptId",
+		  "draftContentId": "mockContentId",
+		  "draftId": "mockDraftId",
+		  "number": "mockAttemptNumber",
+		  "questionResponses": Array [
+		    Object {
+		      "assessment_id": "mock-assessment-id",
+		      "attempt_id": "mock-attempt-id",
+		      "created_at": 0,
+		      "id": 0,
+		      "question_id": "mock-question-id",
+		      "response": Object {
+		        "value": "mock-value-1",
+		      },
+		      "score": 0,
+		    },
+		  ],
 		  "questions": Array [
 		    "mock-to-object",
 		    "mock-to-object",
@@ -145,6 +264,11 @@ describe('Resume Attempt Route', () => {
 		const mockCurrentUser = { id: 1 }
 		AssessmentModel.fetchAttemptById.mockResolvedValue(mockAttempt)
 
+		const mockResponsesMap = new Map()
+		mockResponsesMap.set(mockAttempt.id, [])
+		const mockResponses = mockResponsesMap
+		AssessmentModel.fetchResponsesForAttempts.mockResolvedValue(mockResponses)
+
 		await resumeAttempt(
 			mockCurrentUser,
 			mockCurrentVisit,
@@ -189,6 +313,11 @@ describe('Resume Attempt Route', () => {
 		const mockCurrentVisit = { id: 'mockVisitId', is_preview: 'mockIsPreview' }
 		const mockCurrentUser = { id: 1 }
 		AssessmentModel.fetchAttemptById.mockResolvedValue(mockAttempt)
+
+		const mockResponsesMap = new Map()
+		mockResponsesMap.set(mockAttempt.id, [])
+		const mockResponses = mockResponsesMap
+		AssessmentModel.fetchResponsesForAttempts.mockResolvedValue(mockResponses)
 		// const mockAttempt = await AssessmentModel.getAttempt()
 
 		await resumeAttempt(

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-save.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-save.js
@@ -1,0 +1,20 @@
+const AssessmentModel = require('./models/assessment')
+
+const saveAttempt = async (req, res) => {
+	try {
+		await AssessmentModel.saveAttempt(
+			req.body.assessmentId,
+			req.params.attemptId,
+			req.currentUser.id,
+			req.body.draftId,
+			req.body.draftContentId,
+			req.body.state
+		)
+	} catch {
+		return res.unexpected()
+	}
+
+	return res.success()
+}
+
+module.exports = saveAttempt

--- a/packages/obonode/obojobo-sections-assessment/server/attempt-save.test.js
+++ b/packages/obonode/obojobo-sections-assessment/server/attempt-save.test.js
@@ -1,0 +1,55 @@
+jest.mock('./models/assessment')
+
+const AssessmentModel = require('./models/assessment')
+
+const saveAttempt = require('./attempt-save.js')
+
+describe('save attempt route', () => {
+	let mockRes
+	let mockReq
+
+	beforeEach(() => {
+		jest.resetAllMocks()
+
+		mockReq = {
+			body: {
+				draftId: 'mockDraftId',
+				draftContentId: 'mockDraftContentId',
+				assessmentId: 'mockAssessmentId',
+				state: {
+					currentQuestion: 0,
+					chosen: []
+				}
+			},
+			params: {
+				attemptId: 'mockAttemptId'
+			},
+			currentUser: { id: 4 }
+		}
+
+		mockRes = {
+			success: jest.fn(),
+			unexpected: jest.fn()
+		}
+	})
+
+	test('saveAttempt calls AssessmentModel.saveAttempt, no errors', () => {
+		AssessmentModel.saveAttempt.mockResolvedValueOnce(true)
+
+		return saveAttempt(mockReq, mockRes).then(() => {
+			expect(AssessmentModel.saveAttempt).toHaveBeenCalled()
+			expect(mockRes.success).toHaveBeenCalled()
+			expect(mockRes.unexpected).not.toHaveBeenCalled()
+		})
+	})
+
+	test('saveAttempt calls AssessmentModel.saveAttempt, errors', async () => {
+		AssessmentModel.saveAttempt.mockRejectedValueOnce('error')
+
+		return await saveAttempt(mockReq, mockRes).then(() => {
+			expect(AssessmentModel.saveAttempt).toHaveBeenCalled()
+			expect(mockRes.success).not.toHaveBeenCalled()
+			expect(mockRes.unexpected).toHaveBeenCalled()
+		})
+	})
+})

--- a/packages/obonode/obojobo-sections-assessment/server/events.js
+++ b/packages/obonode/obojobo-sections-assessment/server/events.js
@@ -6,7 +6,7 @@ const db = require('obojobo-express/server/db')
 const eventRecordResponse = 'client:question:setResponse'
 const { isTrueParam } = require('obojobo-express/server/util/is_true_param')
 
-// Store question responces
+// Store question responses
 oboEvents.on(eventRecordResponse, async (event, req) => {
 	try {
 		if (!event.payload.attemptId) return // assume we're in practice

--- a/packages/obonode/obojobo-sections-assessment/server/express.js
+++ b/packages/obonode/obojobo-sections-assessment/server/express.js
@@ -4,6 +4,7 @@ const AssessmentModel = require('./models/assessment')
 const lti = require('obojobo-express/server/lti')
 const logger = require('obojobo-express/server/logger')
 const { startAttempt } = require('./attempt-start')
+const saveAttempt = require('./attempt-save')
 const resumeAttempt = require('./attempt-resume')
 const endAttempt = require('./attempt-end/attempt-end')
 const { attemptReview } = require('./attempt-review')
@@ -77,6 +78,18 @@ router
 		checkValidationRules
 	])
 	.post(startAttempt)
+
+router
+	.route('/api/assessments/attempt/:attemptId/save')
+	.post([
+		requireCurrentUser,
+		requireCurrentVisit,
+		requireCurrentDocument,
+		requireAttemptId,
+		requireAssessmentId,
+		checkValidationRules
+	])
+	.post(saveAttempt)
 
 router
 	.route('/api/assessments/attempt/:attemptId/resume')

--- a/packages/obonode/obojobo-sections-assessment/server/express.test.js
+++ b/packages/obonode/obojobo-sections-assessment/server/express.test.js
@@ -1,6 +1,7 @@
 jest.mock('./models/assessment')
 jest.mock('obojobo-express/server/lti')
 jest.mock('./attempt-start')
+jest.mock('./attempt-save')
 jest.mock('./attempt-resume')
 jest.mock('./attempt-end/attempt-end')
 jest.mock('./attempt-review')
@@ -25,6 +26,7 @@ const request = require('supertest')
 const { attemptReview } = require('./attempt-review')
 const AssessmentModel = require('./models/assessment')
 const { startAttempt } = require('./attempt-start')
+const saveAttempt = require('./attempt-save')
 const resumeAttempt = require('./attempt-resume')
 const endAttempt = require('./attempt-end/attempt-end')
 const lti = require('obojobo-express/server/lti')
@@ -162,6 +164,32 @@ describe('server/express', () => {
 		expect(requireAssessmentId).toHaveBeenCalledTimes(1)
 
 		expect(startAttempt).toHaveBeenCalledTimes(1)
+		expect(response.body).toEqual({
+			status: 'ok',
+			value: mockReturnValue
+		})
+	})
+
+	test('POST /api/assessments/attempt/mock-attempt-id/save', async () => {
+		expect.hasAssertions()
+		const mockReturnValue = {}
+		saveAttempt.mockImplementationOnce((req, res, next) => {
+			res.success(mockReturnValue)
+		})
+
+		const response = await request(app)
+			.post('/api/assessments/attempt/mock-attempt-id/save')
+			.type('application/json')
+
+		expect(response.statusCode).toBe(200)
+		// verify validations ran
+		expect(requireCurrentDocument).toHaveBeenCalledTimes(1)
+		expect(requireCurrentVisit).toHaveBeenCalledTimes(1)
+		expect(requireCurrentUser).toHaveBeenCalledTimes(1)
+		expect(requireAssessmentId).toHaveBeenCalledTimes(1)
+		expect(requireAttemptId).toHaveBeenCalledTimes(1)
+
+		expect(saveAttempt).toHaveBeenCalledTimes(1)
 		expect(response.body).toEqual({
 			status: 'ok',
 			value: mockReturnValue

--- a/packages/obonode/obojobo-sections-assessment/server/models/assessment.test.js
+++ b/packages/obonode/obojobo-sections-assessment/server/models/assessment.test.js
@@ -115,6 +115,52 @@ describe('AssessmentModel', () => {
 	`)
 	})
 
+	test('saveAttempt calls db.none', () => {
+		AssessmentModel.saveAttempt(
+			'mock-assessment-id',
+			'mock-attempt-id',
+			'mock-user-id',
+			'mock-draft-id',
+			'mock-draft-content-id',
+			{
+				currentQuestion: 0,
+				chosen: []
+			}
+		)
+
+		expect(db.none).toHaveBeenCalledTimes(1)
+		expect(db.none.mock.calls[0][1]).toMatchInlineSnapshot(`
+		Object {
+		  "assessmentId": "mock-assessment-id",
+		  "attemptId": "mock-attempt-id",
+		  "draftContentId": "mock-draft-content-id",
+		  "draftId": "mock-draft-id",
+		  "state": Object {
+		    "chosen": Array [],
+		    "currentQuestion": 0,
+		  },
+		  "userId": "mock-user-id",
+		}
+	`)
+	})
+
+	test('saveAttempt errors', () => {
+		db.none.mockRejectedValueOnce('mock-error')
+		return expect(
+			AssessmentModel.saveAttempt(
+				'mock-assessment-id',
+				'mock-attempt-id',
+				'mock-user-id',
+				'mock-draft-id',
+				'mock-draft-content-id',
+				{
+					currentQuestion: 0,
+					chosen: []
+				}
+			)
+		).rejects.toBe('mock-error')
+	})
+
 	test('fetchAttemptHistoryDetails calls db.manyOrNone', () => {
 		AssessmentModel.fetchAttemptHistoryDetails('mock-draft-id')
 


### PR DESCRIPTION
Closes #2105.

Adjusted assessment store/state management to support saving assessment progress when providing a response to a question.

Assessment response states are now saved and recalled properly when resuming an unfinished assessment attempt.